### PR TITLE
Feature/tao 8714/Add style for secondary buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.18.1",
+    "version": "0.19.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.18.1",
+    "version": "0.19.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_buttons.scss
+++ b/scss/inc/_buttons.scss
@@ -18,9 +18,19 @@
     font-style: normal;
     text-align: center;
     height: 35px;
+    &.btn-secondary {
+        background-color: $uiGeneralContentBg;
+        border: 1px solid whiten($uiClickableActiveBg, .1);
+        color: whiten($uiClickableActiveBg, .1) !important;
+        text-shadow: none;
+        line-height: 2.3;
+    }
     &.small {
         line-height: 1.8;
         height: 25px;
+        &.btn-secondary {
+            line-height: 1.5;
+        }
         [class^="icon-"], [class*=" icon-"] {
             @include font-size(13);
         }
@@ -45,20 +55,44 @@
     &.btn-info {
         background-color: whiten($info, .1);
         text-shadow: 1px 1px 0 blacken($info, .2);
+        &.btn-secondary {
+            color: whiten($info, .1) !important;
+            border-color: whiten($info, .1);
+            background-color: $uiGeneralContentBg;
+            text-shadow: none;
+        }
     }
     &.btn-error {
         background-color: whiten($error, .1);
         text-shadow: 1px 1px 0 blacken($error, .2);
+        &.btn-secondary {
+            color: whiten($error, .1) !important;
+            border-color: whiten($error, .1);
+            background-color: $uiGeneralContentBg;
+            text-shadow: none;
+        }
     }
 
     &.btn-success {
         background-color: whiten($success, .1);
         text-shadow: 1px 1px 0 blacken($success, .2);
+        &.btn-secondary {
+            color: whiten($success, .1) !important;
+            border-color: whiten($success, .1);
+            background-color: $uiGeneralContentBg;
+            text-shadow: none;
+        }
     }
 
     &.btn-warning {
         background-color: whiten($warning, .1);
         text-shadow: 1px 1px 0 blacken($warning, .2);
+        &.btn-secondary {
+            color: whiten($warning, .1) !important;
+            border-color: whiten($warning, .1);
+            background-color: $uiGeneralContentBg;
+            text-shadow: none;
+        }
     }
 }
 

--- a/scss/inc/_buttons.scss
+++ b/scss/inc/_buttons.scss
@@ -2,7 +2,7 @@
     @include border-radius(3);
     font-size: 14px !important;
     font-size: 1.4rem !important;
-    color: white() !important;
+    color: white();
     cursor: pointer;
     text-decoration: none !important;
     vertical-align: middle;
@@ -21,7 +21,7 @@
     &.btn-secondary {
         background-color: $uiGeneralContentBg;
         border: 1px solid whiten($uiClickableActiveBg, .1);
-        color: whiten($uiClickableActiveBg, .1) !important;
+        color: whiten($uiClickableActiveBg, .1);
         text-shadow: none;
         line-height: 2.3;
     }
@@ -56,7 +56,7 @@
         background-color: whiten($info, .1);
         text-shadow: 1px 1px 0 blacken($info, .2);
         &.btn-secondary {
-            color: whiten($info, .1) !important;
+            color: whiten($info, .1);
             border-color: whiten($info, .1);
             background-color: $uiGeneralContentBg;
             text-shadow: none;
@@ -66,7 +66,7 @@
         background-color: whiten($error, .1);
         text-shadow: 1px 1px 0 blacken($error, .2);
         &.btn-secondary {
-            color: whiten($error, .1) !important;
+            color: whiten($error, .1);
             border-color: whiten($error, .1);
             background-color: $uiGeneralContentBg;
             text-shadow: none;
@@ -77,7 +77,7 @@
         background-color: whiten($success, .1);
         text-shadow: 1px 1px 0 blacken($success, .2);
         &.btn-secondary {
-            color: whiten($success, .1) !important;
+            color: whiten($success, .1);
             border-color: whiten($success, .1);
             background-color: $uiGeneralContentBg;
             text-shadow: none;
@@ -88,7 +88,7 @@
         background-color: whiten($warning, .1);
         text-shadow: 1px 1px 0 blacken($warning, .2);
         &.btn-secondary {
-            color: whiten($warning, .1) !important;
+            color: whiten($warning, .1);
             border-color: whiten($warning, .1);
             background-color: $uiGeneralContentBg;
             text-shadow: none;
@@ -104,11 +104,14 @@ button, input[type="submit"], input[type="reset"] {
 
 /* todo move to main ? */
 .disabled, button[disabled] {
+    // !important is required here to overwrite any other inherited rule no matter the specificity,
+    // as the disabled style must be consistent all across the stylesheet
     background-color: whiten($websiteBorder, .3) !important;
     text-shadow: 1px 1px 0 white(.8) !important;
     cursor: not-allowed !important;
     opacity: .55 !important;
     color: #000 !important;
+    border: none !important;
 }
 
 // jquery ui

--- a/scss/inc/_buttons.scss
+++ b/scss/inc/_buttons.scss
@@ -1,8 +1,20 @@
+@mixin generic-btn-primary($color, $background) {
+    color: $color;
+    background-color: whiten($background, .1);
+    text-shadow: 1px 1px 0 blacken($background, .2);
+}
+
+@mixin generic-btn-secondary($color, $background) {
+    color: whiten($color, .1);
+    border: 1px solid whiten($color, .1);
+    background-color: $background;
+    text-shadow: none;
+}
+
 %generic-btn-code {
     @include border-radius(3);
     font-size: 14px !important;
     font-size: 1.4rem !important;
-    color: white();
     cursor: pointer;
     text-decoration: none !important;
     vertical-align: middle;
@@ -12,17 +24,13 @@
     display: inline-block;
     line-height: 2.5;
     padding: 0 15px;
-    background-color: whiten($uiClickableActiveBg, .1);
-    text-shadow: 1px 1px 0 blacken($uiClickableActiveBg, .2);
     font-weight: normal;
     font-style: normal;
     text-align: center;
     height: 35px;
+    @include generic-btn-primary(white(), $uiClickableActiveBg);
     &.btn-secondary {
-        background-color: $uiGeneralContentBg;
-        border: 1px solid whiten($uiClickableActiveBg, .1);
-        color: whiten($uiClickableActiveBg, .1);
-        text-shadow: none;
+        @include generic-btn-secondary($uiClickableActiveBg, $uiGeneralContentBg);
         line-height: 2.3;
     }
     &.small {
@@ -53,45 +61,29 @@
         opacity: .85;
     }
     &.btn-info {
-        background-color: whiten($info, .1);
-        text-shadow: 1px 1px 0 blacken($info, .2);
+        @include generic-btn-primary(white(), $info);
         &.btn-secondary {
-            color: whiten($info, .1);
-            border-color: whiten($info, .1);
-            background-color: $uiGeneralContentBg;
-            text-shadow: none;
+            @include generic-btn-secondary($info, $uiGeneralContentBg);
         }
     }
     &.btn-error {
-        background-color: whiten($error, .1);
-        text-shadow: 1px 1px 0 blacken($error, .2);
+        @include generic-btn-primary(white(), $error);
         &.btn-secondary {
-            color: whiten($error, .1);
-            border-color: whiten($error, .1);
-            background-color: $uiGeneralContentBg;
-            text-shadow: none;
+            @include generic-btn-secondary($error, $uiGeneralContentBg);
         }
     }
 
     &.btn-success {
-        background-color: whiten($success, .1);
-        text-shadow: 1px 1px 0 blacken($success, .2);
+        @include generic-btn-primary(white(), $success);
         &.btn-secondary {
-            color: whiten($success, .1);
-            border-color: whiten($success, .1);
-            background-color: $uiGeneralContentBg;
-            text-shadow: none;
+            @include generic-btn-secondary($success, $uiGeneralContentBg);
         }
     }
 
     &.btn-warning {
-        background-color: whiten($warning, .1);
-        text-shadow: 1px 1px 0 blacken($warning, .2);
+        @include generic-btn-primary(white(), $warning);
         &.btn-secondary {
-            color: whiten($warning, .1);
-            border-color: whiten($warning, .1);
-            background-color: $uiGeneralContentBg;
-            text-shadow: none;
+            @include generic-btn-secondary($warning, $uiGeneralContentBg);
         }
     }
 }

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -549,8 +549,10 @@ label {
     [class^="btn-"], [class*=" btn-"],
     button, input[type="submit"], input[type="reset"] {
         &.btn-success {
-            background-color: whiten($info, .1);
-            text-shadow: 1px 1px 0 blacken($info, .2);
+            @include generic-btn-primary(white(), $info);
+            &.btn-secondary {
+                @include generic-btn-secondary($info, $uiGeneralContentBg);
+            }
         }
     }
 

--- a/src/dateRange/tpl/select.tpl
+++ b/src/dateRange/tpl/select.tpl
@@ -11,7 +11,7 @@
     </button>
     {{/if}}
     {{#if resetButton.enable}}
-    <button class="small" data-control="reset" title="{{resetButton.title}}">
+    <button class="small btn-info btn-secondary" data-control="reset" title="{{resetButton.title}}">
         <span class="icon icon-{{resetButton.icon}}"></span> {{resetButton.label}}
     </button>
     {{/if}}

--- a/test/button/test.js
+++ b/test/button/test.js
@@ -468,10 +468,11 @@ define(['jquery', 'lodash', 'ui/button', 'tpl!test/ui/button/click'], function($
         var showDuration = 2000;
         var occurrence = 0;
 
-        function createInstance(id, label, type, delay) {
+        function createInstance(id, label, type, cls, delay) {
             return button({
                 id: id,
                 type: type,
+                cls: cls,
                 label: label
             })
                 .on('render', function() {
@@ -503,12 +504,18 @@ define(['jquery', 'lodash', 'ui/button', 'tpl!test/ui/button/click'], function($
                 });
         }
 
-        assert.expect(5);
+        assert.expect(11);
 
-        createInstance('button-1', 'Button 1', 'info', showDuration);
-        createInstance('button-2', 'Button 2', 'warning', showDuration);
-        createInstance('button-3', 'Button 3', 'error', showDuration);
-        createInstance('button-4', 'Button 4', 'neutral', showDuration);
-        createAsyncInstance('async-button', 'Async Button', 'success', showDuration * 2);
+        createInstance('button-1', 'Button 1', 'info', '', showDuration);
+        createInstance('button-2', 'Button 2', 'warning', '', showDuration);
+        createInstance('button-3', 'Button 3', 'error', '', showDuration);
+        createInstance('button-4', 'Button 4', 'neutral', '', showDuration);
+        createInstance('button-5', 'Button 5', 'success', '', showDuration);
+        createInstance('button-secondary-1', 'Button 1', 'info', 'btn-secondary', showDuration);
+        createInstance('button-secondary-2', 'Button 2', 'warning', 'btn-secondary', showDuration);
+        createInstance('button-secondary-3', 'Button 3', 'error', 'btn-secondary', showDuration);
+        createInstance('button-secondary-4', 'Button 4', 'neutral', 'btn-secondary', showDuration);
+        createInstance('button-secondary-5', 'Button 5', 'success', 'btn-secondary', showDuration);
+        createAsyncInstance('async-button', 'Async Button', 'success', '', showDuration * 2);
     });
 });

--- a/test/dateRange/test.html
+++ b/test/dateRange/test.html
@@ -13,9 +13,45 @@
                 });
             });
         </script>
+        <style>
+            #visual-test {
+                background: #EEE;
+                position: relative;
+                display: flex;
+                margin: 10px;
+                padding: 10px;
+                flex-direction: row;
+                justify-content: space-between;
+            }
+
+            #visual-test .output {
+                display: flex;
+                flex-direction: column;
+            }
+
+            #visual-test .output span {
+                display: inline-block;
+                width: 10rem;
+            }
+
+            #visual-test .output textarea {
+                display: inline-block;
+                min-width: 500px;
+                min-height: 10rem;
+            }
+        </style>
     </head>
     <body>
         <div id="qunit"></div>
         <div id="qunit-fixture"></div>
+        <div id="visual-test">
+            <div class="test"></div>
+            <div class="output">
+                <label>
+                    <span>Changes:</span>
+                    <textarea class="change-output"></textarea>
+                </label>
+            </div>
+        </div>
     </body>
 </html>

--- a/test/dateRange/test.js
+++ b/test/dateRange/test.js
@@ -287,4 +287,57 @@ define(['ui/dateRange/dateRange'], function(dateRangeFactory) {
                 done();
             });
     });
+
+    QUnit.module('Visual');
+
+    QUnit.test('Visual test', function (assert) {
+        var ready = assert.async();
+        var $container = $('#visual-test .test');
+        var $outputChange = $('#visual-test .change-output');
+        var instance = dateRangeFactory($container, {
+            startPicker: {
+                setup: 'date',
+                field: {
+                    name: 'periodStart',
+                    value: '2019-04-05'
+                }
+            },
+            endPicker: {
+                setup: 'date',
+                field: {
+                    name: 'periodEnd'
+                }
+            }
+        });
+
+        assert.expect(3);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                ready();
+            })
+            .on('reset', function () {
+                $outputChange.val('reset');
+            })
+            .on('submit', function (start, end) {
+                $outputChange.val('Submitted values:\n- start: ' + start + '\n- end: ' + end);
+            })
+            .on('change', function (name, value) {
+                $outputChange.val('value of [' + name + '] changed to "' + value + '"\n' + $outputChange.val());
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8714

Add styling for secondary buttons:
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/1500098/61213890-b0d67d80-a706-11e9-9c95-8f00e1422d23.png">

And set the `Reset` button to secondary in the `ui/dateRange` component.

Also added/updated a visual playground for the impacted components.

Impacted unit tests:
- `/test/button/test.html`
- `/test/dateRange/test.html`

To test:
```
npm run prepare
npm run test
```

To see in action:
```
npm run test:keepAlive
```

Then open a browser on:
- http://127.0.0.1:8082/test/button/test.html
- http://127.0.0.1:8082/test/dateRange/test.html

**Important:** After merge do not forget to release and publish to npm