### PR TITLE
fire change event on clearing picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 /node_modules
 /dist
 css/
+
+# phpstorm files
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/datetime/picker.js
+++ b/src/datetime/picker.js
@@ -503,7 +503,7 @@ export default function dateTimePickerFactory(container, options) {
 
                 if (value && _.isString(newValue) && _.isEmpty(newValue)) {
                     //if someone remove the value from the field
-                    //it's considered a propert clean (resets everything)
+                    //it's considered a property clean (resets everything)
                     self.clear();
                 } else if (value !== newValue) {
                     value = newValue;
@@ -513,8 +513,9 @@ export default function dateTimePickerFactory(container, options) {
                      * @event dateTimePicker#change
                      * @param {String} value - the date/time value
                      */
-                    self.trigger('change', value);
                 }
+
+                self.trigger('change', value);
             });
 
             value = this.controls.input.value;


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TAO-8444

affects: https://github.com/oat-sa/tao-core/pull/2189

At the moment, when we clear the date picker, it does not refreshes the data. To do that now I fire change event when the value from date picker is cleared.