### PR TITLE
Feature/tao 8246/handle disable state on button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -872,7 +872,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -893,12 +894,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -913,17 +916,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1040,7 +1046,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1052,6 +1059,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1066,6 +1074,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1073,12 +1082,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1097,6 +1108,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1177,7 +1189,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1189,6 +1202,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -1274,7 +1288,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -1310,6 +1325,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -1329,6 +1345,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -1372,12 +1389,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/button.js
+++ b/src/button.js
@@ -18,91 +18,118 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-import _ from 'lodash';
-import component from 'ui/component';
+import componentFactory from 'ui/component';
 import buttonTpl from 'ui/button/tpl/button';
 
 /**
  * Some default config
  * @type {Object}
  */
-var defaults = {
+const defaults = {
     small: true
 };
 
 /**
- * Builds a simple button component
+ * @typedef {Object} buttonConfig Defines the config entries available to setup a button
+ * @property {String} id - The identifier of the button
+ * @property {String} label - The caption of the button
+ * @property {String} [title] - An optional tooltip for the button
+ * @property {String} [icon] - An optional icon for the button
+ * @property {String} [type] - The type of button to build
+ * @property {Boolean} [small] - Whether build a small button (default: true)
+ * @property {String} [cls] - An additional CSS class name
+ */
+
+/**
+ * Builds a simple button component.
  *
- * @param {Object} config
- * @param {String} config.id - The id of the button
- * @param {String} config.label - The id of the button
- * @param {String} [config.title] - An optional title of the button
- * @param {String} [config.icon] - An optional icon of the button
+ * @example
+ *  // button with simple action
+ *  const button = buttonFactory({
+ *      id: 'foo',
+ *      label: 'Foo',
+ *      title: 'Foo Bar',
+ *      icon: 'globe',
+ *      type: 'info'
+ *  })
+ *      .on('click', function() {
+ *          // do something
+ *      })
+ *      .render(container);
+ *
+ *  // button with handling of async action
+ *  const button = buttonFactory({
+ *      id: 'foo',
+ *      label: 'Foo',
+ *      title: 'Foo Bar',
+ *      icon: 'globe',
+ *      type: 'info'
+ *  })
+ *      .before('click', function(){
+ *          this.disable();
+ *      })
+ *      .on('click', function() {
+ *          return new Promise(resolve => {
+ *              // do something
+ *              resolve();
+ *          });
+ *      })
+ *      .after('click', function(){
+ *          this.enable();
+ *      })
+ *      .render(container);
+ *
+ * @param {buttonConfig} config
+ * @param {String} config.id - The identifier of the button
+ * @param {String} config.label - The caption of the button
+ * @param {String} [config.title] - An optional tooltip for the button
+ * @param {String} [config.icon] - An optional icon for the button
  * @param {String} [config.type] - The type of button to build
  * @param {Boolean} [config.small] - Whether build a small button (default: true)
  * @param {String} [config.cls] - An additional CSS class name
  * @returns {button}
  * @fires click - When the button is clicked
+ * @fires ready - When the button is ready to work
  */
 function buttonFactory(config) {
-    return (
-        component(
-            {
+    return componentFactory({
+        /**
+         * Gets the identifier of the button
+         * @returns {String}
+         */
+        getId() {
+            return this.getConfig().id;
+        }
+    }, defaults)
+        .setTemplate(buttonTpl)
+
+        // renders the component
+        .on('render', function onButtonRender() {
+            this.getElement().on('click', e => {
+                e.preventDefault();
+
                 /**
-                 * Gets the identifier of the button
-                 * @returns {String}
+                 * @event click
+                 * @param {String} buttonId
                  */
-                getId: function getId() {
-                    return this.config.id;
-                }
-            },
-            defaults
-        )
-            .setTemplate(buttonTpl)
+                this.trigger('click', this.getId());
+            });
 
             /**
-             * @todo We should support within the component async actions in order to disable the button while
-             * the action is running. In order to do this we should support Promises within events (TT-36)
-             * in order to do something like :
-             *
-             * ```
-             *  component()
-             *      .before('click', function(){
-             *          this.disable();
-             *      })
-             *      .after('click', function(){
-             *          this.enable();
-             *      })
-             * ```
-             *
-             * So when someone use the component with
-             *
-             * ```
-             *  var myAwesomeButton = button().on('click', function(){
-             *      return aPromise;
-             *  });
-             * ```
-             *
-             * the button state changes accordingly
+             * @event ready
              */
+            this.trigger('ready');
+        })
 
-            // renders the component
-            .on('render', function() {
-                var self = this;
-                var $component = this.getElement();
+        // take care of the disable state
+        .on('disable', function onButtonDisable() {
+            this.getElement().prop('disabled', true);
+        })
+        .on('enable', function onButtonEnable() {
+            this.getElement().prop('disabled', false);
+        })
 
-                $component.on('click', function(e) {
-                    e.preventDefault();
-
-                    /**
-                     * @event click
-                     * @param {String} buttonId
-                     */
-                    self.trigger('click', self.config.id);
-                });
-            })
-            .init(config)
-    );
+        .init(config);
 }
 
 export default buttonFactory;

--- a/test/button/click.tpl
+++ b/test/button/click.tpl
@@ -1,0 +1,4 @@
+<div class="click">
+    <span class="text">Button <strong>{{id}}</strong> clicked!</span>
+    <span class="number">#{{occurrence}}</span>
+</div>

--- a/test/button/test.html
+++ b/test/button/test.html
@@ -13,12 +13,28 @@
                 });
             });
         </script>
+        <style>
+            #visual-test {
+                background: #EEE;
+                position: relative;
+                margin: 10px;
+                padding: 10px;
+            }
+            #visual-test button {
+                margin: 10px;
+            }
+        </style>
     </head>
     <body>
         <div id="qunit"></div>
         <div id="qunit-fixture">
-            <div id="fixture-1"></div>
+            <div id="fixture-render">
+                <div class="dummy"></div>
+            </div>
         </div>
-        <div id="outside"></div>
+        <div id="visual-test">
+            <div class="test"></div>
+            <div class="output"></div>
+        </div>
     </body>
 </html>

--- a/test/button/test.js
+++ b/test/button/test.js
@@ -19,28 +19,10 @@
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
-define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
+define(['jquery', 'lodash', 'ui/button', 'tpl!test/ui/button/click'], function($, _, button, clickTpl) {
     'use strict';
 
-    var renderCases;
-    var buttonApi = [
-        { title: 'init' },
-        { title: 'destroy' },
-        { title: 'render' },
-        { title: 'show' },
-        { title: 'hide' },
-        { title: 'enable' },
-        { title: 'disable' },
-        { title: 'is' },
-        { title: 'setState' },
-        { title: 'getId' },
-        { title: 'getContainer' },
-        { title: 'getElement' },
-        { title: 'getTemplate' },
-        { title: 'setTemplate' }
-    ];
-
-    QUnit.module('button');
+    QUnit.module('Button Factory');
 
     QUnit.test('module', function(assert) {
         assert.expect(3);
@@ -50,7 +32,23 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
         assert.notStrictEqual(button(), button(), 'The button factory provides a different object on each call');
     });
 
-    QUnit.cases.init(buttonApi).test('instance API ', function(data, assert) {
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'setSize'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'},
+        {title: 'getConfig'}
+    ]).test('inherited API ', function (data, assert) {
         var instance = button();
         assert.expect(1);
         assert.equal(
@@ -59,6 +57,35 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
             'The button instance exposes a "' + data.title + '" function'
         );
     });
+
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'spread'}
+    ]).test('event API ', function (data, assert) {
+        var instance = button();
+        assert.expect(1);
+        assert.equal(
+            typeof instance[data.title],
+            'function',
+            'The button instance exposes a "' + data.title + '" function'
+        );
+    });
+
+    QUnit.cases.init([
+        {title: 'getId'}
+    ]).test('instance API ', function(data, assert) {
+        var instance = button();
+        assert.expect(1);
+        assert.equal(
+            typeof instance[data.title],
+            'function',
+            'The button instance exposes a "' + data.title + '" function'
+        );
+    });
+
+    QUnit.module('Button Life cycle');
 
     QUnit.test('init', function(assert) {
         var buttonId = 'myButton';
@@ -89,73 +116,60 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
         instance.destroy();
     });
 
-    renderCases = [
-        {
-            title: 'simple',
-            config: {
-                id: 'btn1',
-                label: 'Button 1'
-            }
-        },
-        {
-            title: 'info',
-            config: {
-                id: 'btn1',
-                type: 'info',
-                label: 'Button 1'
-            }
-        },
-        {
-            title: 'title',
-            config: {
-                id: 'btn1',
-                title: 'My awesome button',
-                label: 'Button 1'
-            }
-        },
-        {
-            title: 'small',
-            config: {
-                id: 'btn1',
-                small: true,
-                label: 'Button 1'
-            }
-        },
-        {
-            title: 'large',
-            config: {
-                id: 'btn1',
-                small: false,
-                label: 'Button 1'
-            }
-        },
-        {
-            title: 'icon',
-            config: {
-                id: 'btn1',
-                icon: 'foo',
-                label: 'Button 1'
-            }
+    QUnit.cases.init([{
+        title: 'simple',
+        config: {
+            id: 'btn1',
+            label: 'Button 1'
         }
-    ];
-    QUnit.cases.init(renderCases).test('render ', function(data, assert) {
-        var $dummy = $('<div class="dummy" />');
-        var $container = $('#fixture-1').append($dummy);
-        var config = _.merge(
-            {
-                renderTo: $container,
-                replace: true
-            },
-            data.config
-        );
+    }, {
+        title: 'info',
+        config: {
+            id: 'btn1',
+            type: 'info',
+            label: 'Button 1'
+        }
+    }, {
+        title: 'title',
+        config: {
+            id: 'btn1',
+            title: 'My awesome button',
+            label: 'Button 1'
+        }
+    }, {
+        title: 'small',
+        config: {
+            id: 'btn1',
+            small: true,
+            label: 'Button 1'
+        }
+    }, {
+        title: 'large',
+        config: {
+            id: 'btn1',
+            small: false,
+            label: 'Button 1'
+        }
+    }, {
+        title: 'icon',
+        config: {
+            id: 'btn1',
+            icon: 'foo',
+            label: 'Button 1'
+        }
+    }]).test('render ', function(data, assert) {
+        var $container = $('#fixture-render');
+        var config = _.merge({
+            renderTo: $container,
+            replace: true
+        }, data.config);
         var instance;
 
-        assert.expect(17);
+        assert.expect(16);
 
         // Check place before render
         assert.equal($container.children().length, 1, 'The container already contains an element');
-        assert.equal($container.children().get(0), $dummy.get(0), 'The container contains the dummy element');
-        assert.equal($container.find('.dummy').length, 1, 'The container contains an element of the class dummy');
+        assert.equal($container.find('.dummy').length, 1, 'The container contains the dummy element');
 
         // Create an instance with auto rendering
         instance = button(config);
@@ -301,7 +315,7 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
         var instance = button().render();
         var $component = instance.getElement();
 
-        assert.expect(8);
+        assert.expect(11);
 
         assert.equal(instance.is('rendered'), true, 'The button instance must be rendered');
         assert.equal($component.length, 1, 'The button instance returns the rendered content');
@@ -312,11 +326,17 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
             false,
             'The button instance does not have the disabled class'
         );
+        assert.equal(
+            instance.getElement().prop('disabled'),
+            false,
+            'The button instance does not have the disabled property'
+        );
 
         instance.disable();
 
         assert.equal(instance.is('disabled'), true, 'The button instance is disabled');
         assert.equal(instance.getElement().hasClass('disabled'), true, 'The button instance has the disabled class');
+        assert.equal(instance.getElement().prop('disabled'), true, 'The button instance has the disabled property');
 
         instance.enable();
 
@@ -325,6 +345,11 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
             instance.getElement().hasClass('disabled'),
             false,
             'The button instance does not have the disabled class'
+        );
+        assert.equal(
+            instance.getElement().prop('disabled'),
+            false,
+            'The button instance does not have the disabled property'
         );
 
         instance.destroy();
@@ -368,65 +393,122 @@ define(['jquery', 'lodash', 'ui/button'], function($, _, button) {
     });
 
     QUnit.test('events', function(assert) {
-        var ready3 = assert.async();
-        var ready2 = assert.async();
-        var ready1 = assert.async();
+        var ready = assert.async();
         var config = {
             id: 'button1',
             label: 'Button 1'
         };
         var instance = button(config);
 
-        instance.on('custom', function() {
-            assert.ok(true, 'The button instance can handle custom events');
-            ready();
-        });
-
-        instance.on('render', function() {
-            assert.ok(true, 'The button instance triggers event when it is rendered');
-            ready1();
-
-            instance.getElement().click();
-        });
-
-        instance.on('click', function(buttonId) {
-            assert.ok(true, 'The button instance call the right action when the button is clicked');
-            assert.equal(
-                buttonId,
-                'button1',
-                'The button instance provides the button identifier when the button is clicked'
-            );
-            ready2();
-        });
-
-        instance.on('destroy', function() {
-            assert.ok(true, 'The button instance triggers event when it is destroyed');
-            ready3();
-        });
-
         assert.expect(5);
-        var ready = assert.async();
 
-        instance
-            .render()
-            .trigger('custom')
-            .destroy();
+        Promise.resolve()
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('ready', function() {
+                            assert.ok(true, 'The button instance triggers event when it is ready');
+                            resolve();
+                        })
+                        .render();
+                });
+            })
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('click', function(buttonId) {
+                            assert.ok(true, 'The button instance call the right action when the button is clicked');
+                            assert.equal(
+                                buttonId,
+                                'button1',
+                                'The button instance provides the button identifier when the button is clicked'
+                            );
+                            resolve();
+                        })
+                        .getElement().click();
+                });
+            })
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('custom', function () {
+                            assert.ok(true, 'The button instance can handle custom events');
+                            resolve();
+                        })
+                        .trigger('custom');
+                });
+            })
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('destroy', function() {
+                            assert.ok(true, 'The button instance triggers event when it is destroyed');
+                            resolve();
+                        })
+                        .destroy();
+                });
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function() {
+                ready();
+            });
     });
 
-    QUnit.module('Visual');
+    QUnit.module('Button Visual Test');
 
     QUnit.test('simple button', function(assert) {
-        assert.expect(1);
-        button({
-            id: 'btn1',
-            label: 'Button 1'
-        })
-            .on('render', function() {
-                assert.ok(true);
+        var $container = $('#visual-test .test');
+        var $output = $('#visual-test .output');
+        var showDuration = 2000;
+        var occurrence = 0;
+
+        function createInstance(id, label, type, delay) {
+            return button({
+                id: id,
+                type: type,
+                label: label
             })
-            .on('click', function() {
-                console.log('button 1', arguments);
-            })
-            .render('#outside');
+                .on('render', function() {
+                    assert.ok(true, 'Button "' + id + '" is rendered');
+                })
+                .on('click', function(buttonId) {
+                    return new Promise(function(resolve) {
+                        var $text = $(clickTpl({
+                            id: buttonId,
+                            occurrence: ++occurrence
+                        }));
+                        $output.append($text);
+                        window.setTimeout(function() {
+                            $text.remove();
+                            resolve();
+                        }, delay);
+                    });
+                })
+                .render($container);
+        }
+
+        function createAsyncInstance(id, label, type, delay) {
+            return createInstance(id, label, type, delay)
+                .before('click', function() {
+                    this.disable();
+                })
+                .after('click', function() {
+                    this.enable();
+                });
+        }
+
+        assert.expect(5);
+
+        createInstance('button-1', 'Button 1', 'info', showDuration);
+        createInstance('button-2', 'Button 2', 'warning', showDuration);
+        createInstance('button-3', 'Button 3', 'error', showDuration);
+        createInstance('button-4', 'Button 4', 'neutral', showDuration);
+        createAsyncInstance('async-button', 'Async Button', 'success', showDuration * 2);
     });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8246

The `ui/button` component gets some improvements as it missed proper support for the enable/disable state.
It also now emits a `ready` event when the component is ready to work.

Unit tests:
```
npm i
npm run test button
```

The visual playground has been updated too, so you can play with the component to see how it behave. To interact with them:
```
npm run test:keepAlive
```
Then open a browser on http://127.0.0.1:8082/test/button/test.html
