### PR TITLE
Fix/tao 8518 russian font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 /node_modules
 /dist
 css/
+
+# phpstorm files
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_variables.scss
+++ b/scss/inc/_variables.scss
@@ -6,8 +6,8 @@ $treeSidebar: 280;
 // fonts
 $fontPath : 'font/' !default;
 $monospaceFont: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace;
-$regularFont: 'Franklin Gothic', 'Franklin Gothic Medium', 'Source Sans Pro', sans-serif;
-$headingFont: "Century Gothic", CenturyGothic, AppleGothic, sans-serif;
+$regularFont: 'Source Sans Pro', sans-serif;
+$headingFont: 'Source Sans Pro', sans-serif;
 
 
 %clearfix {

--- a/src/datetime/picker.js
+++ b/src/datetime/picker.js
@@ -513,9 +513,8 @@ export default function dateTimePickerFactory(container, options) {
                      * @event dateTimePicker#change
                      * @param {String} value - the date/time value
                      */
+                    self.trigger('change', value);
                 }
-
-                self.trigger('change', value);
             });
 
             value = this.controls.input.value;

--- a/src/datetime/picker.js
+++ b/src/datetime/picker.js
@@ -503,7 +503,7 @@ export default function dateTimePickerFactory(container, options) {
 
                 if (value && _.isString(newValue) && _.isEmpty(newValue)) {
                     //if someone remove the value from the field
-                    //it's considered a propert clean (resets everything)
+                    //it's considered a property clean (resets everything)
                     self.clear();
                 } else if (value !== newValue) {
                     value = newValue;
@@ -513,8 +513,9 @@ export default function dateTimePickerFactory(container, options) {
                      * @event dateTimePicker#change
                      * @param {String} value - the date/time value
                      */
-                    self.trigger('change', value);
                 }
+
+                self.trigger('change', value);
             });
 
             value = this.controls.input.value;


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TAO-8518

What changed?

I changed the regular and heading font family to source sans pro from AppleGothic because AppleGothic does not support Russian Alphabets.

Related PR: 

- [ ] https://github.com/oat-sa/tao-core/pull/2193