### PR TITLE
Fix/tao 8122/loading bar sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -190,6 +190,8 @@ var dataTable = {
      */
     _refresh: function($elt, data) {
         // TODO: refresh only rows with data, not all component
+
+        loadingBar.start();
         if (data) {
             this._render($elt, data);
         } else {
@@ -210,8 +212,6 @@ var dataTable = {
         var options = $elt.data(dataNs);
         var parameters;
         var ajaxConfig;
-
-        loadingBar.start();
 
         if (!$filter) {
             $filter = $('.filter', $elt);
@@ -246,7 +246,6 @@ var dataTable = {
         $.ajax(ajaxConfig)
             .done(function(response) {
                 self._render($elt, response);
-                loadingBar.stop();
             })
             .fail(function(response, option, err) {
                 var requestErr = httpErrorParser.parse(response, option, err);
@@ -256,7 +255,6 @@ var dataTable = {
                 $elt.trigger('error.' + ns, [requestErr]);
 
                 self._render($elt, {});
-                loadingBar.stop();
             });
     },
 
@@ -624,6 +622,8 @@ var dataTable = {
                 self._setRows($elt, val);
             });
         }
+
+        loadingBar.stop();
 
         /**
          * @event dataTable#load.dataTable

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -212,7 +212,7 @@ var dataTable = {
         var ajaxConfig;
 
         loadingBar.start();
-        
+
         if (!$filter) {
             $filter = $('.filter', $elt);
         }

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -190,8 +190,6 @@ var dataTable = {
      */
     _refresh: function($elt, data) {
         // TODO: refresh only rows with data, not all component
-
-        loadingBar.start();
         if (data) {
             this._render($elt, data);
         } else {
@@ -213,6 +211,8 @@ var dataTable = {
         var parameters;
         var ajaxConfig;
 
+        loadingBar.start();
+        
         if (!$filter) {
             $filter = $('.filter', $elt);
         }


### PR DESCRIPTION
**Related to task:** 
https://oat-sa.atlassian.net/browse/TAO-8122

**Description:**
Loading bar out of sync.
The loading bar stops before the new items are fully rendered in the table rows.

With this fix, we pretend to see the new items to be added in the datatable at the same time that the loading bar stops.
Also, 

**Requested for:**
- [ ] https://github.com/oat-sa/extension-tao-nccer-delivery/pull/926
