### PR TITLE
Feature/nex 149 add babel setup

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -124,7 +124,6 @@ export default inputs.map(input => {
             babel({
                 presets: [[
                     '@babel/env', {
-                        targets: 'extends @oat-sa/browserslist-config-tao',
                         useBuiltIns: false
                     }
                 ]]

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -23,6 +23,7 @@ import handlebarsPlugin from 'rollup-plugin-handlebars-plus';
 import cssResolve from './css-resolve';
 import externalAlias from './external-alias';
 import resolve from 'rollup-plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
 
 const { srcDir, outputDir, aliases } = require('./path');
 const Handlebars = require('handlebars');
@@ -113,7 +114,16 @@ export default inputs.map(input => {
                         );
                     }
                 }
-            }
+            },
+            babel({
+                presets: [[
+                    '@babel/env', {
+                        targets: 'extends @oat-sa/browserslist-config-tao',
+                        useBuiltIns: false
+                    }
+                ]]
+            })
         ]
     };
 });
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,852 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/core": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+            "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helpers": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/template": "^7.4.4",
+                "@babel/traverse": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "convert-source-map": "^1.1.0",
+                "debug": "^4.1.0",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.11",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+            "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+            "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+            "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-call-delegate": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+            "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.4.4",
+                "@babel/traverse": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+            "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/types": "^7.4.4",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+            "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+            "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+            "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+            "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/template": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+            "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+            "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+            "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-wrap-function": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+            "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/traverse": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+            "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+            "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.2.0"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+            "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.4.4",
+                "@babel/traverse": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+            "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+            "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0",
+                "@babel/plugin-syntax-async-generators": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+            "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+            "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+            "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+            "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.4.4",
+                "regexpu-core": "^4.5.4"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+            "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+            "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+            "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+            "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+            "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+            "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+            "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+            "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+            "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-define-map": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.4.4",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+            "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+            "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+            "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.4.4",
+                "regexpu-core": "^4.5.4"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
+            "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+            "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+            "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+            "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+            "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+            "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
+            "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+            "integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.4.4",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+            "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.4.4",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+            "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+            "integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
+            "dev": true,
+            "requires": {
+                "regexp-tree": "^0.1.6"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+            "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
+            "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+            "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-call-delegate": "^7.4.4",
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+            "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+            "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.14.0"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+            "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+            "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
+            "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+            "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+            "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+            "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+            "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.4.4",
+                "regexpu-core": "^4.5.4"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
+            "integrity": "sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+                "@babel/plugin-proposal-json-strings": "^7.2.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-syntax-async-generators": "^7.2.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+                "@babel/plugin-transform-arrow-functions": "^7.2.0",
+                "@babel/plugin-transform-async-to-generator": "^7.4.4",
+                "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+                "@babel/plugin-transform-block-scoping": "^7.4.4",
+                "@babel/plugin-transform-classes": "^7.4.4",
+                "@babel/plugin-transform-computed-properties": "^7.2.0",
+                "@babel/plugin-transform-destructuring": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+                "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+                "@babel/plugin-transform-for-of": "^7.4.4",
+                "@babel/plugin-transform-function-name": "^7.4.4",
+                "@babel/plugin-transform-literals": "^7.2.0",
+                "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+                "@babel/plugin-transform-modules-amd": "^7.2.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+                "@babel/plugin-transform-modules-systemjs": "^7.4.4",
+                "@babel/plugin-transform-modules-umd": "^7.2.0",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+                "@babel/plugin-transform-new-target": "^7.4.4",
+                "@babel/plugin-transform-object-super": "^7.2.0",
+                "@babel/plugin-transform-parameters": "^7.4.4",
+                "@babel/plugin-transform-property-literals": "^7.2.0",
+                "@babel/plugin-transform-regenerator": "^7.4.5",
+                "@babel/plugin-transform-reserved-words": "^7.2.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+                "@babel/plugin-transform-spread": "^7.2.0",
+                "@babel/plugin-transform-sticky-regex": "^7.2.0",
+                "@babel/plugin-transform-template-literals": "^7.4.4",
+                "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+                "@babel/plugin-transform-unicode-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "browserslist": "^4.6.0",
+                "core-js-compat": "^3.1.1",
+                "invariant": "^2.2.2",
+                "js-levenshtein": "^1.1.3",
+                "semver": "^5.5.0"
+            }
+        },
+        "@babel/template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+            "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.4.5",
+                "@babel/types": "^7.4.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+            "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+                    "dev": true
+                }
+            }
+        },
         "@oat-sa/browserslist-config-tao": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@oat-sa/browserslist-config-tao/-/browserslist-config-tao-0.1.0.tgz",
@@ -374,6 +1220,40 @@
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true
         },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "core-js-compat": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
+            "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.6.2",
+                "core-js-pure": "3.1.4",
+                "semver": "^6.1.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+                    "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+                    "dev": true
+                }
+            }
+        },
+        "core-js-pure": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
+            "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
+            "dev": true
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -525,6 +1405,12 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
             "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "eventemitter3": {
@@ -732,6 +1618,12 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
         "globule": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
@@ -925,6 +1817,15 @@
             "integrity": "sha1-8o2cawgwE9quPHfwJiBPndGYPtk=",
             "dev": true
         },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -1012,16 +1913,34 @@
             "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
             "dev": true
         },
+        "js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+            "dev": true
+        },
         "js-reporters": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
             "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
             "dev": true
         },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
         "json-schema": {
@@ -1041,6 +1960,15 @@
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
+        },
+        "json5": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            }
         },
         "jsonfile": {
             "version": "4.0.0",
@@ -1090,6 +2018,15 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
             "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
             "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
         },
         "loud-rejection": {
             "version": "1.6.0",
@@ -1626,6 +2563,12 @@
             "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
             "dev": true
         },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -1777,6 +2720,73 @@
                 "strip-indent": "^1.0.1"
             }
         },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+            "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0"
+            }
+        },
+        "regenerator-transform": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
+            "integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+            "dev": true,
+            "requires": {
+                "private": "^0.1.6"
+            }
+        },
+        "regexp-tree": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
+            "integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==",
+            "dev": true
+        },
+        "regexpu-core": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+            "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^8.0.2",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.1.0"
+            }
+        },
+        "regjsgen": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+            "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+            "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
         "repeating": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -1888,6 +2898,16 @@
             "dev": true,
             "requires": {
                 "slash": "^3.0.0"
+            }
+        },
+        "rollup-plugin-babel": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
+            "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "rollup-pluginutils": "^2.3.0"
             }
         },
         "rollup-plugin-handlebars-plus": {
@@ -2188,6 +3208,12 @@
             "from": "github:requirejs/text#2.0.16",
             "dev": true
         },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
         "tooltip.js": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.2.tgz",
@@ -2219,6 +3245,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
             "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "true-case-path": {
@@ -2274,6 +3306,34 @@
                     }
                 }
             }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+            "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+            "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+            "dev": true
         },
         "union": {
             "version": "0.4.6",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     },
     "license": "GPL-2.0",
     "devDependencies": {
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/tao-core-libs": "^0.1.0",
@@ -64,6 +66,7 @@
         "requirejs-plugins": "^1.0.2",
         "rollup": "^1.12.1",
         "rollup-plugin-alias": "^1.5.1",
+        "rollup-plugin-babel": "^4.3.2",
         "rollup-plugin-handlebars-plus": "^0.2.4",
         "rollup-plugin-node-resolve": "^5.0.0",
         "select2": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/component.js
+++ b/src/component.js
@@ -30,10 +30,10 @@ var _slice = [].slice;
  * Handles the resize of the component regarding the config set
  */
 function delegatedResize() {
-    var width = this.config.width;
-    var height = this.config.height;
-    var $container = this.getContainer();
-    var $element = this.getElement();
+    let width = this.config.width;
+    let height = this.config.height;
+    const $container = this.getContainer();
+    const $element = this.getElement();
 
     if ($container) {
         if ('auto' === width) {
@@ -46,10 +46,10 @@ function delegatedResize() {
 
     if ($element) {
         if (_.isNumber(width)) {
-            $element.css({ width: width + 'px' });
+            $element.css({ width: `${width}px` });
         }
         if (_.isNumber(height)) {
-            $element.css({ height: height + 'px' });
+            $element.css({ height: `${height}px` });
         }
     }
 


### PR DESCRIPTION
Ensure the sources can be written according the JavaScript coding guide in ES2015 and the generated AMD modules are compatible in `dist`.
This PR setup Babel to transpile the modules

How to test : 
```
npm i
npm run build
npm test
```
The file `src/component.js` has received minor changes to prove the transpilation works, so you can verify it in `dist`
