### PR TITLE
Feature/tao 8720/refactor tabs component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.21.4",
+    "version": "0.22.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.21.4",
+    "version": "0.22.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -15,202 +15,515 @@
  *
  * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
  */
+
 /**
- * @author Martin Nicholson <martin@taotesting.com>
- */
-/**
- * @example
- * const instance = tabs({
- *   renderTo: $container,
- *   tabs: [
- *     { label: 'TAO Local', name: 'local-delivery' },
- *     { label: 'TAO Remote', name: 'remote-delivery' },
- *     { label: 'LTI-based', name: 'lti-delivery', disabled: true }
- *   ],
- *   activeTabIndex: 1
- * });
+ * A simple Tabs component that:
+ * - manage a list of tabs
+ * - each tab is represented by an identifier and a label
+ * - only one tab can be activated at a time
+ * - when a tab is being activated, a `tabactivate` event is emitted, with the tab identifier as parameter
+ * - when a tab has been activated, a `tabchange` event is emitted, with the tab identifier as parameter
+ * - a panel can be linked to each tab, based a data attribute `data-tab-content` that should match the tab name
+ * - a tab can be disabled
  *
+ * @author Martin Nicholson <martin@taotesting.com>
+ * @author Ricardo Proença, <ricardo@taotesting.com>
  */
 import $ from 'jquery';
-import component from 'ui/component';
+import _ from 'lodash';
+import hider from 'ui/hider';
+import componentFactory from 'ui/component';
 import tabsTpl from 'ui/tabs/tpl/tabs';
 import 'ui/tabs/css/tabs.css';
 
-const ns = 'tabs';
+/**
+ * @typedef {Object} tabsBarConfig
+ * @property {String} [activeTab] - The name of the active tab
+ * @property {Integer} [activeTabIndex] - the index of the tab to start on
+ * @property {tabConfig[]} [tabs] - The list of tabs
+ * @property {Boolean} [hideLoneTab] - Prevent to show the tabs when only one is registered
+ * @property {jQuery|HTMLElement|String|Boolean} [showHideTarget] - Defines the container where to wire up tabs to
+ * content, the link will be automatic, based on the data attribute `data-tab-content` that should match the tab name.
+ * If the value is `true` the component's container will be used to find the panels.
+ */
 
 /**
- * Default config
- * @param {Integer} activeTabIndex - the index of the tab to start on
- * @param {Boolean} showHideTargets - if true, no need to wire up tabs to content, it's automatic
+ * @typedef {Object} tabConfig
+ * @property {Boolean} disabled - The tab is disabled
+ * @property {String} name - The tab identifier
+ * @property {String} label - The tab label
+ * @property {String} [icon] - An optional tab icon
+ * @property {String} [cls] - An optional CSS class name
  */
-const tabsDefaults = {
-    activeTabIndex: 0,
-    showHideTargets: true
-};
 
 /**
- * In-memory data
+ * CSS class for the active tab
+ * @type {String}
  */
-let tabs = [];
+const activeTabCls = 'active';
 
 /**
- * API of the tabs component
- * @exports ui/tabs
+ * CSS selector for the tabs
+ * @type {String}
  */
-const tabsApi = {
+const tabSelector = '.tab';
+
+/**
+ * CSS selector for the tab actions
+ * @type {String}
+ */
+const actionSelector = '.action';
+
+/**
+ * Name of the attribute that contain the tab identifier
+ * @type {String}
+ */
+const tabNameAttr = 'data-tab-name';
+
+/**
+ * Name of the attribute that contain the panel identifier
+ * @type {String}
+ */
+const panelNameAttr = 'data-tab-content';
+
+/**
+ * Builds an instance of the tabs component.
+ *
+ * @example
+ *  // activate by index
+ *  const instance = tabsFactory($container, {
+ *      tabs: [
+ *          { label: 'TAO Local', name: 'local-delivery' },
+ *          { label: 'TAO Remote', name: 'remote-delivery' },
+ *          { label: 'LTI-based', name: 'lti-delivery', disabled: true }
+ *      ],
+ *      activeTabIndex: 1
+ *  });
+ *
+ *  // activate by name
+ *  const instance = tabsFactory($container, {
+ *      tabs: [
+ *          { label: 'TAO Local', name: 'local-delivery' },
+ *          { label: 'TAO Remote', name: 'remote-delivery' },
+ *          { label: 'LTI-based', name: 'lti-delivery', disabled: true }
+ *      ],
+ *      activeTab: 'remote-delivery'
+ *  });
+ *
+ *  // link to panels
+ *  const instance = tabsFactory($container, {
+ *      showHideTarget: $panelContainer,
+ *      tabs: [
+ *          { label: 'TAO Local', name: 'local-delivery' },
+ *          { label: 'TAO Remote', name: 'remote-delivery' },
+ *          { label: 'LTI-based', name: 'lti-delivery', disabled: true }
+ *      ]
+ *  });
+ *
+ *  instance
+ *      .on('ready', function onReady() {
+ *          // the component is ready
+ *      })
+ *      .before('tabactivate', function beforeTabChange(e, name) {
+ *          // a tab is being activated
+ *          // it is possible to prevent its activation by returning a rejected promise
+ *          if (name === 'lti-delivery') {
+ *              return Promise.reject();
+ *          }
+ *      })
+ *      .on('tabchange', function onTabChange(name) {
+ *          // a tab has been activated
+ *      });
+ *
+ * @param {HTMLElement|String} container
+ * @param {tabsBarConfig} config
+ * @param {String} [config.activeTab] - The name of the active tab
+ * @param {Integer} [config.activeTabIndex] - the index of the tab to start on
+ * @param {tabConfig[]} [config.tabs] - The list of tabs
+ * @param {Boolean} [config.hideLoneTab] - Prevent to show the tabs when only one is registered
+ * @param {jQuery|HTMLElement|String|Boolean} [config.showHideTarget] - Defines the container where to wire up tabs to
+ * content, the link will be automatic, based on the data attribute `data-tab-content` that should match the tab name.
+ * If the value is `true` the component's container will be used to find the panels.
+ * @returns {tabsBarComponent}
+ * @fires ready - When the component is ready to work
+ * @fires error - When the component encounters issue
+ * @fires tabactivate - Each time a tab must be activated
+ * @fires tabchange - Each time a tab has been activated
+ * @fires tabchange-${name} - Each time the named tab has been activated
+ * @fires tabsupdate - Each time the tabs are updated
+ */
+function tabsFactory(container, config) {
+    // the list of displayed tabs
+    let tabs = [];
+
+    // the current active tab
+    let activeTabName = null;
+
+    // enable/disable elements
+    const enableElement = $el => $el.prop('disabled', false);
+    const disableElement = $el => $el.prop('disabled', true);
+
     /**
-     * Set new values for the tabs
-     * @param {Array} newTabs
-     * @returns {tabs} instance
-     * @throws {TypeError} on non-Array tabs
+     * Gets a tab by its name
+     * @param {String} name
+     * @returns {tabConfig}
      */
-    setTabs(newTabs) {
-        if (!Array.isArray(newTabs)) {
-            throw new TypeError('The provided tabs are not a valid array');
-        }
-        tabs = [...newTabs];
-        return this;
-    },
+    const findTabByName = name => tabs.find(tab => tab.name === name);
 
     /**
-     * Retrieve internal tabs array
-     * @returns {Array} tabs list
-     */
-    getTabs() {
-        return tabs;
-    },
-
-    /**
-     * Wires up the onClick functions of the received tabs
-     * @returns {tabs} instance
-     */
-    connectTabs() {
-        const $tabBar = this.getElement();
-
-        for (let tab of tabs) {
-            $tabBar.find(`[data-tab-name="${tab.name}"]`)
-                .off('click')
-                .on('click', () => {
-                    this.activateTabByName(tab.name);
-                });
-        }
-        return this;
-    },
-
-
-    /**
-     * Activates a single tab by its name
-     * (pass-through method to activateTabByIndex)
+     * Gets a tab by its name, throw a TypeError if the tab does not exist
      * @param {String} name - human-readable identifier
-     * @param {Boolean} [callOnClick=true] - if false, skips the onClick call
-     * @returns {tabs} instance
+     * @returns {tabConfig}
      * @throws {TypeError} on invalid name param
      */
-    activateTabByName(name, callOnClick = true) {
-        const index = tabs.findIndex(t => t.name === name);
-        if (index === -1) {
+    const findTabByNameOrThrow = name => {
+        const tab = findTabByName(name);
+        if (!tab) {
             throw new TypeError(`No tab exists with the name: ${name}`);
         }
-        else {
-            return this.activateTabByIndex(index, callOnClick);
-        }
-    },
+        return tab;
+    };
 
     /**
-     * Activates a single tab (deactivating others)
-     * Triggers the automatic showing & hiding of target tab-contents
-     * Triggers onClick functions of the tabs
-     * @param {Number} index - zero-based
-     * @param {Boolean} [callOnClick=true] - if false, skips the onClick call
-     * @returns {tabs} instance
-     * @fires activate-tab
-     * @throws {TypeError} on invalid index param
+     * Initializes the tabs
+     * @param {tabsBarComponent} component
      */
-    activateTabByIndex(index, callOnClick = true) {
-        const $tabBar = this.getElement();
-
-        if (typeof index !== 'number' || index < 0 || index >= tabs.length) {
-            throw new TypeError(`No tab exists at index: ${index}`);
+    const initTabs = component => {
+        if (activeTabName) {
+            const activeTab = activeTabName;
+            activeTabName = null;
+            component.setActiveTab(activeTab);
         }
 
-        // set/unset active
-        for (let j of Object.keys(tabs)) {
-            tabs[j].active = false;
-            $tabBar.find('.tab').removeClass('active');
+        if (component.getConfig().hideLoneTab && tabs.length === 1) {
+            hider.hide(component.getElement().find(tabSelector));
         }
-        tabs[index].active = true;
-        $tabBar.find(`.tab[data-tab-name="${tabs[index].name}"]`).addClass('active');
-
-        // toggle targets
-        if (this.config.showHideTargets) {
-            this.showTabContent(tabs[index].name);
-        }
-
-        // call its onClick
-        if (callOnClick && typeof tabs[index].onClick === 'function') {
-            tabs[index].onClick.call();
-        }
-
-        this.trigger(`activate-tab.${ns}`, index);
-        return this;
-    },
+    };
 
     /**
-     * Shows one tab content, hides the rest
-     * The tab content elements are not tied to any template and can be located anywhere in the DOM
-     * @param {String} name - human-readable identifier
-     * @fires show-tab-content
+     * API of the tabs component
+     * @exports ui/tabs
      */
-    showTabContent(name) {
-        if (!name || name.length === 0) {
-            return;
-        }
-        $(`[data-tab-content]`).addClass('hidden');
-        $(`[data-tab-content="${name}"]`).removeClass('hidden');
+    const tabsApi = {
+        /**
+         * Set new values for the tabs
+         * @param {Array} newTabs
+         * @returns {tabsBarComponent} instance
+         * @throws {TypeError} on non-Array tabs
+         * @fires tabsupdate once the tabs have been updated
+         * @fires tabactivate once the active tab is updated
+         */
+        setTabs(newTabs) {
+            if (!Array.isArray(newTabs)) {
+                throw new TypeError('The provided tabs are not a valid array');
+            }
 
-        this.trigger(`show-tab-content.${ns}`, name);
-    },
+            tabs = [...newTabs];
+
+            // reset tab to default if needed
+            if (!activeTabName || !findTabByName(activeTabName)) {
+                activeTabName = this.getDefaultActiveTab();
+            }
+
+            // replace the displayed tabs if already rendered
+            if (this.is('rendered')) {
+                const template = this.getTemplate();
+                this.getElement().html(
+                    $(template({tabs})).html()
+                );
+
+                // make sure the tab is selected and hide lone tab if needed
+                initTabs(this);
+            }
+
+            /**
+             * @event tabsupdate - Tabs have been updated
+             * @param {Array} newTabs
+             */
+            this.trigger('tabsupdate', newTabs);
+
+            return this;
+        },
+
+        /**
+         * Retrieve internal tabs array
+         * @returns {Array} tabs list
+         */
+        getTabs() {
+            return [...tabs];
+        },
+
+        /**
+         * Gets the name of the active tab (if any)
+         * @returns {String}
+         */
+        getActiveTab() {
+            return activeTabName;
+        },
+
+        /**
+         * Gets the index of the current active tab (if any)
+         * @returns {Number}
+         */
+        getActiveTabIndex() {
+            return tabs.findIndex(tab => tab.name === activeTabName);
+        },
+
+        /**
+         * Gets the name of the default active tab
+         * @returns {String|null}
+         */
+        getDefaultActiveTab() {
+            const {activeTab, activeTabIndex} = this.getConfig();
+
+            if (activeTab && findTabByName(activeTab)) {
+                return activeTab;
+            }
+
+            if (typeof activeTabIndex === 'number' && tabs[activeTabIndex]) {
+                return tabs[activeTabIndex].name;
+            }
+
+            return tabs.length && tabs[0].name || null;
+        },
+
+        /**
+         * Activates a single tab by its name (deactivating others)
+         * @param {String} name - human-readable identifier
+         * @returns {tabsBarComponent} instance
+         * @throws {TypeError} on invalid name param
+         * @fires tabactivate
+         */
+        setActiveTab(name) {
+            const tab = findTabByNameOrThrow(name);
+
+            if (!tab.disabled) {
+                /**
+                 * @event tabactivate - A tab is being activated
+                 * @param {String} - name
+                 */
+                this.trigger('tabactivate', tab.name);
+            }
+
+            return this;
+        },
+
+        /**
+         * Activates a single tab by its index (deactivating others)
+         * Triggers the automatic showing & hiding of target tab-contents
+         * @param {Number} index - zero-based
+         * @returns {tabsBarComponent} instance
+         * @throws {TypeError} on invalid index param
+         * @fires tabactivate
+         */
+        setActiveTabIndex(index) {
+            if (typeof index !== 'number' || index < 0 || index >= tabs.length) {
+                throw new TypeError(`No tab exists at index: ${index}`);
+            }
+            const tab = tabs[index];
+            if (!tab.disabled) {
+                /**
+                 * @event tabactivate - A tab is being activated
+                 * @param {String} - name
+                 */
+                this.trigger('tabactivate', tab.name);
+            }
+
+            return this;
+        },
+
+        /**
+         * Enables a single tab by its name
+         * @param {String} name - human-readable identifier
+         * @returns {tabsBarComponent} instance
+         * @throws {TypeError} on invalid name param
+         * @fires tabenable
+         */
+        enableTab(name) {
+            const tab = findTabByNameOrThrow(name);
+
+            tab.disabled = false;
+
+            if (this.is('rendered')) {
+                enableElement(this.getElement().find(`[${tabNameAttr}="${name}"] ${actionSelector}`));
+            }
+
+            /**
+             * @event tabenable - A tab is enabled
+             * @param {String} - name
+             */
+            this.trigger('tabenable', name);
+
+            return this;
+        },
+
+        /**
+         * Disables a single tab by its name
+         * @param {String} name - human-readable identifier
+         * @returns {tabsBarComponent} instance
+         * @throws {TypeError} on invalid name param
+         * @fires tabdisable
+         */
+        disableTab(name) {
+            const tab = findTabByNameOrThrow(name);
+
+            tab.disabled = true;
+
+            if (this.is('rendered')) {
+                disableElement(this.getElement().find(`[${tabNameAttr}="${name}"] ${actionSelector}`));
+            }
+
+            /**
+             * @event tabdisable - A tab is disabled
+             * @param {String} - name
+             */
+            this.trigger('tabdisable', name);
+        },
+
+        /**
+         * Shows one tab content, hides the rest
+         * The tab content elements are not tied to any template and can be located anywhere in the DOM
+         * @param {String} name - human-readable identifier
+         * @throws {TypeError} on invalid name param
+         * @fires tabshowcontent
+         */
+        showTabContent(name) {
+            findTabByNameOrThrow(name);
+
+            const {showHideTarget} = this.getConfig();
+            if (showHideTarget) {
+                (showHideTarget === true ? this.getContainer() : $(showHideTarget))
+                    .find(`[${panelNameAttr}]`)
+                    .addClass('hidden')
+                    .filter(`[${panelNameAttr}="${name}"]`)
+                    .removeClass('hidden');
+            }
+
+            /**
+             * @event tabshowcontent - A tab panel is displayed
+             * @param {String} - name
+             */
+            this.trigger('tabshowcontent', name);
+        }
+    };
 
     /**
-     * Gets the current active tab (if any)
-     * @returns {Object|null} name and index of tab
+     * @typedef {component} tabsBarComponent
      */
-    getActiveTab() {
-        const activeIndex = tabs.findIndex(t => t.active === true);
-        if (activeIndex === -1) {
-            return null;
-        }
-        return {
-            name: tabs[activeIndex].name,
-            index: activeIndex
-        };
-    }
-};
-
-/**
- * Builds an instance of the tabs component
- * @param {Object} config
- * @param {Array} [config.tabs] - The list of tabs to create
- * @param {jQuery|HTMLElement|String} [config.renderTo] - An optional container in which renders the component
- * @param {Boolean} [config.replace] - When the component is appended to its container, clears the place before
- * @returns {tabs}
- */
-
-const tabsFactory = function(config) {
-    return component(tabsApi, tabsDefaults)
+    const tabsBarComponent = componentFactory(tabsApi)
+        // set the component's layout
         .setTemplate(tabsTpl)
-        .on('init', function() {
-            if (this.config && this.config.tabs) {
-                this.setTabs(this.config.tabs);
+
+        // auto render on init
+        .on('init', function onTabsBarInit() {
+            try {
+                // extract the tabs from the config
+                if (this.config && this.config.tabs) {
+                    this.setTabs(this.config.tabs);
+                }
+
+                // auto render on init (defer the call to give a chance to the init event to be completed before)
+                _.defer(() => this.render(container));
+            } catch (err) {
+                /**
+                 * @event error
+                 * @param {Error} err
+                 */
+                this.trigger('error', err);
             }
         })
-        .on('render', function() {
-            this.connectTabs();
-            if (typeof this.config.activeTabIndex === 'number') {
-                this.activateTabByIndex(this.config.activeTabIndex, false);
+
+        // renders the component
+        .on('render', function onTabsBarRender() {
+            try {
+                // make sure the tab is selected and hide lone tab if needed
+                initTabs(this);
+            } catch (err) {
+                /**
+                 * @event error
+                 * @param {Error} err
+                 */
+                this.trigger('error', err);
+            }
+
+            // delegate the click on tabs
+            this.getElement().on('click', tabSelector, e => {
+                try {
+                    this.setActiveTab(e.currentTarget.getAttribute(tabNameAttr));
+                } catch (err) {
+                    /**
+                     * @event error
+                     * @param {Error} err
+                     */
+                    this.trigger('error', err);
+                }
+            });
+
+            /**
+             * @event ready - The component is ready to work
+             */
+            this.trigger('ready');
+        })
+
+        // take care of the disable state
+        .on('disable', function onButtonDisable() {
+            if (this.is('rendered')) {
+                disableElement(this.getElement().find(`[${tabNameAttr}] ${actionSelector}`));
             }
         })
-        .init(config);
-};
+        .on('enable', function onButtonEnable() {
+            if (this.is('rendered')) {
+                this.getElement()
+                    .find(`[${tabNameAttr}] ${actionSelector}`)
+                    .each((index, el) => {
+                        const tab = findTabByName(el.parentNode.getAttribute(tabNameAttr));
+                        if (!tab || !tab.disabled) {
+                            el.disabled = false;
+                        }
+                    });
+            }
+        })
+
+        // reacts to tab activate
+        .on('tabactivate', function onTabActivate(name) {
+            const tab = findTabByName(name);
+            if (tab && !tab.disabled && name !== activeTabName) {
+                activeTabName = name;
+
+                if (this.is('rendered')) {
+                    this.getElement()
+                        .find(tabSelector)
+                        .removeClass(activeTabCls)
+                        .filter(`[${tabNameAttr}="${name}"]`)
+                        .addClass(activeTabCls);
+                }
+
+                /**
+                 * @event tabchange - A tab is activated
+                 * @param {String} - name
+                 */
+                this.trigger('tabchange', name);
+            }
+        })
+
+        // reacts to tab change
+        .on('tabchange', function onTabChange(name) {
+            // auto show the linked panel
+            if (this.getConfig().showHideTarget) {
+                this.showTabContent(name);
+            }
+
+            /**
+             * @event tabchange-${name} - The tab is activated
+             */
+            this.trigger(`tabchange-${name}`);
+        });
+
+    // initialize the component with the provided config
+    // defer the call to allow to listen to the init event
+    _.defer(() => tabsBarComponent.init(config));
+
+    return tabsBarComponent;
+}
 
 export default tabsFactory;

--- a/src/tabs/tpl/tabs.tpl
+++ b/src/tabs/tpl/tabs.tpl
@@ -1,7 +1,10 @@
 <ul class="tab-group">
     {{#each tabs}}
-    <li class="tab {{#if active}}active{{/if}}" data-tab-name="{{name}}">
-        <button tabindex="0" {{#if disabled}}disabled{{/if}}>{{ label }}</button>
+    <li class="tab {{cls}}" data-tab-name="{{name}}">
+        <button class="action" tabindex="0" {{#if disabled}}disabled{{/if}}>
+            {{#if icon}}<span class="icon icon-{{ icon }}"></span>{{/if}}
+            {{#if label}}<span class="label">{{ label }}</span>{{/if}}
+        </button>
     </li>
     {{/each}}
 </ul>

--- a/test/tabs/test.html
+++ b/test/tabs/test.html
@@ -4,12 +4,35 @@
         <meta charset="utf-8" />
         <title>Ui Test - Tabs</title>
         <style>
-                #visual-fixture {
-                    padding: 50px;
-                }
-                #visual-fixture input {
-                    margin: 25px 0;
-                }
+            #visual-fixture {
+                padding: 50px;
+            }
+            #visual-fixture input {
+                margin: 25px 0;
+            }
+            #visual-fixture .output {
+                border: 1px solid #eee;
+                background: #ddd;
+                position: relative;
+                margin: 10px 2px;
+                padding: 2px;
+                line-height: 40px;
+            }
+            #visual-fixture .output:after {
+                content: 'Event';
+                position: absolute;
+                left: 0;
+                top: 0;
+                font-size: 10px;
+                line-height: 12px;
+                color: #888;
+            }
+            #visual-fixture .panels {
+                position: relative;
+                background: #eee;
+                margin: 10px 0;
+                padding: 10px;
+            }
         </style>
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
@@ -24,11 +47,38 @@
     </head>
     <body>
         <div id="qunit"></div>
-        <div id="qunit-fixture"></div>
+        <div id="qunit-fixture">
+            <div id="fixture-api"></div>
+            <div id="fixture-init"></div>
+            <div id="fixture-render"></div>
+            <div id="fixture-single"></div>
+            <div id="fixture-hide"></div>
+            <div id="fixture-disable"></div>
+            <div id="fixture-destroy"></div>
+            <div id="fixture-error"></div>
+            <div id="fixture-settabs"></div>
+            <div id="fixture-activate"></div>
+            <div id="fixture-panel-selector">
+                <div class="panel" data-tab-content="tabA">tab A</div>
+                <div class="panel" data-tab-content="tabB">tab B</div>
+                <div class="panel" data-tab-content="tabC">tab C</div>
+                <div class="panel" data-tab-content="tabD">tab D</div>
+                <div class="panel" data-tab-content="tabE">tab E</div>
+            </div>
+            <div id="fixture-panel-true">
+                <div class="panel" data-tab-content="tabA">tab A</div>
+                <div class="panel" data-tab-content="tabB">tab B</div>
+                <div class="panel" data-tab-content="tabC">tab C</div>
+                <div class="panel" data-tab-content="tabD">tab D</div>
+                <div class="panel" data-tab-content="tabE">tab E</div>
+            </div>
+            <div id="fixture-click"></div>
+        </div>
         <div id="visual-fixture">
+            <div class="output"></div>
             <input type="text" placeholder="I'm for testing focus" />
             <nav></nav>
-            <div>
+            <div class="panels">
                 <div data-tab-content="tao-local">
                     TAO Local
                 </div>

--- a/test/tabs/test.js
+++ b/test/tabs/test.js
@@ -20,9 +20,8 @@
  */
 define([
     'jquery',
-    'lodash',
     'ui/tabs'
-], function ($, _, tabsFactory) {
+], function ($, tabsFactory) {
     'use strict';
 
     function getInstance(fixture, config) {

--- a/test/tabs/test.js
+++ b/test/tabs/test.js
@@ -22,360 +22,1523 @@ define([
     'jquery',
     'lodash',
     'ui/tabs'
-], function($, _, tabsFactory) {
+], function ($, _, tabsFactory) {
     'use strict';
 
-    QUnit.module('tabs');
+    function getInstance(fixture, config) {
+        return tabsFactory(fixture, config)
+            .on('ready', function () {
+                this.destroy();
+            });
+    }
 
-    QUnit.test('module', function(assert) {
-        assert.expect(3);
+    QUnit.module('Tabs Factory');
 
-        assert.equal(typeof tabsFactory, 'function', 'The tabs module exposes a function');
-        assert.equal(typeof tabsFactory(), 'object', 'The tabs factory produces an object');
-        assert.notStrictEqual(
-            tabsFactory(),
-            tabsFactory(),
-            'The tabs factory provides a different object on each call'
-        );
-    });
-
-    var $qunitFixture = $('#qunit-fixture');
-
-    var testTabsApi = [
-        { name: 'init' },
-        { name: 'destroy' },
-        { name: 'render' },
-        { name: 'show' },
-        { name: 'hide' },
-        { name: 'enable' },
-        { name: 'disable' },
-        { name: 'is' },
-        { name: 'setState' },
-        { name: 'getElement' },
-        { name: 'getContainer' },
-        { name: 'getTemplate' },
-        { name: 'setTemplate' },
-        { name: 'setTabs' },
-        { name: 'getTabs' },
-        { name: 'connectTabs' },
-        { name: 'activateTabByName' },
-        { name: 'activateTabByIndex' },
-        { name: 'showTabContent' },
-        { name: 'getActiveTab' }
-    ];
-
-    QUnit.cases.init(testTabsApi).test('instance API ', function(data, assert) {
-        var instance = tabsFactory();
-        assert.expect(1);
-        assert.equal(
-            typeof instance[data.name],
-            'function',
-            'The tabs instance exposes a "' + data.name + '" function'
-        );
-        instance.destroy();
-    });
-
-    QUnit.test('init', function(assert) {
-        var config = {};
-        var instance = tabsFactory(config);
-
-        assert.expect(1);
-
-        assert.equal(instance.is('rendered'), false, 'The tabs instance must not be rendered');
-
-        instance.destroy();
-    });
-
-    QUnit.test('rendering', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
-            tabs: [
-                { label: 'first', name: 'tab1' },
-                { label: 'second', name: 'tab2' },
-                { label: 'third', name: 'tab3' },
-            ]
-        };
-        var instance = tabsFactory(config);
-        var $tabsDom = $('.tab-group', $qunitFixture);
-
-        assert.expect(10);
-
-        assert.equal(instance.is('rendered'), true, 'The tabs instance must be rendered');
-        assert.equal($tabsDom.length, 1, '1 .tab-group was rendered');
-        assert.equal($tabsDom.find('li.tab').length, 3, '3 <li>s were rendered');
-        assert.equal($tabsDom.find('li.tab button').length, 3, '3 <button>s were rendered');
-        assert.equal($tabsDom.find('li.tab button').eq(0).html(), 'first', '<button> text as defined');
-        assert.equal($tabsDom.find('li.tab button').eq(1).html(), 'second', '<button> text as defined');
-        assert.equal($tabsDom.find('li.tab button').eq(2).html(), 'third', '<button> text as defined');
-        assert.ok($tabsDom.find('li.tab').eq(0).hasClass('active'), 'First tab is activated');
-        assert.notOk($tabsDom.find('li.tab').eq(1).hasClass('active'), 'Second tab is deactivated');
-        assert.notOk($tabsDom.find('li.tab').eq(2).hasClass('active'), 'Third tab is deactivated');
-
-        instance.destroy();
-    });
-
-    QUnit.test('setTabs', function(assert) {
-        var config = {};
-        var tabs = [
-            { label: 'set1' },
-            { label: 'set2' }
-        ];
-        var notTabs = { name: 'tab' };
-
-        var instance = tabsFactory(config);
-        var ret = instance.setTabs(tabs);
+    QUnit.test('module', function (assert) {
+        var instance = getInstance('#fixture-api');
+        var instance2 = getInstance('#fixture-api');
 
         assert.expect(3);
-
-        assert.deepEqual(instance.getTabs(), tabs, 'The tabs were set internally');
-        assert.deepEqual(ret, instance, 'setTabs() returns the same instance');
-
-        assert.throws(
-            function() {
-                instance.setTabs(notTabs);
-            },
-            TypeError,
-            'setTabs throws TypeError if non-array type passed'
-        );
-
-        instance.destroy();
+        assert.strictEqual(typeof tabsFactory, 'function', 'The module exposes a function');
+        assert.strictEqual(typeof instance, 'object', 'The factory produces an object');
+        assert.notStrictEqual(instance, instance2, 'The factory provides a different object on each call');
     });
 
-    QUnit.test('connectTabs', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
-            tabs: [
-                { label: 'tabToConnect', name: '' }
-            ]
-        };
-        var instance = tabsFactory(config);
-        var $firstBtn = $('.tab-group button:first-of-type', $qunitFixture);
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'setSize'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'},
+        {title: 'getConfig'}
+    ]).test('inherited API', function (data, assert) {
+        var instance = getInstance('#fixture-api');
 
-        assert.expect(2);
-
-        instance.on('activate-tab.*', function(value) {
-            assert.ok(true, 'An activate-tab event was fired upon clicking');
-            assert.strictEqual(value, 0, 'The param passed with the event matches the tab index');
-        });
-
-        $firstBtn.trigger('click');
-
-        instance.destroy();
+        assert.expect(1);
+        assert.strictEqual(typeof instance[data.title], 'function', 'The tabs instance exposes a "' + data.title + '" function');
     });
 
-    QUnit.test('activateTabByName', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
-            tabs: [
-                { label: 'first', name: 'tab1' },
-                { label: 'second', name: 'tab2' },
-                { label: 'third', name: 'tab3' },
-            ]
-        };
-        var instance = tabsFactory(config);
-        var $tabsDom = $('.tab-group', $qunitFixture);
 
-        assert.expect(8);
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'spread'}
+    ]).test('event API ', function (data, assert) {
+        var instance = getInstance('#fixture-api');
 
-        var ret = instance.activateTabByName('tab2');
-        assert.deepEqual(ret, instance, 'activateTabByName() returns the same instance');
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'second', 'second tab is active');
-
-        instance.activateTabByName('tab3');
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'third', 'third tab is active');
-
-        instance.activateTabByName('tab1');
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'first', 'first tab is active');
-
-        assert.throws(
-            function() {
-                instance.activateTabByName('hello');
-            },
-            TypeError,
-            'activateTabByName throws TypeError if name is not found'
-        );
-
-        instance.destroy();
+        assert.expect(1);
+        assert.strictEqual(typeof instance[data.title], 'function', 'The tabs instance exposes a "' + data.title + '" function');
     });
 
-    QUnit.test('activateTabByIndex', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
-            tabs: [
-                { label: 'first', name: 'tab1' },
-                { label: 'second', name: 'tab2' },
-                { label: 'third', name: 'tab3' },
-            ]
-        };
-        var instance = tabsFactory(config);
-        var $tabsDom = $('.tab-group', $qunitFixture);
+    QUnit.cases.init([
+        {title: 'setTabs'},
+        {title: 'getTabs'},
+        {title: 'getActiveTab'},
+        {title: 'getActiveTabIndex'},
+        {title: 'getDefaultActiveTab'},
+        {title: 'setActiveTab'},
+        {title: 'setActiveTabIndex'},
+        {title: 'disableTab'},
+        {title: 'enableTab'},
+        {title: 'showTabContent'}
+    ]).test('tabs API ', function (data, assert) {
+        var instance = getInstance('#fixture-api');
 
-        assert.expect(8);
-
-        var ret = instance.activateTabByIndex(1);
-        assert.deepEqual(ret, instance, 'activateTabByIndex() returns the same instance');
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'second', 'second tab is active');
-
-        instance.activateTabByIndex(2);
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'third', 'third tab is active');
-
-        instance.activateTabByIndex(0);
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'first', 'first tab is active');
-
-        assert.throws(
-            function() {
-                instance.activateTabByIndex(4);
-            },
-            TypeError,
-            'activateTabByIndex throws TypeError if index is not valid'
-        );
-
-        instance.destroy();
+        assert.expect(1);
+        assert.strictEqual(typeof instance[data.title], 'function', 'The tabs instance exposes a "' + data.title + '" function');
     });
 
-    QUnit.test('getActiveTab', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
-            tabs: [
-                { label: 'set1', name: 'first' },
-                { label: 'set2', name: 'second' }
-            ]
-        };
+    QUnit.module('Tabs Life cycle');
 
-        var instance = tabsFactory(config);
-        var active;
+    QUnit.cases.init([{
+        title: 'default',
+        expected: {
+            tabs: [],
+            active: null,
+            activeIndex: -1
+        }
+    }, {
+        title: 'empty',
+        config: {},
+        expected: {
+            tabs: [],
+            active: null,
+            activeIndex: -1
+        }
+    }, {
+        title: 'tabs',
+        config: {
+            tabs: [
+                {name: 'tab1', label: 'Tab 1'},
+                {name: 'tab2', label: 'Tab 2'}
+            ]
+        },
+        expected: {
+            tabs: [
+                {name: 'tab1', label: 'Tab 1'},
+                {name: 'tab2', label: 'Tab 2'}
+            ],
+            active: 'tab1',
+            activeIndex: 0
+        }
+    }, {
+        title: 'activeTab',
+        config: {
+            activeTab: 'tab2',
+            tabs: [
+                {name: 'tab1', label: 'Tab 1'},
+                {name: 'tab2', label: 'Tab 2'}
+            ]
+        },
+        expected: {
+            tabs: [
+                {name: 'tab1', label: 'Tab 1'},
+                {name: 'tab2', label: 'Tab 2'}
+            ],
+            active: 'tab2',
+            activeIndex: 1
+        }
+    }, {
+        title: 'activeTabIndex',
+        config: {
+            activeTabIndex: 1,
+            tabs: [
+                {name: 'tab1', label: 'Tab 1'},
+                {name: 'tab2', label: 'Tab 2'}
+            ]
+        },
+        expected: {
+            tabs: [
+                {name: 'tab1', label: 'Tab 1'},
+                {name: 'tab2', label: 'Tab 2'}
+            ],
+            active: 'tab2',
+            activeIndex: 1
+        }
+    }]).test('init', function (data, assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-init');
+        var instance = tabsFactory($container, data.config);
 
         assert.expect(5);
 
-        active = instance.getActiveTab();
-        assert.equal(typeof active, 'object', 'getActiveTab returns an object');
-        assert.equal(active.name, 'first', 'returned name is correct');
-        assert.equal(active.index, 0, 'returned index is 0');
-
-        instance.activateTabByIndex(1);
-
-        active = instance.getActiveTab();
-        assert.equal(active.name, 'second', 'returned name is correct');
-        assert.equal(active.index, 1, 'returned index is 1');
-
-        instance.destroy();
+        instance
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+                assert.strictEqual(data.expected.active, instance.getDefaultActiveTab(), 'The default tab is as expected');
+                assert.strictEqual(data.expected.active, instance.getActiveTab(), 'The expected tab name is active');
+                assert.strictEqual(data.expected.activeIndex, instance.getActiveTabIndex(), 'The expected tab index is active');
+                assert.deepEqual(data.expected.tabs, instance.getTabs(), 'The expected tabs are set');
+            })
+            .on('ready', function () {
+                instance.destroy();
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
     });
 
-    QUnit.test('onClick callback (call=true)', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
+    QUnit.cases.init([{
+        title: 'default'
+    }, {
+        title: 'empty',
+        config: {}
+    }, {
+        title: 'tabs',
+        config: {
             tabs: [
-                {
-                    label: 'first',
-                    name: 'tab1',
-                    onClick: function() {
-                        assert.ok(true, 'The passed onClick callback was called');
+                {name: 'tab1', label: 'Tab 1', icon: 'globe'},
+                {name: 'tab2', label: 'Tab 2', cls: 'foo'},
+                {name: 'tab3', label: 'Tab 3', disabled: 'true'},
+                {name: 'tab4', icon: 'flag'}
+            ]
+        },
+        active: 'tab1'
+    }, {
+        title: 'activeTab',
+        config: {
+            activeTab: 'tab2',
+            tabs: [
+                {name: 'tab1', label: 'Tab 1', icon: 'globe'},
+                {name: 'tab2', label: 'Tab 2', cls: 'foo'},
+                {name: 'tab3', label: 'Tab 3', disabled: 'true'},
+                {name: 'tab4', icon: 'flag'}
+            ]
+        },
+        active: 'tab2'
+    }, {
+        title: 'activeTabIndex',
+        config: {
+            activeTabIndex: 3,
+            tabs: [
+                {name: 'tab1', label: 'Tab 1', icon: 'globe'},
+                {name: 'tab2', label: 'Tab 2', cls: 'foo'},
+                {name: 'tab3', label: 'Tab 3', disabled: 'true'},
+                {name: 'tab4', icon: 'flag'}
+            ]
+        },
+        active: 'tab4'
+    }]).test('render', function (data, assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-render');
+        var numberOfTabs = data.config && data.config.tabs && data.config.tabs.length || 0;
+        var instance;
+        var index;
+        var tab;
+
+        assert.expect(7 + numberOfTabs * 6);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container, data.config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 1, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group .tab').length, numberOfTabs, 'The component contains ' + numberOfTabs + ' tabs');
+
+                if (numberOfTabs) {
+                    assert.strictEqual($container.find('.tab-group .tab.active').length, 1, 'The component contains an active tab');
+                    assert.strictEqual($container.find('.tab-group .tab.active').attr('data-tab-name'), data.active, 'The expected tab is active');
+                } else {
+                    assert.strictEqual($container.find('.tab-group .tab.active').length, 0, 'The component does not contain an active tab');
+                    assert.strictEqual($container.find('.tab-group').children().length, 0, 'No tab is rendered');
+                }
+
+                for (index = 0; index < numberOfTabs; index++) {
+                    tab = data.config.tabs[index];
+                    assert.deepEqual(instance.getTabs()[index], tab, 'The instance contains the expected tab at index ' + index);
+                    assert.strictEqual(
+                        $container.find('.tab[data-tab-name="' + tab.name + '"] .action').length,
+                        1,
+                        'The tab ' + tab.name + ' has an action element'
+                    );
+                    if (tab.cls) {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"].' + tab.cls).length,
+                            1,
+                            'The tab ' + tab.name + ' is rendered with the expected class'
+                        );
+                    } else {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                            1,
+                            'The tab ' + tab.name + ' is rendered'
+                        );
+                    }
+                    if (tab.disabled) {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"] .action:disabled').length,
+                            1,
+                            'The tab ' + tab.name + ' is rendered disabled'
+                        );
+                    } else {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"] .action:disabled').length,
+                            0,
+                            'The tab ' + tab.name + ' is rendered enabled'
+                        );
+                    }
+                    if (tab.icon) {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"] .icon-' + tab.icon).length,
+                            1,
+                            'The tab ' + tab.name + ' contains an icon'
+                        );
+                    } else {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"] .icon').length,
+                            0,
+                            'The tab ' + tab.name + ' does not contain an icon'
+                        );
+                    }
+                    if (tab.label) {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"]').text().trim(),
+                            tab.label,
+                            'The tab ' + tab.name + ' contains the expected label'
+                        );
+                    } else {
+                        assert.strictEqual(
+                            $container.find('.tab[data-tab-name="' + tab.name + '"]').text().trim(),
+                            '',
+                            'The tab ' + tab.name + ' does not contain a label'
+                        );
                     }
                 }
-            ]
-        };
-        var instance = tabsFactory(config);
 
-        assert.expect(1);
-
-        instance.activateTabByName('tab1'); // call
-
-        instance.destroy();
+                instance.destroy();
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
     });
 
-    QUnit.test('onClick callback (call=false)', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
+    QUnit.cases.init([{
+        title: 'hide lone tab, without active',
+        config: {
+            hideLoneTab: true,
             tabs: [
-                {
-                    label: 'first',
-                    name: 'tab1',
-                    onClick: function() {
-                        assert.ok(false, 'The passed onClick callback was called');
-                    }
+                {name: 'tab1', label: 'TAB #1'}
+            ]
+        }
+    }, {
+        title: 'hide lone tab, with active',
+        config: {
+            hideLoneTab: true,
+            activeTab: 'tab1',
+            tabs: [
+                {name: 'tab1', label: 'TAB #1'}
+            ]
+        }
+    }, {
+        title: 'several tabs, without active',
+        config: {
+            hideLoneTab: true,
+            tabs: [
+                {name: 'tab1', label: 'TAB #1'},
+                {name: 'tab2', label: 'TAB #2'},
+                {name: 'tab3', label: 'TAB #3', cls: 'foo'}
+            ]
+        }
+    }, {
+        title: 'several tabs, with active',
+        config: {
+            hideLoneTab: true,
+            activeTab: 'tab1',
+            tabs: [
+                {name: 'tab1', label: 'TAB #1'},
+                {name: 'tab2', label: 'TAB #2'},
+                {name: 'tab3', label: 'TAB #3', cls: 'foo'}
+            ]
+        }
+    }, {
+        title: 'show lone tab, without active',
+        config: {
+            tabs: [
+                {name: 'tab1', label: 'TAB #1'}
+            ]
+        }
+    }, {
+        title: 'show lone tab, with active',
+        config: {
+            activeTab: 'tab1',
+            tabs: [
+                {name: 'tab1', label: 'TAB #1'}
+            ]
+        }
+    }]).test('single tab', (data, assert) => {
+        const ready = assert.async();
+        const $container = $('#fixture-single');
+        const numberOfTabs = data.config.tabs.length;
+
+        assert.expect(7);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = tabsFactory($container, data.config)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', () => {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.equal($container.find('.tab-group .tab').length, numberOfTabs, `The component contains ${numberOfTabs} tabs`);
+                assert.equal($container.find('.tab-group .tab.active').length, 1, 'The component contains 1 active tab.');
+                if (data.config.hideLoneTab && numberOfTabs === 1) {
+                    assert.equal($container.find('.tab-group .tab:hidden').length, 1, 'The tab is hidden.');
+                } else {
+                    assert.equal($container.find('.tab-group .tab:hidden').length, 0, 'The tab is visible.');
                 }
+
+                instance.destroy();
+            })
+            .on('destroy', () => ready())
+            .on('error', err => {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('hide', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-hide');
+        var config = {
+            activeTab: 'tab2',
+            tabs: [
+                {name: 'tab1', label: 'Tab 1', icon: 'globe'},
+                {name: 'tab2', label: 'Tab 2', cls: 'foo'},
+                {name: 'tab3', label: 'Tab 3', disabled: 'true'},
+                {name: 'tab4', icon: 'flag'}
             ]
         };
-        var instance = tabsFactory(config);
+        var instance;
+
+        assert.expect(12);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container, config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 1, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group:visible').length, 1, 'The component is visible');
+                assert.strictEqual($container.find('.tab-group .tab:visible').length, config.tabs.length, 'All tabs are visible');
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        return new Promise(function (resolve) {
+                            instance
+                                .off('.test')
+                                .on('hide.test', function () {
+                                    assert.ok(true, 'The hide event has been emitted');
+                                    resolve();
+                                })
+                                .hide();
+                        });
+                    })
+                    .then(function () {
+                        return new Promise(function (resolve) {
+                            assert.strictEqual($container.find('.tab-group:visible').length, 0, 'The component is hidden');
+                            assert.strictEqual($container.find('.tab-group .tab:visible').length, 0, 'All tabs are hidden');
+
+                            instance
+                                .off('.test')
+                                .on('show.test', function () {
+                                    assert.ok(true, 'The show event has been emitted');
+                                    resolve();
+                                })
+                                .show();
+                        });
+                    })
+                    .then(function () {
+                        assert.strictEqual($container.find('.tab-group:visible').length, 1, 'The component is visible');
+                        assert.strictEqual($container.find('.tab-group .tab:visible').length, config.tabs.length, 'All tabs are visible');
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('disable', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-disable');
+        var config = {
+            activeTab: 'tab2',
+            tabs: [
+                {name: 'tab1', label: 'Tab 1', icon: 'globe'},
+                {name: 'tab2', label: 'Tab 2', cls: 'foo'},
+                {name: 'tab3', label: 'Tab 3', disabled: 'true'},
+                {name: 'tab4', icon: 'flag'}
+            ]
+        };
+        var instance;
+
+        assert.expect(18);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container, config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 1, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group').length, 1, 'The component is rendered');
+                assert.strictEqual($container.find('.tab-group.disabled').length, 0, 'The component is enabled');
+                assert.strictEqual($container.find('.tab-group .tab').length, config.tabs.length, 'The component contains the expected number of tabs');
+                assert.strictEqual($container.find('.tab-group .tab .action:not(:disabled)').length, config.tabs.length - 1, 'The expected number of tabs is enabled');
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        return new Promise(function (resolve) {
+                            instance
+                                .off('.test')
+                                .on('disable.test', function () {
+                                    assert.ok(true, 'The disable event has been emitted');
+                                    resolve();
+                                })
+                                .disable();
+                        });
+                    })
+                    .then(function () {
+                        return new Promise(function (resolve) {
+                            assert.strictEqual($container.find('.tab-group.disabled').length, 1, 'The component is disabled');
+                            assert.strictEqual($container.find('.tab-group .tab .action:disabled').length, config.tabs.length, 'The expected number of tabs is enabled');
+
+                            instance
+                                .off('.test')
+                                .on('enable.test', function () {
+                                    assert.ok(true, 'The enable event has been emitted');
+                                    resolve();
+                                })
+                                .enable();
+                        });
+                    })
+                    .then(function () {
+                        return new Promise(function (resolve) {
+                            assert.strictEqual($container.find('.tab-group.disabled').length, 0, 'The component is enabled');
+                            assert.strictEqual($container.find('.tab-group .tab .action:not(:disabled)').length, config.tabs.length - 1, 'The expected number of tabs is enabled');
+
+                            instance
+                                .off('.test')
+                                .on('tabenable.test', function (name) {
+                                    assert.strictEqual(name, 'tab3', 'The tabenable event has been emitted');
+                                    resolve();
+                                })
+                                .enableTab('tab3');
+                        });
+                    })
+                    .then(function () {
+                        return new Promise(function (resolve) {
+                            assert.strictEqual($container.find('.tab-group .tab .action:not(:disabled)').length, config.tabs.length, 'The expected number of tabs is enabled');
+
+                            instance
+                                .off('.test')
+                                .on('tabdisable.test', function (name) {
+                                    assert.strictEqual(name, 'tab3', 'The tabdisable event has been emitted');
+                                    resolve();
+                                })
+                                .disableTab('tab3');
+                        });
+                    })
+                    .then(function () {
+                        assert.strictEqual($container.find('.tab-group .tab .action:not(:disabled)').length, config.tabs.length - 1, 'The expected number of tabs is enabled');
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('destroy', function(assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-destroy');
+        var instance;
+
+        assert.expect(4);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container)
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                instance.destroy();
+            })
+            .after('destroy', function () {
+                assert.equal($container.children().length, 0, 'The container is now empty');
+                ready();
+            })
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.module('Tabs API');
+
+    QUnit.test('error', function(assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-error');
+        var instance;
+
+        assert.expect(9);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        Promise
+            .all([
+                new Promise(function(resolve) {
+                    getInstance($container, {tabs: {}})
+                        .on('error', function() {
+                            assert.ok(true, 'Wrong tabs setup');
+                            resolve();
+                        })
+                        .on('ready', function() {
+                            assert.ok(false, 'Should accept a wrong tabs setup');
+                            resolve();
+                        });
+                }),
+                new Promise(function(resolve) {
+                    getInstance($container)
+                        .on('ready', function() {
+                            assert.throws(function() {
+                                instance.setTabs({});
+                            }, 'Trying to set wrong tabs');
+                            resolve();
+                        })
+                        .on('error', resolve);
+                }),
+                new Promise(function(resolve) {
+                    getInstance($container, {tabs: [{name: 'tab1', label: 'Tab 1'}]})
+                        .on('ready', function() {
+                            assert.throws(function() {
+                                instance.setActiveTab('tab2');
+                            }, 'Trying to activate unknown tab name');
+                            resolve();
+                        })
+                        .on('error', resolve);
+                }),
+                new Promise(function(resolve) {
+                    getInstance($container, {tabs: [{name: 'tab1', label: 'Tab 1'}]})
+                        .on('ready', function() {
+                            assert.throws(function() {
+                                instance.setActiveTabIndex(2);
+                            }, 'Trying to activate unknown tab index');
+                            resolve();
+                        })
+                        .on('error', resolve);
+                }),
+                new Promise(function(resolve) {
+                    getInstance($container, {tabs: [{name: 'tab1', label: 'Tab 1'}]})
+                        .on('ready', function() {
+                            assert.throws(function() {
+                                instance.enableTab('tab3');
+                            }, 'Trying to enable unknown tab');
+                            resolve();
+                        })
+                        .on('error', resolve);
+                }),
+                new Promise(function(resolve) {
+                    getInstance($container, {tabs: [{name: 'tab1', label: 'Tab 1'}]})
+                        .on('ready', function() {
+                            assert.throws(function() {
+                                instance.disableTab('tab3');
+                            }, 'Trying to disable unknown tab');
+                            resolve();
+                        })
+                        .on('error', resolve);
+                }),
+                new Promise(function(resolve) {
+                    getInstance($container, {tabs: [{name: 'tab1', label: 'Tab 1'}]})
+                        .on('ready', function() {
+                            assert.throws(function() {
+                                instance.showTabContent('tab3');
+                            }, 'Trying to show content of unknown tab');
+                            resolve();
+                        })
+                        .on('error', resolve);
+                })
+            ])
+            .catch(function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function () {
+                assert.equal($container.children().length, 0, 'The container is empty');
+            })
+            .then(ready);
+    });
+
+    QUnit.cases.init([{
+        title: 'empty',
+        config: {
+            tabs: []
+        },
+        tabs: [
+            {name: 'tabA', label: 'Tab A', icon: 'globe'},
+            {name: 'tabB', label: 'Tab B', cls: 'foo'},
+            {name: 'tabC', label: 'Tab C', disabled: 'true'},
+            {name: 'tabD', icon: 'flag'}
+        ],
+        active: 'tabA',
+        activeIndex: 0
+    }, {
+        title: 'replace tabs',
+        config: {
+            activeTab: 'tab2',
+            tabs: [
+                {name: 'tab1', label: 'Tab 1', icon: 'globe'},
+                {name: 'tab2', label: 'Tab 2', cls: 'foo'},
+                {name: 'tab3', label: 'Tab 3', disabled: 'true'},
+                {name: 'tab4', icon: 'flag'}
+            ]
+        },
+        active: 'tabA',
+        activeIndex: 0,
+        tabs: [
+            {name: 'tabA', label: 'Tab A', icon: 'globe'},
+            {name: 'tabB', label: 'Tab B', cls: 'foo'},
+            {name: 'tabC', label: 'Tab C', disabled: 'true'},
+            {name: 'tabD', icon: 'flag'},
+            {name: 'tabE', label: 'Tab E', icon: 'flag', cls: 'bar'}
+        ]
+    }]).test('setTabs', function (data, assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-settabs');
+        var instance;
+
+        assert.expect(10 + data.config.tabs.length + data.tabs.length * 5);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container, data.config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 1, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group .tab').length, data.config.tabs.length, 'The component contains the expected number of tabs');
+
+                data.config.tabs.forEach(function(tab) {
+                    assert.strictEqual(
+                        $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                        1,
+                        'The tab ' + tab.name + ' is rendered'
+                    );
+                });
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        return new Promise(function(resolve) {
+                            instance
+                                .off('.test')
+                                .on('tabsupdate', function (newTabs) {
+                                    assert.deepEqual(newTabs, data.tabs, 'The tabs has been updated');
+                                    resolve();
+                                })
+                                .setTabs(data.tabs);
+                        });
+                    })
+                    .then(function () {
+                        assert.deepEqual(instance.getTabs(), data.tabs, 'The instance contains the expected tabs');
+                        assert.deepEqual(instance.getActiveTab(), data.active, 'The expected tab name is active');
+                        assert.deepEqual(instance.getActiveTabIndex(), data.activeIndex, 'The expected tab indx is active');
+                        assert.strictEqual($container.find('.tab-group .tab').length, data.tabs.length, 'The component contains the expected number of tabs');
+
+                        data.tabs.forEach(function(tab) {
+                            assert.strictEqual(
+                                $container.find('.tab[data-tab-name="' + tab.name + '"] .action').length,
+                                1,
+                                'The tab ' + tab.name + ' has an action element'
+                            );
+                            if (tab.cls) {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"].' + tab.cls).length,
+                                    1,
+                                    'The tab ' + tab.name + ' is rendered with the expected class'
+                                );
+                            } else {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                                    1,
+                                    'The tab ' + tab.name + ' is rendered'
+                                );
+                            }
+                            if (tab.disabled) {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"] .action:disabled').length,
+                                    1,
+                                    'The tab ' + tab.name + ' is rendered disabled'
+                                );
+                            } else {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"] .action:disabled').length,
+                                    0,
+                                    'The tab ' + tab.name + ' is rendered enabled'
+                                );
+                            }
+                            if (tab.icon) {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"] .icon-' + tab.icon).length,
+                                    1,
+                                    'The tab ' + tab.name + ' contains an icon'
+                                );
+                            } else {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"] .icon').length,
+                                    0,
+                                    'The tab ' + tab.name + ' does not contain an icon'
+                                );
+                            }
+                            if (tab.label) {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"]').text().trim(),
+                                    tab.label,
+                                    'The tab ' + tab.name + ' contains the expected label'
+                                );
+                            } else {
+                                assert.strictEqual(
+                                    $container.find('.tab[data-tab-name="' + tab.name + '"]').text().trim(),
+                                    '',
+                                    'The tab ' + tab.name + ' does not contain a label'
+                                );
+                            }
+                        });
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('activate', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-activate');
+        var config = {
+            tabs: [
+                {name: 'tabA', label: 'Tab A', icon: 'globe'},
+                {name: 'tabB', label: 'Tab B', cls: 'foo'},
+                {name: 'tabC', label: 'Tab C', disabled: 'true'},
+                {name: 'tabD', icon: 'flag'},
+                {name: 'tabE', label: 'Tab E', icon: 'flag', cls: 'bar'}
+            ]
+        };
+        var instance;
+
+        assert.expect(30);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container, config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 1, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group .tab').length, config.tabs.length, 'The component contains the expected number of tabs');
+                assert.deepEqual(config.tabs, instance.getTabs(), 'The expected tabs are set');
+
+                config.tabs.forEach(function(tab) {
+                    assert.strictEqual(
+                        $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                        1,
+                        'The tab ' + tab.name + ' is rendered'
+                    );
+                });
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), instance.getDefaultActiveTab(), 'The default tab is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 0, 'The first tab is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabA"]'), 'The tab tabA is active');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange-tabB.test', function () {
+                                assert.ok(true, 'The event tabchange-tabB has been emitted');
+                                resolve();
+                            });
+                        }));
+
+                        instance.setActiveTab('tabB');
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), 'tabB', 'The expected tab name is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 1, 'The expected tab index is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabB"]'), 'The tab tabB is active');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange-tabD.test', function () {
+                                assert.ok(true, 'The event tabchange-tabD has been emitted');
+                                resolve();
+                            });
+                        }));
+
+                        instance.setActiveTabIndex(3);
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        return new Promise(function(resolve) {
+                            assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is activated');
+                            assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is activated');
+                            assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is active');
+
+                            instance
+                                .off('.test')
+                                .before('tabactivate.test', function (e, name) {
+                                    assert.strictEqual(name, 'tabA', 'The expected tab is being activated');
+                                    window.setTimeout(resolve, 300);
+                                    return Promise.reject();
+                                })
+                                .on('tabchange.test', function () {
+                                    assert.ok(false, 'The tab should not be activated');
+                                })
+                                .on('tabchange-tabA.test', function () {
+                                    assert.ok(false, 'The event tabchange-tabA should not be emitted');
+                                })
+                                .setActiveTab('tabA');
+                        });
+                    })
+                    .then(function () {
+                        assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is still activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is still activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is still active');
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('panel selector', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-panel-selector');
+        var config = {
+            showHideTarget: $container,
+            tabs: [
+                {name: 'tabA', label: 'Tab A', icon: 'globe'},
+                {name: 'tabB', label: 'Tab B', cls: 'foo'},
+                {name: 'tabC', label: 'Tab C', disabled: 'true'},
+                {name: 'tabD', icon: 'flag'},
+                {name: 'tabE', label: 'Tab E', icon: 'flag', cls: 'bar'}
+            ]
+        };
+        var instance;
+
+        assert.expect(37);
+        assert.equal($container.children().length, 5, 'The container is empty');
+
+        instance = tabsFactory($container, config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 6, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group .tab').length, config.tabs.length, 'The component contains the expected number of tabs');
+                assert.deepEqual(config.tabs, instance.getTabs(), 'The expected tabs are set');
+                assert.strictEqual($container.find('.panel').length, config.tabs.length, 'The expected number of panels is there');
+
+                config.tabs.forEach(function(tab) {
+                    assert.strictEqual(
+                        $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                        1,
+                        'The tab ' + tab.name + ' is rendered'
+                    );
+                });
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), instance.getDefaultActiveTab(), 'The default tab is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 0, 'The first tab is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabA"]'), 'The tab tabA is active');
+
+                        assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                        assert.strictEqual($container.find('.panel[data-tab-content="tabA"]:visible').length, 1, 'The expected panel is visible');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        instance.setActiveTab('tabB');
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), 'tabB', 'The expected tab name is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 1, 'The expected tab index is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabB"]'), 'The tab tabB is active');
+
+                        assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                        assert.strictEqual($container.find('.panel[data-tab-content="tabB"]:visible').length, 1, 'The expected panel is visible');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        instance.setActiveTabIndex(3);
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        return new Promise(function(resolve) {
+                            assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is activated');
+                            assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is activated');
+                            assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is active');
+
+                            assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                            assert.strictEqual($container.find('.panel[data-tab-content="tabD"]:visible').length, 1, 'The expected panel is visible');
+
+                            instance
+                                .off('.test')
+                                .before('tabactivate.test', function (e, name) {
+                                    assert.strictEqual(name, 'tabA', 'The expected tab is being activated');
+                                    window.setTimeout(resolve, 300);
+                                    return Promise.reject();
+                                })
+                                .on('tabchange.test', function () {
+                                    assert.ok(false, 'The tab should not be activated');
+                                })
+                                .setActiveTab('tabA');
+                        });
+                    })
+                    .then(function () {
+                        assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is still activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is still activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is still active');
+
+                        assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                        assert.strictEqual($container.find('.panel[data-tab-content="tabD"]:visible').length, 1, 'The expected panel is still visible');
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('panel true', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-panel-true');
+        var config = {
+            showHideTarget: true,
+            tabs: [
+                {name: 'tabA', label: 'Tab A', icon: 'globe'},
+                {name: 'tabB', label: 'Tab B', cls: 'foo'},
+                {name: 'tabC', label: 'Tab C', disabled: 'true'},
+                {name: 'tabD', icon: 'flag'},
+                {name: 'tabE', label: 'Tab E', icon: 'flag', cls: 'bar'}
+            ]
+        };
+        var instance;
+
+        assert.expect(37);
+        assert.equal($container.children().length, 5, 'The container is empty');
+
+        instance = tabsFactory($container, config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 6, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group .tab').length, config.tabs.length, 'The component contains the expected number of tabs');
+                assert.deepEqual(config.tabs, instance.getTabs(), 'The expected tabs are set');
+                assert.strictEqual($container.find('.panel').length, config.tabs.length, 'The expected number of panels is there');
+
+                config.tabs.forEach(function(tab) {
+                    assert.strictEqual(
+                        $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                        1,
+                        'The tab ' + tab.name + ' is rendered'
+                    );
+                });
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), instance.getDefaultActiveTab(), 'The default tab is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 0, 'The first tab is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabA"]'), 'The tab tabA is active');
+
+                        assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                        assert.strictEqual($container.find('.panel[data-tab-content="tabA"]:visible').length, 1, 'The expected panel is visible');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        instance.setActiveTab('tabB');
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), 'tabB', 'The expected tab name is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 1, 'The expected tab index is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabB"]'), 'The tab tabB is active');
+
+                        assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                        assert.strictEqual($container.find('.panel[data-tab-content="tabB"]:visible').length, 1, 'The expected panel is visible');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        instance.setActiveTabIndex(3);
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        return new Promise(function(resolve) {
+                            assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is activated');
+                            assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is activated');
+                            assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is active');
+
+                            assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                            assert.strictEqual($container.find('.panel[data-tab-content="tabD"]:visible').length, 1, 'The expected panel is visible');
+
+                            instance
+                                .off('.test')
+                                .before('tabactivate.test', function (e, name) {
+                                    assert.strictEqual(name, 'tabA', 'The expected tab is being activated');
+                                    window.setTimeout(resolve, 300);
+                                    return Promise.reject();
+                                })
+                                .on('tabchange.test', function () {
+                                    assert.ok(false, 'The tab should not be activated');
+                                })
+                                .setActiveTab('tabA');
+                        });
+                    })
+                    .then(function () {
+                        assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is still activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is still activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is still active');
+
+                        assert.strictEqual($container.find('.panel:visible').length, 1, 'Only one panel is visible');
+                        assert.strictEqual($container.find('.panel[data-tab-content="tabD"]:visible').length, 1, 'The expected panel is still visible');
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.test('click', function (assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-click');
+        var config = {
+            tabs: [
+                {name: 'tabA', label: 'Tab A', icon: 'globe'},
+                {name: 'tabB', label: 'Tab B', cls: 'foo'},
+                {name: 'tabC', label: 'Tab C', disabled: 'true'},
+                {name: 'tabD', icon: 'flag'},
+                {name: 'tabE', label: 'Tab E', icon: 'flag', cls: 'bar'}
+            ]
+        };
+        var instance;
+
+        assert.expect(33);
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = tabsFactory($container, config)
+            .on('init', function () {
+                assert.strictEqual(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.strictEqual($container.children().length, 1, 'The container contains an element');
+                assert.strictEqual($container.children().is('.tab-group'), true, 'The container contains the expected element');
+                assert.strictEqual($container.find('.tab-group .tab').length, config.tabs.length, 'The component contains the expected number of tabs');
+                assert.deepEqual(config.tabs, instance.getTabs(), 'The expected tabs are set');
+
+                config.tabs.forEach(function(tab) {
+                    assert.strictEqual(
+                        $container.find('.tab[data-tab-name="' + tab.name + '"]').length,
+                        1,
+                        'The tab ' + tab.name + ' is rendered'
+                    );
+                });
+
+                Promise
+                    .resolve()
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), instance.getDefaultActiveTab(), 'The default tab is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 0, 'The first tab is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabA"]'), 'The tab tabA is active');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabB', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange-tabB.test', function () {
+                                assert.ok(true, 'The event tabchange-tabB has been emitted');
+                                resolve();
+                            });
+                        }));
+
+                        $container.find('[data-tab-name="tabB"]').click();
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        var promises = [];
+                        instance.off('.test');
+
+                        assert.strictEqual(instance.getActiveTab(), 'tabB', 'The expected tab name is activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 1, 'The expected tab index is activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabB"]'), 'The tab tabB is active');
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabactivate.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab is being activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange.test', function (name) {
+                                assert.strictEqual(name, 'tabD', 'The expected tab has been activated');
+                                resolve();
+                            });
+                        }));
+
+                        promises.push(new Promise(function(resolve) {
+                            instance.on('tabchange-tabD.test', function () {
+                                assert.ok(true, 'The event tabchange-tabD has been emitted');
+                                resolve();
+                            });
+                        }));
+
+                        $container.find('[data-tab-name="tabD"] .icon').click();
+
+                        return Promise.all(promises);
+                    })
+                    .then(function () {
+                        return new Promise(function(resolve) {
+                            assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is activated');
+                            assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is activated');
+                            assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is active');
+
+                            instance
+                                .off('.test')
+                                .on('tabactivate.test', function () {
+                                    assert.ok(false, 'The tab should not be activating');
+                                })
+                                .on('tabchange.test', function () {
+                                    assert.ok(false, 'The tab should not be activated');
+                                })
+                                .on('tabchange-tabC.test', function () {
+                                    assert.ok(false, 'The event tabchange-tabC should not be emitted');
+                                });
+
+                            window.setTimeout(resolve, 300);
+
+                            $container.find('[data-tab-name="tabC"] .action').click();
+                        });
+                    })
+                    .then(function () {
+                        return new Promise(function(resolve) {
+                            assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is activated');
+                            assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is activated');
+                            assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is active');
+
+                            instance
+                                .off('.test')
+                                .before('tabactivate.test', function (e, name) {
+                                    assert.strictEqual(name, 'tabA', 'The expected tab is being activated');
+                                    window.setTimeout(resolve, 300);
+                                    return Promise.reject();
+                                })
+                                .on('tabchange.test', function () {
+                                    assert.ok(false, 'The tab should not be activated');
+                                })
+                                .on('tabchange-tabA.test', function () {
+                                    assert.ok(false, 'The event tabchange-tabA should not be emitted');
+                                });
+
+                            $container.find('[data-tab-name="tabA"] .label').click();
+                        });
+                    })
+                    .then(function () {
+                        assert.strictEqual(instance.getActiveTab(), 'tabD', 'The expected tab name is still activated');
+                        assert.strictEqual(instance.getActiveTabIndex(), 3, 'The expected tab index is still activated');
+                        assert.ok($container.find('.tab.active').is('[data-tab-name="tabD"]'), 'The tab tabD is still active');
+                    })
+                    .catch(function (err) {
+                        assert.pushResult({
+                            result: false,
+                            message: err
+                        });
+                    })
+                    .then(function () {
+                        instance.destroy();
+                    });
+            })
+            .on('destroy', ready)
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
+    QUnit.module('Tabs Visual');
+
+    QUnit.test('Visual test', function (assert) {
+        var ready = assert.async();
+        var config = {
+            showHideTarget: '#visual-fixture .panels',
+            tabs: [
+                {label: 'TAO Local', name: 'tao-local'},
+                {label: 'TAO Remote', name: 'tao-remote', icon: 'globe'},
+                {label: 'LTI-based', name: 'lti-based', disabled: true}
+            ]
+        };
 
         assert.expect(1);
-
-        instance.activateTabByName('tab1', false); // no call
-        assert.ok(true, 'Test ran without triggering onClick callback');
-
-        instance.destroy();
-    });
-
-    QUnit.test('activeTabIndex param', function(assert) {
-        var config = {
-            renderTo: $qunitFixture,
-            tabs: [
-                { label: 'first', name: 'tab1' },
-                { label: 'second', name: 'tab2' }
-            ],
-            activeTabIndex: 1
-        };
-        var instance = tabsFactory(config);
-        var $tabsDom = $('.tab-group', $qunitFixture);
-
-        assert.expect(2);
-
-        assert.equal($('.tab.active', $tabsDom).length, 1, 'Only 1 tab is active');
-        assert.equal($('.tab.active button', $tabsDom).html(), 'second', 'second tab is active');
-
-        instance.destroy();
-    });
-
-    QUnit.test('showHideTargets param (true)', function(assert) {
-        // Set up content fixture first
-        var $nav = $('<nav>').appendTo($qunitFixture);
-        var $firstPanel = $('<div data-tab-content="tab1">Panel 1</div>').appendTo($qunitFixture);
-        var $secondPanel = $('<div data-tab-content="tab2">Panel 2</div>').appendTo($qunitFixture);
-
-        var config = {
-            renderTo: $nav,
-            tabs: [
-                { label: 'first', name: 'tab1' },
-                { label: 'second', name: 'tab2' }
-            ],
-            activeTabIndex: 0,
-            showHideTargets: true
-        };
-
-        var instance = tabsFactory(config);
-
-        var $tab2 = $('[data-tab-name="tab2"]', $nav);
-
-        assert.expect(2);
-
-        instance.on('show-tab-content.*', function(name) {
-            assert.ok(true, 'The show-tab-content event fired');
-            assert.equal(name, 'tab2', 'The event was fired with a value matching the tab name');
-        });
-        $tab2.trigger('click');
-
-        instance.destroy();
-    });
-
-    QUnit.test('visual', function(assert) {
-        var config = {
-            renderTo: $('#visual-fixture nav'),
-            tabs: [
-                { label: 'TAO Local', name: 'tao-local', onClick: () => console.log('visual 1st cb') },
-                { label: 'TAO Remote', name: 'tao-remote', onClick: () => console.log('visual 2nd cb') },
-                { label: 'LTI-based', name: 'lti-based', onClick: () => console.log('visual 3rd cb'), disabled: true }
-            ]
-        };
-
-        var instance = tabsFactory(config);
-
-        assert.ok(true, 'visual test ran');
+        tabsFactory('#visual-fixture nav', config)
+            .on('ready', function () {
+                assert.ok(true, 'visual test ran');
+                ready();
+            })
+            .on('tabchange', function (name) {
+                $('#visual-fixture .output').html('tabchange event for Tab <strong>' + name + '</strong>');
+            })
+            .on('error', function (err) {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
     });
 
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8720

A `tabs` component has been made temporarily in `taoAuthoringWorkflow` during componentisation of frontend libs, and has been forgotten there. Meanwhile the same kind of component has been made in this repository, unfortunately with some design flaws.

This PR is an effort to mix them together into a single one version. Obviously the API won't be exactly the same, and will require some changes in the consumers.

What has changed:
- the factory requires the container as a first parameter: `tabsFactory(container, config)`
- the component is asynchronous, the `init` and the `render` steps are deferred, that allows to perform some extra steps meanwhile. A `ready` event is emitted when the component is fully set up.
- the link with related panels is still available, but require a proper config to link the tabs bar (`showHideTarget` must be set to the panels' container)
- no more callbacks available, you need to rely on events instead: `instance.on('tabchange', name => {})` or `instance.on('tabchange-tabX', () => {})`
- the API is now more consistent, whith reciprocal accessors (`getXx`/`setXx`)
- tabs can be disabled on the fly (`enableTab(name)` and `disableTab(name)`)
- tabs can be replaced on the fly too (`setTabs(newTabs)`)
- tabs can be prevented thanks to chain of events: `tabactivate` => `tabchange`, so that if you prevent the `tabactivate` to continue, the `tabchange` will be prevented

The UI should not have been changed, except it now supports icons. For specific purposes, the template can be replaced before the component is rendered to set a different layout: 
```javascript
tabsFactory(container, config)
    .setTemplate(newTemplate)
    .on('ready' () => {
        //
    });
```

Unit test: `test/tabs/test.html`

To test CLI:
```
npm run prepare
npm run test tabs
```

or: `npm run test:keepAlive`

Once merged, don't forget to release and run `npm publish`