### PR TITLE
Feature/tao 8246/add form components/validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -872,7 +872,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -893,12 +894,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -913,17 +916,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1040,7 +1046,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1052,6 +1059,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1066,6 +1074,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1073,12 +1082,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -1097,6 +1108,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -1177,7 +1189,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1189,6 +1202,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -1274,7 +1288,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -1310,6 +1325,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -1329,6 +1345,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -1372,12 +1389,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/form/validator/renderer.js
+++ b/src/form/validator/renderer.js
@@ -1,0 +1,118 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+import _ from 'lodash';
+import componentFactory from 'ui/component';
+import messageTpl from 'ui/form/validator/tpl/message';
+import validatorTpl from 'ui/form/validator/tpl/validator';
+import 'ui/form/validator/css/validator.css';
+
+/**
+ * Some default config
+ * @type {Object}
+ */
+const defaults = {};
+
+/**
+ * Builds a renderer component for the validation messages.
+ *
+ * @example
+ *  const $container = $('.my-container');
+ *  const validatorRenderer = validatorRendererFactory($container);
+ *
+ *  const messages = [
+ *      'An error occurred!',
+ *      'Please check your input'
+ *  ];
+ *
+ *  if (isInvalid()) {
+ *      validatorRenderer.display(messages);
+ *  } else {
+ *      validatorRenderer.clear();
+ *  }
+ *
+ * @param {HTMLElement|String} container
+ * @param {Object} config
+ * @returns {validatorRenderer}
+ * @fires ready - When the component is ready to work
+ */
+function validatorRendererFactory(container, config) {
+    const api = {
+        /**
+         * Displays messages
+         * @param {String|String[]} messages
+         * @returns {component}
+         */
+        display(messages) {
+            const $element = this.getElement();
+
+            if (this.is('rendered')) {
+                this.clear();
+                if (messages && !_.isArray(messages)) {
+                    messages = [messages];
+                }
+                _.forEach(messages, message => $element.append(messageTpl({message})));
+            }
+
+            return this;
+        },
+
+        /**
+         * Clears all messages
+         * @returns {component}
+         */
+        clear() {
+            if (this.is('rendered')) {
+                this.getElement().empty();
+            }
+            return this;
+        }
+    };
+
+    const validatorRenderer = componentFactory(api, defaults)
+        .setTemplate(validatorTpl)
+
+        // auto render on init
+        .on('init', function () {
+            // auto render on init (defer the call to give a chance to the init event to be completed before)
+            _.defer(() => this.render(container));
+        })
+
+        // renders the component
+        .on('render', function () {
+            if (this.getConfig().messages) {
+                this.display(this.getConfig().messages);
+            }
+
+            /**
+             * @event ready
+             */
+            this.trigger('ready');
+        });
+
+    // initialize the component with the provided config
+    // defer the call to allow to listen to the init event
+    _.defer(() => validatorRenderer.init(config));
+
+    return validatorRenderer;
+}
+
+export default validatorRendererFactory;

--- a/src/form/validator/scss/validator.scss
+++ b/src/form/validator/scss/validator.scss
@@ -1,0 +1,14 @@
+@import 'inc/bootstrap';
+
+.form-validator {
+    color: $error;
+    text-align: right;
+    width: 99%;
+
+    input.error,
+    select.error,
+    textarea.error {
+        border-color: $error;
+        color: $error;
+    }
+}

--- a/src/form/validator/tpl/message.tpl
+++ b/src/form/validator/tpl/message.tpl
@@ -1,0 +1,1 @@
+<div class="validation-error">{{message}}</div>

--- a/src/form/validator/tpl/validator.tpl
+++ b/src/form/validator/tpl/validator.tpl
@@ -1,0 +1,1 @@
+<div class="form-validator"></div>

--- a/src/form/validator/validator.js
+++ b/src/form/validator/validator.js
@@ -1,0 +1,225 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 Open Assessment Technologies SA ;
+ */
+/**
+ * Simple validator engine. Apply a collection of validation rules on a value.
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+import _ from 'lodash';
+import __ from 'i18n';
+
+/**
+ * @typedef {Object} validationRule Defines a validation rule to apply on a value.
+ * @property {String} id - The validation identifier
+ * @property {RegExp|Function|String|String[]} predicate - The validation rule to apply on the value.
+ *                                                         It could be either a RegExp or a Function.
+ *                                                         The function must return a boolean value,
+ *                                                         it can wrap it in a Promise too.
+ * @property {String} [message] - The message returned in case of failed validation
+ * @property {Number} [precedence] - The precedence order for sorting
+ */
+
+/**
+ * @typedef {Object} validatorConfig Defines the config entries available to setup a form widget validator
+ * @property {validationRule[]} validations - The list of validations to apply
+ * @property {String} defaultMessage - The default message returned when a validation fails and no message is set
+ */
+
+/**
+ * Defaults config for the validator
+ * @type {validatorConfig}
+ */
+const defaults = {
+    defaultMessage: __('Invalid input')
+};
+
+/**
+ * Validates a value
+ * @param {String} value
+ * @param {validationRule} validation
+ * @returns {Boolean|Promise}
+ */
+function validateValue(value, validation) {
+    if (validation.predicate instanceof RegExp) {
+        return validation.predicate.test(value);
+    } else if (_.isFunction(validation.predicate)) {
+        return validation.predicate(value);
+    } else if (_.isArray(validation.predicate)) {
+        return _.indexOf(validation.predicate, value) > -1;
+    }
+    return validation.predicate === value;
+}
+
+/**
+ * Compares validation rules
+ * @param {validationRule} a
+ * @param {validationRule} b
+ * @returns {Number}
+ */
+function compareRule(a, b) {
+    return ((a && a.precedence) || 0) - ((b && b.precedence) || 0);
+}
+
+/**
+ * Creates a simple form widget's validator.
+ * It manages and applies a collection of validation rules on a value.
+ *
+ * @example
+ *  const validator = validatorFactory({
+ *      defaultMessage: 'An error occurred!',
+ *      validations: [{
+ *          id: 'numeric',
+ *          message: 'This field must be numerical',
+ *          predicate: /^\d+$/,
+ *          precedence: 2
+ *      }, {
+ *          id: 'required',
+ *          message: 'This field is required',
+ *          predicate:  value => value.length > 0,
+ *          precedence: 1
+ *      }, {
+ *          id: 'domain',
+ *          predicate: value => (parseInt(value, 10) || 0) <= 10,
+ *          precedence: 3
+ *      }]
+ *  });
+ *
+ *  validator.validate('100')
+ *      .then(() => {
+ *          // ...
+ *      })
+ *      .catch(messages => {
+ *          // ...
+ *      });
+ *
+ * @param {validatorConfig} config
+ * @param {validationRule[]} [config.validations] - The list of validation rules to apply
+ * @param {String} [config.defaultMessage] - The default message returned when a validation fails and no message is set
+ * @returns {validator}
+ */
+function validatorFactory(config) {
+    const validations = new Map();
+
+    /**
+     * @typedef {Object} validator
+     */
+    const validator = {
+        /**
+         * Runs all validation rules on a value
+         * @param {String} value
+         * @returns {Promise} Will provide the list of error messages if the validation failed.
+         */
+        validate(value) {
+            const rules = this.getValidations();
+            rules.sort(compareRule);
+
+            return Promise
+                .all(rules.map(validation => Promise.resolve(validateValue(value, validation))))
+                .then(results => {
+                    const errors = _.reduce(results, (list, result, index) => {
+                        if (!result) {
+                            list.push(rules[index].message || config.defaultMessage);
+                        }
+                        return list;
+                    }, []);
+
+                    if (errors.length) {
+                        return Promise.reject(errors);
+                    }
+                });
+        },
+
+        /**
+         * Adds a validation rule
+         * @param {validationRule} validation
+         * @returns {validator}
+         * @throws {TypeError} if the validation object is not valid
+         */
+        addValidation(validation) {
+            if (!_.isPlainObject(validation)) {
+                throw new TypeError('The validation must be an object');
+            }
+            if (!_.isString(validation.id) || !validation.id) {
+                throw new TypeError('The validation must contain an identifier');
+            }
+            if (!_.isFunction(validation.predicate) &&
+                !_.isRegExp(validation.predicate) &&
+                !_.isString(validation.predicate) &&
+                !_.isArray(validation.predicate)) {
+                throw new TypeError('The validation must provide a predicate');
+            }
+
+            validations.set(validation.id, validation);
+
+            return this;
+        },
+
+        /**
+         * Gets a validation rule by its identifier
+         * @param {String} id
+         * @returns {validationRule|null}
+         */
+        getValidation(id) {
+            if (validations.has(id)) {
+                return validations.get(id);
+            }
+            return null;
+        },
+
+        /**
+         * Gets the list of validation rules.
+         * @returns {validationRule[]}
+         */
+        getValidations() {
+            const list = [];
+            for(let validation of validations.values()) {
+                list.push(validation);
+            }
+            return list;
+        },
+
+        /**
+         * Removes a validation rule
+         * @param {String} id
+         * @returns {validator}
+         */
+        removeValidation(id) {
+            if (validations.has(id)) {
+                validations.delete(id);
+            }
+            return this;
+        },
+
+        /**
+         * Removes all validation rules
+         * @returns {validator}
+         */
+        removeValidations() {
+            validations.clear();
+
+            return this;
+        }
+    };
+
+    config = _.defaults(_.clone(config) || {}, defaults);
+    _.forEach(config.validations, validator.addValidation);
+
+    return validator;
+}
+
+export default validatorFactory;

--- a/src/form/validator/validator.js
+++ b/src/form/validator/validator.js
@@ -175,10 +175,7 @@ function validatorFactory(config) {
          * @returns {validationRule|null}
          */
         getValidation(id) {
-            if (validations.has(id)) {
-                return validations.get(id);
-            }
-            return null;
+            return validations.get(id) || null;
         },
 
         /**
@@ -199,9 +196,7 @@ function validatorFactory(config) {
          * @returns {validator}
          */
         removeValidation(id) {
-            if (validations.has(id)) {
-                validations.delete(id);
-            }
+            validations.delete(id);
             return this;
         },
 

--- a/src/generis/validator/readme.md
+++ b/src/generis/validator/readme.md
@@ -1,4 +1,5 @@
 ### ui/generis/validator/validator (is a ui/component)
+**deprecated**: Please use `ui/form/validator/validator` and `ui/form/validator/renderer` instead.
 ```
 /**
  * Examples

--- a/src/generis/validator/validator.js
+++ b/src/generis/validator/validator.js
@@ -26,6 +26,7 @@ import 'ui/generis/validator/css/validator.css';
  * The factory
  * @param {Object[]} [options.validations]
  * @return {ui/component}
+ * @deprecated
  */
 function factory(options) {
     var validator;

--- a/test/form/validator/renderer/test.html
+++ b/test/form/validator/renderer/test.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>Ui Test - Form Validator Renderer</title>
+    <script type="text/javascript" src="/environment/require.js"></script>
+    <script type="text/javascript">
+        require(['/environment/config.js'], function () {
+            require(['qunitEnv'], function () {
+                require(['test/ui/form/validator/renderer/test'], function () {
+                    QUnit.start();
+                });
+            });
+        });
+    </script>
+    <style>
+        #visual-test {
+            background: #EEE;
+            position: relative;
+            display: flex;
+            margin: 10px;
+            padding: 10px;
+            flex-direction: row;
+            justify-content: space-between;
+        }
+    </style>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture">
+    <div id="fixture-api"></div>
+    <div id="fixture-init"></div>
+    <div id="fixture-render"></div>
+    <div id="fixture-show"></div>
+    <div id="fixture-destroy"></div>
+    <div id="fixture-messages"></div>
+</div>
+<div id="visual-test"></div>
+</body>
+</html>

--- a/test/form/validator/renderer/test.js
+++ b/test/form/validator/renderer/test.js
@@ -1,0 +1,405 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'ui/form/validator/renderer'
+], function (
+    $,
+    _,
+    validatorRendererFactory
+) {
+    'use strict';
+
+    QUnit.module('Factory');
+
+    QUnit.test('module', function (assert) {
+        function getInstance() {
+            return validatorRendererFactory('#fixture-api')
+                .on('ready', function () {
+                    this.destroy();
+                });
+        }
+
+        assert.expect(3);
+
+        assert.equal(typeof validatorRendererFactory, 'function', 'The module exposes a function');
+        assert.equal(typeof getInstance(), 'object', 'The factory produces an object');
+        assert.notStrictEqual(getInstance(), getInstance(), 'The factory provides a different object on each call');
+    });
+
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'setSize'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'},
+        {title: 'getConfig'}
+    ]).test('inherited API ', function (data, assert) {
+        var instance = validatorRendererFactory('#fixture-api')
+            .on('ready', function () {
+                this.destroy();
+            });
+        assert.expect(1);
+        assert.equal(typeof instance[data.title], 'function', 'The instance exposes a "' + data.title + '" function');
+    });
+
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'spread'}
+    ]).test('event API ', function (data, assert) {
+        var instance = validatorRendererFactory('#fixture-api')
+            .on('ready', function () {
+                this.destroy();
+            });
+        assert.expect(1);
+        assert.equal(typeof instance[data.title], 'function', 'The instance exposes a "' + data.title + '" function');
+    });
+
+    QUnit.cases.init([
+        {title: 'clear'},
+        {title: 'display'}
+    ]).test('component API ', function (data, assert) {
+        var instance = validatorRendererFactory('#fixture-api')
+            .on('ready', function () {
+                this.destroy();
+            });
+        assert.expect(1);
+        assert.equal(typeof instance[data.title], 'function', 'The instance exposes a "' + data.title + '" function');
+    });
+
+    QUnit.module('Life cycle');
+
+    QUnit.test('init', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-init');
+        var instance = validatorRendererFactory($container);
+
+        assert.expect(1);
+
+        instance
+            .after('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                this.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('render empty', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-render');
+        var config = {};
+        var instance;
+
+        assert.expect(5);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.form-validator'), true, 'The container contains the expected element');
+                assert.equal($container.find('.form-validator .validation-error').length, 0, 'The component is empty');
+
+                this.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('render single message', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-render');
+        var config = {
+            messages: 'Foo'
+        };
+        var instance;
+
+        assert.expect(5);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.form-validator'), true, 'The container contains the expected element');
+                assert.equal($container.find('.form-validator .validation-error').length, 1, 'The component displays one message');
+
+                this.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('render messages', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-render');
+        var config = {
+            messages: [
+                'Foo',
+                'Bar'
+            ]
+        };
+        var instance;
+
+        assert.expect(5);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.form-validator'), true, 'The container contains the expected element');
+                assert.equal($container.find('.form-validator .validation-error').length, 2, 'The component displays some messages');
+
+                this.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('show', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-show');
+        var config = {
+            messages: [
+                'Foo',
+                'Bar'
+            ]
+        };
+        var instance;
+
+        assert.expect(11);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.form-validator'), true, 'The container contains the expected element');
+                assert.equal($container.find('.form-validator .validation-error').length, 2, 'The component displays some messages');
+
+                assert.equal($container.find('.form-validator:visible').length, 1, 'The component is visible');
+                assert.equal($container.find('.form-validator .validation-error:visible').length, 2, 'The messages are visible');
+
+                instance.hide();
+                assert.equal($container.find('.form-validator:visible').length, 0, 'The component is hidden');
+                assert.equal($container.find('.form-validator .validation-error:visible').length, 0, 'The messages are hidden');
+
+                instance.show();
+                assert.equal($container.find('.form-validator:visible').length, 1, 'The component is visible again');
+                assert.equal($container.find('.form-validator .validation-error:visible').length, 2, 'The messages are visible again');
+
+                instance.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('destroy', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-destroy');
+        var instance;
+
+        assert.expect(4);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, {widget: 'text', uri: 'foo'})
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                this.destroy();
+            })
+            .after('destroy', function () {
+                assert.equal($container.children().length, 0, 'The container is now empty');
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.module('API');
+
+    QUnit.test('messages', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-messages');
+        var config = {
+            messages: [
+                'Foo',
+                'Bar'
+            ]
+        };
+        var instance;
+
+        assert.expect(8);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.form-validator'), true, 'The container contains the expected element');
+                assert.equal($container.find('.form-validator .validation-error').length, 2, 'The component displays some messages');
+
+                instance.clear();
+                assert.equal($container.find('.form-validator .validation-error').length, 0, 'The component is now empty');
+
+                instance.display('foo');
+                assert.equal($container.find('.form-validator .validation-error').length, 1, 'The component displays a message');
+
+                instance.display(['first', 'second']);
+                assert.equal($container.find('.form-validator .validation-error').length, 2, 'The component displays 2 messages');
+
+                this.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+
+    QUnit.module('Visual');
+
+    QUnit.test('Visual test', function (assert) {
+        var ready = assert.async();
+        var $container = $('#visual-test');
+        var config = {
+            messages: [
+                'This field is required',
+                'The value should be comprised between 0 and 100'
+            ]
+        };
+        var instance;
+
+        assert.expect(3);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = validatorRendererFactory($container, config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+});

--- a/test/form/validator/validator/test.html
+++ b/test/form/validator/validator/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>Ui Test - Form Validator Factory</title>
+    <script type="text/javascript" src="/environment/require.js"></script>
+    <script type="text/javascript">
+        require(['/environment/config.js'], function () {
+            require(['qunitEnv'], function () {
+                require(['test/ui/form/validator/validator/test'], function () {
+                    QUnit.start();
+                });
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/test/form/validator/validator/test.js
+++ b/test/form/validator/validator/test.js
@@ -1,0 +1,476 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'ui/form/validator/validator'
+], function (
+    _,
+    validatorFactory
+) {
+    'use strict';
+
+    QUnit.module('Factory');
+
+    QUnit.test('module', function (assert) {
+        assert.expect(3);
+
+        assert.equal(typeof validatorFactory, 'function', 'The module exposes a function');
+        assert.equal(typeof validatorFactory(), 'object', 'The factory produces an object');
+        assert.notStrictEqual(validatorFactory(), validatorFactory(), 'The factory provides a different object on each call');
+    });
+
+    QUnit.cases.init([
+        {title: 'validate'},
+        {title: 'addValidation'},
+        {title: 'getValidation'},
+        {title: 'getValidations'},
+        {title: 'removeValidation'},
+        {title: 'removeValidations'}
+    ]).test('module API ', function (data, assert) {
+        var instance = validatorFactory();
+        assert.expect(1);
+        assert.equal(typeof instance[data.title], 'function', 'The instance exposes a "' + data.title + '" function');
+    });
+
+    QUnit.module('API');
+
+    QUnit.test('manage rules', function (assert) {
+        var fooRule = {
+            id: 'foo',
+            predicate: /^\w+$/
+        };
+        var barRule = {
+            id: 'bar',
+            predicate: function(value) {
+                return value === 'foo';
+            }
+        };
+        var instance = validatorFactory({
+            validations: [fooRule, barRule]
+        });
+
+        assert.expect(21);
+
+        assert.deepEqual(instance.getValidations(), [fooRule, barRule], 'The list of rules is filled');
+        assert.equal(instance.getValidation('foo'), fooRule, 'There is a rule identified by foo');
+        assert.equal(instance.getValidation('bar'), barRule, 'There is a rule identified by bar');
+
+        instance.removeValidations();
+        assert.deepEqual(instance.getValidations(), [], 'The list of rules is now empty');
+        assert.equal(instance.getValidation('foo'), null, 'There is no rule identified by foo anymore');
+        assert.equal(instance.getValidation('bar'), null, 'There is no rule identified by bar anymore');
+
+        assert.throws(function() {
+            instance.addValidation();
+        }, 'Should raise an error as the rule is missing');
+
+        assert.throws(function() {
+            instance.addValidation({});
+        }, 'Should raise an error as the rule is empty');
+
+        assert.throws(function() {
+            instance.addValidation({id: ''});
+        }, 'Should raise an error as the id is empty');
+
+        assert.throws(function() {
+            instance.addValidation({id: 'required'});
+        }, 'Should raise an error as the predicate is missing');
+
+        assert.throws(function() {
+            instance.addValidation({id: 'required', predicate: false});
+        }, 'Should raise an error as the predicate is invalid');
+
+        instance = validatorFactory();
+        assert.deepEqual(instance.getValidations(), [], 'The list of rules is empty');
+        assert.equal(instance.getValidation('foo'), null, 'There is no rule identified by foo');
+        assert.equal(instance.getValidation('bar'), null, 'There is no rule identified by bar');
+
+        instance.addValidation(fooRule);
+        assert.equal(instance.getValidation('foo'), fooRule, 'There is a rule identified by foo');
+
+        instance.addValidation(barRule);
+        assert.equal(instance.getValidation('bar'), barRule, 'There is a rule identified by bar');
+
+        assert.deepEqual(instance.getValidations(), [fooRule, barRule], 'The list of rules is set');
+
+        instance.removeValidation('foo');
+        assert.equal(instance.getValidation('foo'), null, 'There is no rule identified by foo anymore');
+
+        assert.deepEqual(instance.getValidations(), [barRule], 'The list of rules only contains the rule identified by bar');
+
+        instance.removeValidation('bar');
+        assert.equal(instance.getValidation('bar'), null, 'There is no rule identified by bar anymore');
+
+        assert.deepEqual(instance.getValidations(), [], 'The list of rules is empty');
+    });
+
+    QUnit.test('validate no rules', function (assert) {
+        var ready = assert.async();
+        var instance = validatorFactory();
+
+        assert.expect(3);
+
+        Promise
+            .all([
+                new Promise(function(resolve) {
+                    instance.validate('')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('foo')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('10')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                })
+            ])
+            .catch(function(err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function() {
+                ready();
+            });
+    });
+
+    QUnit.test('validate rules', function (assert) {
+        var ready = assert.async();
+        var defaultMessage = 'Oops!';
+        var instance = validatorFactory({
+            defaultMessage: defaultMessage,
+            validations: [{
+                id: 'numeric',
+                message: 'This field must be numerical',
+                predicate: /^\d+$/,
+                precedence: 2
+            }, {
+                id: 'required',
+                message: 'This field is required',
+                predicate: function (value) {
+                    return value.length > 0;
+                },
+                precedence: 1
+            }, {
+                id: 'domain',
+                predicate: function (value) {
+                    value = parseInt(value, 10) || 0;
+                    return Promise.resolve(value <= 10);
+                },
+                precedence: 3
+            }]
+        });
+
+        assert.expect(7);
+
+        Promise
+            .all([
+                new Promise(function(resolve) {
+                    instance.validate('')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, ['This field is required', 'This field must be numerical'], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('foo')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, ['This field must be numerical'], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('100')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, [defaultMessage], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('10')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                })
+            ])
+            .catch(function(err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function() {
+                ready();
+            });
+    });
+
+    QUnit.test('validate precise rule', function (assert) {
+        var ready = assert.async();
+        var defaultMessage = 'Oops!';
+        var instance = validatorFactory({
+            defaultMessage: defaultMessage,
+            validations: [{
+                id: 'precise',
+                message: 'This field must be yes',
+                predicate: 'yes'
+            }]
+        });
+
+        assert.expect(7);
+
+        Promise
+            .all([
+                new Promise(function(resolve) {
+                    instance.validate('')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, ['This field must be yes'], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('foo')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, ['This field must be yes'], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('100')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, ['This field must be yes'], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('yes')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                })
+            ])
+            .catch(function(err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function() {
+                ready();
+            });
+    });
+
+    QUnit.test('validate list', function (assert) {
+        var ready = assert.async();
+        var defaultMessage = 'Oops!';
+        var instance = validatorFactory({
+            defaultMessage: defaultMessage,
+            validations: [{
+                id: 'precise',
+                predicate: ['yes', 'no']
+            }]
+        });
+
+        assert.expect(8);
+
+        Promise
+            .all([
+                new Promise(function(resolve) {
+                    instance.validate('')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, [defaultMessage], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('foo')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, [defaultMessage], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('100')
+                        .then(function() {
+                            assert.ok(false, 'The value should not be valid');
+                        })
+                        .catch(function(messages) {
+                            assert.ok(true, 'The value is not valid');
+                            assert.deepEqual(messages, [defaultMessage], 'The expected messages are returned');
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('yes')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    instance.validate('no')
+                        .then(function() {
+                            assert.ok(true, 'The value is valid');
+                        })
+                        .catch(function(err) {
+                            assert.ok(false, 'The value should be valid');
+                            assert.pushResult({
+                                result: false,
+                                message: err
+                            });
+                        })
+                        .then(function() {
+                            resolve();
+                        });
+                })
+            ])
+            .catch(function(err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function() {
+                ready();
+            });
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8246

This PR is part of a bigger feature set, and is a split of https://github.com/oat-sa/tao-core/pull/2131.
The main purpose is to add a collection of form components.

So here's what we have here:
- `ui/form/validator/validator` simple validation engine that applies a list of predicates to a value, and return a promise.
- ` ui/form/validator/renderer` component that will render the messages produced by a validator.

Unit tests:
```
npm i
npm run test form/validator
```

Each unit test also comes with a visual playground so you can play with each component to see how they behave. To interact with them:
```
npm run test:keepAlive
```
Then open a browser on:
- http://127.0.0.1:8082/test/form/validator/renderer/test.html
- http://127.0.0.1:8082/test/form/validator/validator/test.html