### PR TITLE
Fix/tao 8246/form value discrepency with complex widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/form/form.js
+++ b/src/form/form.js
@@ -42,6 +42,12 @@ import 'ui/form/css/form.css';
  */
 
 /**
+ * @typedef {Object} widgetValue Defines the value serialized from a widget
+ * @property {String} name - The identifier of the widget
+ * @property {String} value - The value of the widget
+ */
+
+/**
  * Some default config
  * @type {formConfig}
  */
@@ -503,7 +509,10 @@ function formFactory(container, config) {
         serializeValues() {
             const values = [];
             for (let widget of widgets.values()) {
-                values.push(widget.serializeValue());
+                values.push({
+                    name: widget.getUri(),
+                    value: widget.getValue()
+                });
             }
             return values;
         },

--- a/src/form/widget/providers/default.js
+++ b/src/form/widget/providers/default.js
@@ -39,6 +39,14 @@ const defaultWidgetProvider = {
     },
 
     /**
+     * Gets the raw value of the widget
+     * @returns {*}
+     */
+    getRawValue() {
+        return this.getValue();
+    },
+
+    /**
      * Sets the value of the widget
      * @param {String} value
      */

--- a/src/form/widget/providers/default.js
+++ b/src/form/widget/providers/default.js
@@ -79,17 +79,6 @@ const defaultWidgetProvider = {
     },
 
     /**
-     * Serializes the value of the widget
-     * @returns {widgetValue}
-     */
-    serializeValue() {
-        return {
-            name: this.getUri(),
-            value: this.getValue()
-        };
-    },
-
-    /**
      * Gets access to the actual form element
      * @returns {jQuery}
      */

--- a/src/form/widget/providers/hiddenBox.js
+++ b/src/form/widget/providers/hiddenBox.js
@@ -86,16 +86,29 @@ const widgetHiddenBoxProvider = {
 
     /**
      * Gets the value of the widget
-     * @returns {Object}
+     * @returns {String}
      */
     getValue() {
+        let value = this.getConfig().value;
+
+        if (this.is('rendered')) {
+            value = this.getElement().find(`[name="${this.getUri()}"]`).val();
+        }
+
+        return value;
+    },
+
+    /**
+     * Gets the raw value of the widget
+     * @returns {*}
+     */
+    getRawValue() {
         const value = {
-            value: this.getConfig().value,
+            value: this.getValue(),
             confirmation: this.getConfig().confirmation.value
         };
 
         if (this.is('rendered')) {
-            value.value = this.getElement().find(`[name="${this.getUri()}"]`).val();
             value.confirmation = this.getElement().find(`[name="${this.getConfig().confirmation.uri}"]`).val();
         }
 
@@ -107,24 +120,18 @@ const widgetHiddenBoxProvider = {
      * @param {String} value
      */
     setValue(value) {
-        this.getConfig().value = value;
-        this.getConfig().confirmation.value = value;
-
         if (this.is('rendered')) {
-            this.getElement().find(`[name="${this.getUri()}"]`).val(value);
-            this.getElement().find(`[name="${this.getConfig().confirmation.uri}"]`).val(value);
-        }
-    },
+            const $input = this.getElement().find(`[name="${this.getUri()}"]`);
+            const $confirmation = this.getElement().find(`[name="${this.getConfig().confirmation.uri}"]`);
 
-    /**
-     * Serializes the value of the widget
-     * @returns {widgetValue}
-     */
-    serializeValue() {
-        return {
-            name: this.getUri(),
-            value: this.getValue().value
-        };
+            if ($input.val() === $confirmation.val()) {
+                this.getConfig().confirmation.value = value;
+                $confirmation.val(value);
+            }
+            $input.val(value);
+        } else {
+            this.getConfig().confirmation.value = value;
+        }
     },
 
     /**

--- a/src/form/widget/widget.js
+++ b/src/form/widget/widget.js
@@ -209,6 +209,14 @@ function widgetFactory(container, config) {
         },
 
         /**
+         * Gets the raw value of the widget
+         * @returns {*}
+         */
+        getRawValue() {
+            return delegate('getRawValue');
+        },
+
+        /**
          * Sets the value of the widget
          * @param {String|String[]} value
          * @returns {widgetForm}
@@ -292,7 +300,7 @@ function widgetFactory(container, config) {
          */
         validate() {
             return this.getValidator()
-                .validate(this.getValue())
+                .validate(this.getRawValue())
                 .then(res => {
                     setInvalidState(false);
                     return res;

--- a/src/form/widget/widget.js
+++ b/src/form/widget/widget.js
@@ -53,12 +53,6 @@ import 'ui/form/widget/css/widget.css';
  */
 
 /**
- * @typedef {Object} widgetValue Defines the value serialized from a widget
- * @property {String} name - The identifier of the widget
- * @property {String} value - The value of the widget
- */
-
-/**
  * Some default config
  * @type {widgetConfig}
  */
@@ -284,14 +278,6 @@ function widgetFactory(container, config) {
             delegate('reset');
             setInvalidState(false);
             return this;
-        },
-
-        /**
-         * Serializes the value of the widget
-         * @returns {widgetValue}
-         */
-        serializeValue() {
-            return delegate('serializeValue');
         },
 
         /**

--- a/test/form/widget/checkBox/test.js
+++ b/test/form/widget/checkBox/test.js
@@ -93,6 +93,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -418,13 +419,14 @@ define([
         };
         var instance;
 
-        assert.expect(5);
+        assert.expect(6);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
                 assert.equal(this.getValue(), config.value, 'The expected value is returned');
+                assert.equal(this.getRawValue(), config.value, 'The expected raw value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
             })
             .on('ready', function () {
@@ -458,7 +460,7 @@ define([
         };
         var instance;
 
-        assert.expect(14);
+        assert.expect(16);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -476,6 +478,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [name="yes"]').length, 1, 'The component contains the yes field');
                         assert.equal($container.find('.form-widget .widget-field [name="no"]').length, 1, 'The component contains the no field');
                         assert.equal(instance.getValue(), '', 'Empty value');
+                        assert.equal(instance.getRawValue(), '', 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -491,6 +494,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             assert.deepEqual(instance.getValue(), ['yes'], 'The value is set');
+                            assert.deepEqual(instance.getRawValue(), ['yes'], 'The raw value is set');
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
@@ -543,7 +547,7 @@ define([
         };
         var instance;
 
-        assert.expect(11);
+        assert.expect(13);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -561,6 +565,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [name="yes"]').length, 1, 'The component contains the yes field');
                         assert.equal($container.find('.form-widget .widget-field [name="no"]').length, 1, 'The component contains the no field');
                         assert.deepEqual(instance.getValue(), ['yes'], 'Init value');
+                        assert.deepEqual(instance.getRawValue(), ['yes'], 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -568,6 +573,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.deepEqual(value, ['no'], 'The expected value is there');
+                                    assert.deepEqual(this.getRawValue(), value, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue(['no']);
@@ -735,7 +741,7 @@ define([
         };
         var instance;
 
-        assert.expect(12);
+        assert.expect(14);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -753,6 +759,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [name="yes"]').length, 1, 'The component contains the yes field');
                         assert.equal($container.find('.form-widget .widget-field [name="no"]').length, 1, 'The component contains the no field');
                         assert.deepEqual(instance.getValue(), ['no'], 'Init value');
+                        assert.deepEqual(instance.getRawValue(), ['no'], 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -767,6 +774,7 @@ define([
                     })
                     .then(function () {
                         assert.deepEqual(instance.getValue(), [], 'The value has been reset');
+                        assert.deepEqual(instance.getRawValue(), [], 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/checkBox/test.js
+++ b/test/form/widget/checkBox/test.js
@@ -96,7 +96,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -591,55 +590,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var config = {
-            widget: 'cb',
-            uri: 'foo',
-            range: [{
-                uri: 'yes'
-            }, {
-                uri: 'no'
-            }]
-        };
-        var instance;
-
-        assert.expect(10);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, config)
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field [name="yes"]').length, 1, 'The component contains the yes field');
-                assert.equal($container.find('.form-widget .widget-field [name="no"]').length, 1, 'The component contains the no field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: []}, 'Empty value');
-                instance.setValue(['yes']);
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ['yes']}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/comboBox/test.js
+++ b/test/form/widget/comboBox/test.js
@@ -96,7 +96,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -570,54 +569,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var config = {
-            widget: 'cb',
-            uri: 'foo',
-            range: [{
-                uri: 'yes'
-            }, {
-                uri: 'no'
-            }]
-        };
-        var instance;
-
-        assert.expect(9);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, config)
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field select').attr('name'), config.uri, 'The component contains the expected field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('yes');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'yes'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/comboBox/test.js
+++ b/test/form/widget/comboBox/test.js
@@ -93,6 +93,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -411,13 +412,14 @@ define([
         };
         var instance;
 
-        assert.expect(6);
+        assert.expect(7);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
                 assert.equal(this.getValue(), config.value, 'The expected value is returned');
+                assert.equal(this.getRawValue(), config.value, 'The expected raw value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
                 assert.deepEqual(this.getConfig().range, [{uri: 'yes'}], 'The range is fixed');
             })
@@ -452,7 +454,7 @@ define([
         };
         var instance;
 
-        assert.expect(10);
+        assert.expect(12);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -469,6 +471,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field select').attr('name'), config.uri, 'The component contains the expected field');
                         assert.equal(instance.getValue(), '', 'Empty value');
+                        assert.equal(instance.getRawValue(), '', 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -476,6 +479,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.equal(value, 'yes', 'The expected value is there');
+                                    assert.equal(this.getRawValue(), value, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('yes');
@@ -522,7 +526,7 @@ define([
         };
         var instance;
 
-        assert.expect(11);
+        assert.expect(13);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -540,6 +544,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field select').attr('name'), config.uri, 'The component contains the expected field');
                         assert.equal($container.find('.form-widget .widget-field select').val(), config.value, 'The component contains the expected value');
                         assert.equal(instance.getValue(), 'yes', 'Init value');
+                        assert.equal(instance.getRawValue(), 'yes', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -547,6 +552,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.equal(value, 'no', 'The expected value is there');
+                                    assert.equal(this.getRawValue(), value, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('no');
@@ -716,7 +722,7 @@ define([
         };
         var instance;
 
-        assert.expect(12);
+        assert.expect(14);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -734,6 +740,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field select').attr('name'), config.uri, 'The component contains the expected field');
                         assert.equal($container.find('.form-widget .widget-field select').val(), config.value, 'The component contains the expected value');
                         assert.equal(instance.getValue(), 'no', 'Init value');
+                        assert.equal(instance.getRawValue(), 'no', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -748,6 +755,7 @@ define([
                     })
                     .then(function () {
                         assert.equal(instance.getValue(), '', 'The value has been reset');
+                        assert.equal(instance.getRawValue(), '', 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/hidden/test.js
+++ b/test/form/widget/hidden/test.js
@@ -99,7 +99,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -566,43 +565,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var instance;
-
-        assert.expect(7);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, {widget: 'hidden', uri: 'foo'})
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('input[type="hidden"]'), true, 'The container contains the expected element');
-                assert.equal($container.find('input[type="hidden"]').attr('name'), 'foo', 'The component contains the expected field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('top');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'top'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/hidden/test.js
+++ b/test/form/widget/hidden/test.js
@@ -96,6 +96,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -382,13 +383,14 @@ define([
         };
         var instance;
 
-        assert.expect(5);
+        assert.expect(6);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
                 assert.equal(this.getValue(), config.value, 'The expected value is returned');
+                assert.equal(this.getRawValue(), config.value, 'The expected raw value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
             })
             .on('ready', function () {
@@ -413,7 +415,7 @@ define([
         var $container = $('#fixture-change');
         var instance;
 
-        assert.expect(13);
+        assert.expect(15);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -428,6 +430,7 @@ define([
                         assert.equal($container.children().is('input[type="hidden"]'), true, 'The container contains the expected element');
                         assert.equal($container.find('input[type="hidden"]').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), '', 'Empty value');
+                        assert.equal(instance.getRawValue(), '', 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -443,6 +446,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             assert.equal(instance.getValue(), 'test', 'The value is set');
+                            assert.equal(instance.getRawValue(), 'test', 'The raw value is set');
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
@@ -521,7 +525,7 @@ define([
         var $container = $('#fixture-value');
         var instance;
 
-        assert.expect(8);
+        assert.expect(10);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -536,6 +540,7 @@ define([
                         assert.equal($container.children().is('input[type="hidden"]'), true, 'The container contains the expected element');
                         assert.equal($container.find('input[type="hidden"]').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.equal(instance.getRawValue(), 'bar', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -543,6 +548,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.equal(value, 'test', 'The expected value is there');
+                                    assert.equal(this.getRawValue(), value, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('test');
@@ -680,7 +686,7 @@ define([
         var $container = $('#fixture-reset');
         var instance;
 
-        assert.expect(9);
+        assert.expect(11);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -695,6 +701,7 @@ define([
                         assert.equal($container.children().is('input[type="hidden"]'), true, 'The container contains the expected element');
                         assert.equal($container.find('input[type="hidden"]').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.equal(instance.getRawValue(), 'bar', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -709,6 +716,7 @@ define([
                     })
                     .then(function () {
                         assert.equal(instance.getValue(), '', 'The value has been reset');
+                        assert.equal(instance.getRawValue(), '', 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/hiddenBox/test.js
+++ b/test/form/widget/hiddenBox/test.js
@@ -93,6 +93,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -398,16 +399,17 @@ define([
         };
         var instance;
 
-        assert.expect(5);
+        assert.expect(6);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
-                assert.deepEqual(this.getValue(), {
+                assert.deepEqual(this.getValue(), '', 'The expected value is returned');
+                assert.deepEqual(this.getRawValue(), {
                     confirmation: '',
                     value: ''
-                }, 'The expected value is returned');
+                }, 'The expected raw value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
             })
             .on('ready', function () {
@@ -436,7 +438,7 @@ define([
         };
         var instance;
 
-        assert.expect(14);
+        assert.expect(18);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -453,20 +455,22 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 2, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '"]').length, 1, 'The component contains the main field');
                         assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '_confirmation"]').length, 1, 'The component contains the confirmation field');
-                        assert.deepEqual(instance.getValue(), {
+                        assert.deepEqual(instance.getValue(), '', 'Empty value');
+                        assert.deepEqual(instance.getRawValue(), {
                             confirmation: '',
                             value: ''
-                        }, 'Empty value');
+                        }, 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
-                                    assert.deepEqual(value, {
+                                    assert.deepEqual(value, 'yes', 'The expected value is there');
+                                    assert.deepEqual(this.getRawValue(), {
                                         confirmation: 'yes',
                                         value: 'yes'
-                                    }, 'The expected value is there');
+                                    }, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('yes');
@@ -474,18 +478,20 @@ define([
                     })
                     .then(function () {
                         return new Promise(function (resolve) {
-                            assert.deepEqual(instance.getValue(), {
+                            assert.deepEqual(instance.getValue(), 'yes', 'The value is set');
+                            assert.deepEqual(instance.getRawValue(), {
                                 confirmation: 'yes',
                                 value: 'yes'
-                            }, 'The value is set');
+                            }, 'The raw value is set');
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
-                                    assert.deepEqual(value, {
+                                    assert.deepEqual(value, 'no', 'The expected value is there');
+                                    assert.deepEqual(this.getRawValue(), {
                                         confirmation: 'yes',
                                         value: 'no'
-                                    }, 'The expected value is there');
+                                    }, 'The expected raw value is there');
                                     resolve();
                                 });
 
@@ -528,7 +534,7 @@ define([
         };
         var instance;
 
-        assert.expect(11);
+        assert.expect(13);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -545,20 +551,22 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 2, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '"]').length, 1, 'The component contains the main field');
                         assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '_confirmation"]').length, 1, 'The component contains the confirmation field');
-                        assert.deepEqual(instance.getValue(), {
+                        assert.deepEqual(instance.getValue(), '', 'Init value');
+                        assert.deepEqual(instance.getRawValue(), {
                             confirmation: '',
                             value: ''
-                        }, 'Init value');
+                        }, 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
-                                    assert.deepEqual(value, {
+                                    assert.deepEqual(value, 'yes', 'The expected value is there');
+                                    assert.deepEqual(this.getRawValue(), {
                                         confirmation: 'yes',
                                         value: 'yes'
-                                    }, 'The expected value is there');
+                                    }, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('yes');
@@ -711,7 +719,7 @@ define([
         };
         var instance;
 
-        assert.expect(12);
+        assert.expect(15);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -729,17 +737,19 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '"]').length, 1, 'The component contains the main field');
                         assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '_confirmation"]').length, 1, 'The component contains the confirmation field');
                         instance.setValue('yes');
-                        assert.deepEqual(instance.getValue(), {
+                        assert.deepEqual(instance.getValue(), 'yes', 'Init value');
+                        assert.deepEqual(instance.getRawValue(), {
                             confirmation: 'yes',
                             value: 'yes'
-                        }, 'Init value');
+                        }, 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
-                                    assert.deepEqual(value, {
+                                    assert.deepEqual(value, '', 'The expected value is there');
+                                    assert.deepEqual(this.getRawValue(), {
                                         confirmation: '',
                                         value: ''
                                     }, 'The expected value is there');
@@ -749,10 +759,11 @@ define([
                         });
                     })
                     .then(function () {
-                        assert.deepEqual(instance.getValue(), {
+                        assert.deepEqual(instance.getValue(), '', 'The value has been reset');
+                        assert.deepEqual(instance.getRawValue(), {
                             confirmation: '',
                             value: ''
-                        }, 'The value has been reset');
+                        }, 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/hiddenBox/test.js
+++ b/test/form/widget/hiddenBox/test.js
@@ -96,7 +96,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -584,50 +583,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var config = {
-            widget: 'hidden',
-            uri: 'foo'
-        };
-        var instance;
-
-        assert.expect(10);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, config)
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 2, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 2, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 2, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '"]').length, 1, 'The component contains the main field');
-                assert.equal($container.find('.form-widget .widget-field [name="' + config.uri + '_confirmation"]').length, 1, 'The component contains the confirmation field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('yes');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'yes'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/radioBox/test.js
+++ b/test/form/widget/radioBox/test.js
@@ -96,7 +96,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -592,55 +591,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var config = {
-            widget: 'rb',
-            uri: 'foo',
-            range: [{
-                uri: 'yes'
-            }, {
-                uri: 'no'
-            }]
-        };
-        var instance;
-
-        assert.expect(10);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, config)
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field [value="yes"]').length, 1, 'The component contains the yes field');
-                assert.equal($container.find('.form-widget .widget-field [value="no"]').length, 1, 'The component contains the no field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('yes');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'yes'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/radioBox/test.js
+++ b/test/form/widget/radioBox/test.js
@@ -93,6 +93,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -419,13 +420,14 @@ define([
         };
         var instance;
 
-        assert.expect(5);
+        assert.expect(6);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
                 assert.equal(this.getValue(), config.value, 'The expected value is returned');
+                assert.equal(this.getRawValue(), config.value, 'The expected raw value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
             })
             .on('ready', function () {
@@ -459,7 +461,7 @@ define([
         };
         var instance;
 
-        assert.expect(14);
+        assert.expect(16);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -477,6 +479,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [value="yes"]').length, 1, 'The component contains the yes field');
                         assert.equal($container.find('.form-widget .widget-field [value="no"]').length, 1, 'The component contains the no field');
                         assert.equal(instance.getValue(), '', 'Empty value');
+                        assert.equal(instance.getRawValue(), '', 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -492,6 +495,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             assert.equal(instance.getValue(), 'yes', 'The value is set');
+                            assert.equal(instance.getRawValue(), 'yes', 'The raw value is set');
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
@@ -544,7 +548,7 @@ define([
         };
         var instance;
 
-        assert.expect(11);
+        assert.expect(13);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -562,6 +566,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [value="yes"]').length, 1, 'The component contains the yes field');
                         assert.equal($container.find('.form-widget .widget-field [value="no"]').length, 1, 'The component contains the no field');
                         assert.equal(instance.getValue(), 'yes', 'Init value');
+                        assert.equal(instance.getRawValue(), 'yes', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -569,6 +574,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.equal(value, 'no', 'The value is set to "no"');
+                                    assert.equal(this.getRawValue(), value, 'The value is set to "no"');
                                     resolve();
                                 })
                                 .setValue('no');
@@ -736,7 +742,7 @@ define([
         };
         var instance;
 
-        assert.expect(12);
+        assert.expect(14);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -754,6 +760,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field [value="yes"]').length, 1, 'The component contains the yes field');
                         assert.equal($container.find('.form-widget .widget-field [value="no"]').length, 1, 'The component contains the no field');
                         assert.equal(instance.getValue(), 'no', 'Init value');
+                        assert.equal(instance.getRawValue(), 'no', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -768,6 +775,7 @@ define([
                     })
                     .then(function () {
                         assert.equal(instance.getValue(), '', 'The value has been reset');
+                        assert.equal(instance.getRawValue(), '', 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/textArea/test.js
+++ b/test/form/widget/textArea/test.js
@@ -96,7 +96,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -594,45 +593,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var instance;
-
-        assert.expect(9);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, {widget: 'text', uri: 'foo'})
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field textarea').attr('name'), 'foo', 'The component contains the expected field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('top');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'top'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/textArea/test.js
+++ b/test/form/widget/textArea/test.js
@@ -93,6 +93,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -406,13 +407,14 @@ define([
         };
         var instance;
 
-        assert.expect(5);
+        assert.expect(6);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
                 assert.equal(this.getValue(), config.value, 'The expected value is returned');
+                assert.equal(this.getRawValue(), config.value, 'The expected raw value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
             })
             .on('ready', function () {
@@ -437,7 +439,7 @@ define([
         var $container = $('#fixture-change');
         var instance;
 
-        assert.expect(15);
+        assert.expect(17);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -454,6 +456,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field textarea').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), '', 'Empty value');
+                        assert.equal(instance.getRawValue(), '', 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -469,6 +472,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             assert.equal(instance.getValue(), 'test', 'The value is set');
+                            assert.equal(instance.getRawValue(), 'test', 'The raw value is set');
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
@@ -547,7 +551,7 @@ define([
         var $container = $('#fixture-value');
         var instance;
 
-        assert.expect(10);
+        assert.expect(12);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -564,6 +568,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field textarea').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.equal(instance.getRawValue(), 'bar', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -571,6 +576,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.equal(value, 'test', 'The expected value is there');
+                                    assert.equal(this.getRawValue(), value, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('test');
@@ -712,7 +718,7 @@ define([
         var $container = $('#fixture-reset');
         var instance;
 
-        assert.expect(11);
+        assert.expect(13);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -729,6 +735,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field textarea').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.equal(instance.getRawValue(), 'bar', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -743,6 +750,7 @@ define([
                     })
                     .then(function () {
                         assert.equal(instance.getValue(), '', 'The value has been reset');
+                        assert.equal(instance.getRawValue(), '', 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/textBox/test.js
+++ b/test/form/widget/textBox/test.js
@@ -96,7 +96,6 @@ define([
         {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -590,45 +589,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var instance;
-
-        assert.expect(9);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, {widget: 'text', uri: 'foo'})
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('top');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'top'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();

--- a/test/form/widget/textBox/test.js
+++ b/test/form/widget/textBox/test.js
@@ -93,6 +93,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'reset'},
         {title: 'serializeValue'},
@@ -402,13 +403,14 @@ define([
         };
         var instance;
 
-        assert.expect(5);
+        assert.expect(6);
 
         instance = widgetFactory($container, config)
             .on('init', function () {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getUri(), config.uri, 'The expected uri is returned');
                 assert.equal(this.getValue(), config.value, 'The expected value is returned');
+                assert.equal(this.getRawValue(), config.value, 'The expected value is returned');
                 assert.equal(this.getWidgetElement(), null, 'There is no form element yet');
             })
             .on('ready', function () {
@@ -433,7 +435,7 @@ define([
         var $container = $('#fixture-change');
         var instance;
 
-        assert.expect(15);
+        assert.expect(17);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -450,6 +452,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), '', 'Empty value');
+                        assert.equal(instance.getRawValue(), '', 'Empty raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -465,6 +468,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             assert.equal(instance.getValue(), 'test', 'The value is set');
+                            assert.equal(instance.getRawValue(), 'test', 'The raw value is set');
                             instance
                                 .off('.test')
                                 .on('change.test', function (value, uri) {
@@ -543,7 +547,7 @@ define([
         var $container = $('#fixture-value');
         var instance;
 
-        assert.expect(10);
+        assert.expect(12);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -560,6 +564,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.equal(instance.getRawValue(), 'bar', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -567,6 +572,7 @@ define([
                                 .on('change.test', function (value, uri) {
                                     assert.equal(uri, 'foo', 'The change event has been triggered');
                                     assert.equal(value, 'test', 'The expected value is there');
+                                    assert.equal(this.getRawValue(), value, 'The expected raw value is there');
                                     resolve();
                                 })
                                 .setValue('test');
@@ -708,7 +714,7 @@ define([
         var $container = $('#fixture-reset');
         var instance;
 
-        assert.expect(11);
+        assert.expect(13);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
@@ -725,6 +731,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.equal(instance.getRawValue(), 'bar', 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -739,6 +746,7 @@ define([
                     })
                     .then(function () {
                         assert.equal(instance.getValue(), '', 'The value has been reset');
+                        assert.equal(instance.getRawValue(), '', 'The raw value has been reset');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');

--- a/test/form/widget/widget/test.js
+++ b/test/form/widget/widget/test.js
@@ -107,6 +107,7 @@ define([
     QUnit.cases.init([
         {title: 'getUri'},
         {title: 'getValue'},
+        {title: 'getRawValue'},
         {title: 'setValue'},
         {title: 'getValidator'},
         {title: 'setValidator'},
@@ -158,7 +159,7 @@ define([
 
         assert.expect(1);
 
-        assert.throws(function() {
+        assert.throws(function () {
             widgetFactory($container, data.config);
         }, 'The factory should raise an error');
     });
@@ -350,7 +351,7 @@ define([
                 assert.ok(true, 'The provider init() method is called');
                 assert.equal(typeof this.is, 'function', 'The lexical scope is the widget');
 
-                this.on('render', function() {
+                this.on('render', function () {
                     assert.ok(true, 'The listener has been called');
                 });
             }
@@ -407,7 +408,7 @@ define([
                 assert.ok(true, 'The provider init() method is called');
                 assert.equal(typeof this.is, 'function', 'The lexical scope is the widget');
 
-                this.on('render', function() {
+                this.on('render', function () {
                     assert.ok(true, 'The listener has been called');
                 });
             }
@@ -463,7 +464,7 @@ define([
                 assert.ok(true, 'The provider init() method is called');
                 assert.equal(typeof this.is, 'function', 'The lexical scope is the widget');
 
-                this.on('render', function() {
+                this.on('render', function () {
                     assert.ok(true, 'The listener has been called');
                 });
             },
@@ -817,7 +818,7 @@ define([
                                     resolve();
                                 });
 
-                            _.delay(function() {
+                            _.delay(function () {
                                 instance.off('.test');
                                 assert.ok(true, 'The change event has not been triggered');
                                 resolve();
@@ -835,7 +836,7 @@ define([
                                     resolve();
                                 });
 
-                            _.delay(function() {
+                            _.delay(function () {
                                 instance.off('.test');
                                 assert.ok(true, 'The change event has not been triggered');
                                 resolve();
@@ -876,12 +877,19 @@ define([
         var instance;
         var providerValue;
 
-        assert.expect(16);
+        assert.expect(21);
 
         widgetFactory.registerProvider('values', {
             init: function init(config) {
                 assert.ok(true, 'The provider init() method is called');
                 providerValue = config.value;
+            },
+            getRawValue: function getRawValue() {
+                assert.ok(true, 'The provider getRawValue() method is called');
+                return {
+                    value: providerValue,
+                    type: typeof providerValue
+                };
             },
             getValue: function getValue() {
                 assert.ok(true, 'The provider getValue() method is called');
@@ -908,6 +916,7 @@ define([
                         assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
                         assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
                         assert.equal(instance.getValue(), 'bar', 'Init value');
+                        assert.deepEqual(instance.getRawValue(), {type: 'string', value: 'bar'}, 'Init raw value');
 
                         return new Promise(function (resolve) {
                             instance
@@ -921,7 +930,9 @@ define([
                         });
                     })
                     .then(function () {
-                        assert.equal(providerValue, instance.getValue(), 'The value has been changed');
+                        assert.equal(providerValue, 'test', 'The value has been changed');
+                        assert.deepEqual(instance.getValue(), 'test', 'New value');
+                        assert.deepEqual(instance.getRawValue(), {type: 'string', value: 'test'}, 'New raw value');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'The operation should not fail!');
@@ -1100,7 +1111,7 @@ define([
                 assert.ok(true, 'The provider setDefaultValidators() method is called');
                 this.setValidator({
                     id: 'required',
-                    predicate: function() {
+                    predicate: function () {
                         return false;
                     }
                 });
@@ -1176,7 +1187,7 @@ define([
                     .then(function () {
                         instance.setValidator({
                             id: 'required2',
-                            predicate: function() {
+                            predicate: function () {
                                 return false;
                             }
                         });
@@ -1252,7 +1263,7 @@ define([
                     })
                     .then(function () {
                         instance.setValidator({
-                            validate: function() {
+                            validate: function () {
                                 return Promise.reject(false);
                             }
                         });
@@ -1466,9 +1477,9 @@ define([
             })
             .on('change', function (value, uri) {
                 this.validate()
-                    .catch(function() {
+                    .catch(function () {
                     })
-                    .then(function() {
+                    .then(function () {
                         $outputChange.val('value of [' + uri + '] changed to "' + value + '"\n' + $outputChange.val());
                     });
             })

--- a/test/form/widget/widget/test.js
+++ b/test/form/widget/widget/test.js
@@ -113,7 +113,6 @@ define([
         {title: 'setValidator'},
         {title: 'setDefaultValidators'},
         {title: 'reset'},
-        {title: 'serializeValue'},
         {title: 'validate'},
         {title: 'getWidgetElement'}
     ]).test('component API ', function (data, assert) {
@@ -946,97 +945,6 @@ define([
                             .off('.test')
                             .destroy();
                     });
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var instance;
-
-        assert.expect(9);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, {widget: 'text', uri: 'foo'})
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('top');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'top'}, 'New value');
-
-                instance.destroy();
-            })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                assert.ok(false, 'The operation should not fail!');
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
-                ready();
-            });
-    });
-
-    QUnit.test('serialize value from provider', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-serialize-value');
-        var instance;
-
-        assert.expect(12);
-
-        widgetFactory.registerProvider('serializeValue', {
-            init: function init() {
-                assert.ok(true, 'The provider init() method is called');
-            },
-            serializeValue: function serializeValue() {
-                assert.ok(true, 'The provider serializeValue() method is called');
-                return {
-                    name: this.getUri(),
-                    value: this.getValue()
-                };
-            }
-        });
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = widgetFactory($container, {widget: 'serializeValue', uri: 'foo'})
-            .on('init', function () {
-                assert.equal(this, instance, 'The instance has been initialized');
-            })
-            .on('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                assert.equal($container.children().is('.form-widget'), true, 'The container contains the expected element');
-                assert.equal($container.find('.form-widget .widget-label').length, 1, 'The component contains an area for the label');
-                assert.equal($container.find('.form-widget .widget-field').length, 1, 'The component contains an area for the field');
-                assert.equal($container.find('.form-widget .widget-field input').attr('name'), 'foo', 'The component contains the expected field');
-
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: ''}, 'Empty value');
-                instance.setValue('top');
-                assert.deepEqual(instance.serializeValue(), {name: 'foo', value: 'top'}, 'New value');
-
-                instance.destroy();
             })
             .on('destroy', function () {
                 ready();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8246

I found an issue occurring with widgets that manage internally a complex data set, like the `hiddenBox`. The API `getValue()` and `setValue()` were asymetric, the getter being able to return data format incompatible with the setter. This was necessary to make the validator working, but needed the add of a silly `serializeValue()` API.

I reworked a little the API, in order to get rid of the useless `serializeValue()` API that was introduced to workaround the discrepancy explained above. Now `getValue()` returns the same kind of value `setValue()` can handle, and `getRawValue()` returns the internal data set, which is mandatory to properly apply the validators.

To test the changes:
```
npm run prepare
npm run test form
```