### PR TITLE
[WIP] Feature/tao 8246/use new ui form in resourceselector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.16.1",
+    "version": "0.17.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -869,9 +869,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.4.1.tgz",
-            "integrity": "sha512-oeR7ZCKkhhz0JLA2MJ+mGlUIYEj4/1wuJkM417HwgdOXRX9Ojz5L3wW70Iof8JFJDts58YrgVIHyhfTWHuAL/Q==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.5.0.tgz",
+            "integrity": "sha512-abBCI1vpmWhlfmvD2VgsbZSOB1VZYjFr8HAX27aSvFpAmb42bI8Hh7CqDdoZVLArfrSx7ZTZVOAQE11kCJP8Ag==",
             "dev": true,
             "requires": {
                 "idb-wrapper": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.16.1",
+    "version": "0.17.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/tao-core-libs": "^0.1.0",
-        "@oat-sa/tao-core-sdk": "^0.4.1",
+        "@oat-sa/tao-core-sdk": "^0.5.0",
         "async": "^0.2.10",
         "autoprefixer": "^9.5.1",
         "decimal.js": "^10.1.1",

--- a/src/form/widget/definitions.js
+++ b/src/form/widget/definitions.js
@@ -31,6 +31,7 @@ const widgetDefinitions = {
     HIDDENBOX: 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#HiddenBox',
     RADIOBOX: 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox',
     COMBOBOX: 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox',
+    STATEWIDGET: 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#StateWidget',
     CHECKBOX: 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox'
 
     /* @todo implement the remaining form widgets */

--- a/src/form/widget/loader.js
+++ b/src/form/widget/loader.js
@@ -31,6 +31,7 @@ import widgetTextBoxProvider from 'ui/form/widget/providers/textBox';
 
 widgetFactory.registerProvider(widgetDefinitions.CHECKBOX, widgetCheckBoxProvider);
 widgetFactory.registerProvider(widgetDefinitions.COMBOBOX, widgetComboBoxProvider);
+widgetFactory.registerProvider(widgetDefinitions.STATEWIDGET, widgetComboBoxProvider);
 widgetFactory.registerProvider(widgetDefinitions.HIDDEN, widgetHiddenProvider);
 widgetFactory.registerProvider(widgetDefinitions.HIDDENBOX, widgetHiddenBoxProvider);
 widgetFactory.registerProvider(widgetDefinitions.RADIOBOX, widgetRadioBoxProvider);

--- a/src/resource/filters.js
+++ b/src/resource/filters.js
@@ -130,6 +130,11 @@ export default function filtersFactory($container, config) {
                         title: this.config.title,
                     })
                         .on('ready', () => {
+                            /**
+                             * Notifies the update is done
+                             * @event filter#update
+                             * @param {Object} data - the filtering data
+                             */
                             this.trigger('update', data);
                         })
                         .on('submit reset', () => {

--- a/test/form/widget/definitions/test.js
+++ b/test/form/widget/definitions/test.js
@@ -45,6 +45,7 @@ define([
         {title: 'HIDDENBOX'},
         {title: 'RADIOBOX'},
         {title: 'COMBOBOX'},
+        {title: 'STATEWIDGET'},
         {title: 'CHECKBOX'}
     ]).test('constant ', function (data, assert) {
         assert.expect(1);

--- a/test/form/widget/loader/test.js
+++ b/test/form/widget/loader/test.js
@@ -67,6 +67,7 @@ define([
         {title: 'HIDDENBOX'},
         {title: 'RADIOBOX'},
         {title: 'COMBOBOX'},
+        {title: 'STATEWIDGET'},
         {title: 'CHECKBOX'}
     ]).test('constant ', function (data, assert) {
         const widget = widgetDefinitions[data.title];

--- a/test/resource/filters/test.js
+++ b/test/resource/filters/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -132,7 +132,7 @@ define([
             data: propertiesData,
             title: 'Foo',
             applyLabel: 'Bar'
-        }).on('render', function() {
+        }).on('update', function() {
             var $element = this.getElement();
 
             assert.equal($('.filters', $container).length, 1, 'The component has been inserted');
@@ -148,17 +148,17 @@ define([
                 'The component contains the lang field'
             );
 
-            assert.equal($('h2', $element).length, 1, 'The component contains a title');
+            assert.equal($('.form-title', $element).length, 1, 'The component contains a title');
             assert.equal(
-                $('h2', $element)
+                $('.form-title', $element)
                     .text()
                     .trim(),
                 'Foo',
                 'The component has the correct title'
             );
-            assert.equal($('.toolbar :submit', $element).length, 1, 'The component contains the apply button');
+            assert.equal($('.form-actions [data-control="submit"]', $element).length, 1, 'The component contains the apply button');
             assert.equal(
-                $('.toolbar :submit', $element)
+                $('.form-actions [data-control="submit"]', $element)
                     .text()
                     .trim(),
                 'Bar',
@@ -180,10 +180,10 @@ define([
         filtersFactory($container, {
             classUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
             data: propertiesData
-        }).on('render', function() {
+        }).on('update', function() {
             var $element = this.getElement();
             var $label = $('[name="' + labelUri + '"]', $element);
-            var $apply = $('.toolbar :submit', $element);
+            var $apply = $('.form-actions [data-control="submit"]', $element);
             var values;
 
             assert.equal($label.length, 1, 'The component has the label field');
@@ -222,7 +222,7 @@ define([
         filtersFactory($container, {
             classUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
             data: propertiesData
-        }).on('render', function() {
+        }).on('update', function() {
             var $element = this.getElement();
             var $label = $('[name="' + labelUri + '"]', $element);
             var values;

--- a/test/resource/filters/test.js
+++ b/test/resource/filters/test.js
@@ -132,7 +132,7 @@ define([
             data: propertiesData,
             title: 'Foo',
             applyLabel: 'Bar'
-        }).on('update', function() {
+        }).on('ready', function() {
             var $element = this.getElement();
 
             assert.equal($('.filters', $container).length, 1, 'The component has been inserted');
@@ -180,7 +180,7 @@ define([
         filtersFactory($container, {
             classUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
             data: propertiesData
-        }).on('update', function() {
+        }).on('ready', function() {
             var $element = this.getElement();
             var $label = $('[name="' + labelUri + '"]', $element);
             var $apply = $('.form-actions [data-control="submit"]', $element);
@@ -222,7 +222,7 @@ define([
         filtersFactory($container, {
             classUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
             data: propertiesData
-        }).on('update', function() {
+        }).on('ready', function() {
             var $element = this.getElement();
             var $label = $('[name="' + labelUri + '"]', $element);
             var values;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8246

A side PR to replace the use of `ui/generis/form` by `ui/form/form`.
The only place where it was in use was in the `resourceSelector`.

The biggest change, apart the change of component, is that the new form component does not render synchronously, so the consumer should listen to the `ready` event to be able to properly interact with it. For that reason, the `filters.update()` method now emits an `update` event when the form filter is ready. It also emits a `ready` event when the component has been fully rendered.

To test the PR:
```
npm run prepare
npm run test
```

To visually interact with the component:
```
npm run test:keepAlive
```
Then open your browser on http://127.0.0.1:8082/test/resource/filters/test.html