### PR TITLE
Fix/tao 8725/update interactjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,8 +866,9 @@
             }
         },
         "@oat-sa/tao-core-libs": {
-            "version": "github:oat-sa/tao-core-libs-fe#9bdf68b89c1bf3b3ddbeadbcfc74047e98e95ace",
-            "from": "github:oat-sa/tao-core-libs-fe#fix/TAO-8725/update-interactjs",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.3.0.tgz",
+            "integrity": "sha512-4fuJQ2nrm2bW4ydauz+hxkjHEWbSFPeeMo1m6uSJgFYIRwEuVhy0LUt3LRaifxH0WbyumX0xuEezGJQVbL6QYg==",
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
@@ -926,9 +927,9 @@
             }
         },
         "@types/jquery": {
-            "version": "2.0.53",
-            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.53.tgz",
-            "integrity": "sha512-MZKPWUhp5TKkoJ/58NSq6io+CSUCOHm2b3Z6U4+r9v70kktB0JM+eRjdp6YmDHtw0kK2XB7L2K7/FMIoziHjUA==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.54.tgz",
+            "integrity": "sha512-D/PomKwNkDfSKD13DEVQT/pq2TUjN54c6uB341fEZanIzkjfGe7UaFuuaLZbpEiS5j7Wk2MUHAZqZIoECw29lg==",
             "dev": true
         },
         "@types/minimatch": {
@@ -938,9 +939,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.6.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-            "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
+            "version": "12.7.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+            "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
             "dev": true
         },
         "@types/resolve": {
@@ -969,9 +970,9 @@
             }
         },
         "acorn": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-            "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+            "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
             "dev": true
         },
         "agent-base": {
@@ -1096,9 +1097,9 @@
             "dev": true
         },
         "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
             "dev": true
         },
         "asynckit": {
@@ -1492,9 +1493,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30000988",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
-            "integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==",
+            "version": "1.0.30000989",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+            "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
             "dev": true
         },
         "caseless": {
@@ -1649,14 +1650,13 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-            "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+            "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.6.2",
-                "core-js-pure": "3.1.4",
-                "semver": "^6.1.1"
+                "browserslist": "^4.6.6",
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -1666,12 +1666,6 @@
                     "dev": true
                 }
             }
-        },
-        "core-js-pure": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-            "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
-            "dev": true
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1843,9 +1837,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.211",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.211.tgz",
-            "integrity": "sha512-GZAiK3oHrs0K+LwH+HD+bdjZ17v40oQQdXbbd3dgrwgbENvazrGpcuIADSAREWnxzo9gADB1evuizrbXsnoU2Q==",
+            "version": "1.3.235",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.235.tgz",
+            "integrity": "sha512-xNabEDbMIKPLQd6xgv4nyyeMaWXIKSJr6G51ZhUemHhbz6kjZAYcygA8CvfEcMF+Mt5eLmDWaLmfSOWdQxzBVQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -2272,9 +2266,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
             "dev": true
         },
         "handlebars": {
@@ -2348,9 +2342,9 @@
             }
         },
         "hosted-git-info": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+            "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
             "dev": true
         },
         "http-errors": {
@@ -3154,9 +3148,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.26",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-            "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+            "version": "1.1.27",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+            "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
             "dev": true,
             "requires": {
                 "semver": "^5.3.0"
@@ -3614,9 +3608,9 @@
             }
         },
         "p-limit": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+            "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
             "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
@@ -3797,9 +3791,9 @@
             }
         },
         "postcss-value-parser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-            "integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+            "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
             "dev": true
         },
         "private": {
@@ -4018,13 +4012,13 @@
             "dev": true
         },
         "regexpu-core": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-            "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
+            "integrity": "sha512-FpI67+ky9J+cDizQUJlIlNZFKual/lUkFr1AG6zOCpwZ9cLrg8UUVakyUQJD7fCDIe9Z2nwTQJNPyonatNmDFQ==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.0",
-                "regenerate-unicode-properties": "^8.0.2",
+                "regenerate-unicode-properties": "^8.1.0",
                 "regjsgen": "^0.5.0",
                 "regjsparser": "^0.6.0",
                 "unicode-match-property-ecmascript": "^1.0.4",
@@ -4148,23 +4142,23 @@
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
         },
         "rollup": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.18.0.tgz",
-            "integrity": "sha512-MBAWr6ectF948gW/bs/yfi0jW7DzwI8n0tEYG/ZMQutmK+blF/Oazyhg3oPqtScCGV8bzCtL9KzlzPtTriEOJA==",
+            "version": "1.19.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.19.4.tgz",
+            "integrity": "sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==",
             "dev": true,
             "requires": {
                 "@types/estree": "0.0.39",
-                "@types/node": "^12.6.3",
-                "acorn": "^6.2.0"
+                "@types/node": "^12.6.9",
+                "acorn": "^6.2.1"
             }
         },
         "rollup-plugin-alias": {
@@ -4561,9 +4555,9 @@
             "dev": true
         },
         "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true
         },
         "send": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,9 +2449,9 @@
             "dev": true
         },
         "interactjs": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.2.8.tgz",
-            "integrity": "sha1-8o2cawgwE9quPHfwJiBPndGYPtk=",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.3.4.tgz",
+            "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ==",
             "dev": true
         },
         "invariant": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.22.0",
+    "version": "0.23.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -866,9 +866,8 @@
             }
         },
         "@oat-sa/tao-core-libs": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.2.0.tgz",
-            "integrity": "sha512-oEKv7JJ5UIYD/kqvj32b/QQQ/17GPNIizT/KRwxmvPMpDxQcx6RtyQ8dumnn4aT8EVCgMccpQI9rhayiT6R7jw==",
+            "version": "github:oat-sa/tao-core-libs-fe#9bdf68b89c1bf3b3ddbeadbcfc74047e98e95ace",
+            "from": "github:oat-sa/tao-core-libs-fe#fix/TAO-8725/update-interactjs",
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
@@ -3921,7 +3920,7 @@
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.22.0",
+    "version": "0.23.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "gamp": "^0.2.1",
         "glob": "^7.1.4",
         "handlebars": "1.3.0",
-        "interactjs": "1.2.8",
+        "interactjs": "1.3.4",
         "jquery": "1.9.1",
         "jquery-mockjax": "^2.5.0",
         "lodash": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "^0.2.0",
+        "@oat-sa/tao-core-libs": "^0.3.0",
         "@oat-sa/tao-core-sdk": "^0.4.1",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",
         "async": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "oat-sa/tao-core-libs-fe#fix/TAO-8725/update-interactjs",
+        "@oat-sa/tao-core-libs": "^0.3.0",
         "@oat-sa/tao-core-sdk": "^0.4.1",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",
         "async": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "^0.3.0",
+        "@oat-sa/tao-core-libs": "oat-sa/tao-core-libs-fe#fix/TAO-8725/update-interactjs",
         "@oat-sa/tao-core-sdk": "^0.4.1",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",
         "async": "^0.2.10",

--- a/src/component/draggable.js
+++ b/src/component/draggable.js
@@ -50,6 +50,8 @@ export default function makeDraggable(component, config) {
                 element = $element[0],
                 rootNode = document.querySelector('html');
 
+            $element.css('touch-action', 'none');
+
             if (!this.config.dragRestriction) {
                 this.config.dragRestriction = this.getContainer()[0];
             }

--- a/src/component/resizable.js
+++ b/src/component/resizable.js
@@ -162,7 +162,7 @@ export default function makeResizable(component, config) {
             var self = this,
                 $element = this.getElement(),
                 element = $element[0];
-
+            $element.css('touch-action', 'none');
             if (!this.config.resizeRestriction) {
                 this.config.resizeRestriction = this.getContainer()[0];
             }

--- a/src/dynamicComponent.js
+++ b/src/dynamicComponent.js
@@ -220,6 +220,8 @@ var dynComponentFactory = function dynComponentFactory(specs, defaults) {
             var pixelRatio = window.devicePixelRatio;
             var interactElement;
 
+            //prevent parent machine OS to handle its touch gestures on this particular element
+            $element.css('touch-action', 'none');
             //keeps moving/resizing positions data
             self.position = {
                 x: this.config.left,

--- a/src/dynamicComponent.js
+++ b/src/dynamicComponent.js
@@ -280,12 +280,6 @@ var dynComponentFactory = function dynComponentFactory(specs, defaults) {
                     interaction.start(
                         {
                             name: 'drag',
-                            edges: {
-                                top: handle.dataset.top,
-                                left: handle.dataset.left,
-                                bottom: handle.dataset.bottom,
-                                right: handle.dataset.right
-                            }
                         },
                         interactElement,
                         $element[0]

--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -72,13 +72,20 @@ interactHelper = {
     tapOn: function tapOn(element, cb, delay) {
         var domElement,
             eventOptions = {
-                bubbles: true
+                bubbles: true,
+                pointerId: 1,
+                bubbles: true, 
+                cancelable: true, 
+                pointerType: "touch",
+                width: 100,
+                height: 100,
+                isPrimary: true
             };
         if (element) {
             domElement = element instanceof $ ? element.get(0) : element;
 
-            triggerMouseEvent(domElement, 'mousedown', eventOptions);
-            triggerMouseEvent(domElement, 'mouseup', eventOptions);
+            domElement.dispatchEvent(new PointerEvent('pointerdown', eventOptions));
+            domElement.dispatchEvent(new PointerEvent('pointerup', eventOptions));
 
             if (cb) {
                 _.delay(cb, delay || 0);

--- a/test/interactUtils/test.js
+++ b/test/interactUtils/test.js
@@ -14,11 +14,11 @@ define(['jquery', 'lodash', 'interact', 'ui/interactUtils', 'core/mouseEvent'], 
         assert.expect(3);
 
         var button = document.getElementById('button');
-        button.addEventListener('mousedown', function mousedown() {
-            assert.ok(true, 'mousedown has been fired');
+        button.addEventListener('pointerdown', function pointerdown() {
+            assert.ok(true, 'pointerdown has been fired');
         });
-        button.addEventListener('mouseup', function mouseup() {
-            assert.ok(true, 'mouseup has been fired');
+        button.addEventListener('pointerup', function pointerup() {
+            assert.ok(true, 'pointerup has been fired');
         });
 
         interactUtils.tapOn(button, function() {
@@ -51,11 +51,11 @@ define(['jquery', 'lodash', 'interact', 'ui/interactUtils', 'core/mouseEvent'], 
         var button = document.getElementById('button'),
             $button = $('#button');
 
-        button.addEventListener('mousedown', function mousedown() {
-            assert.ok(true, 'mousedown has been fired');
+        button.addEventListener('pointerdown', function pointerdown() {
+            assert.ok(true, 'pointerdown has been fired');
         });
-        button.addEventListener('mouseup', function mouseup() {
-            assert.ok(true, 'mouseup has been fired');
+        button.addEventListener('pointerup', function pointerup() {
+            assert.ok(true, 'pointerup has been fired');
         });
 
         interactUtils.tapOn($button, function() {


### PR DESCRIPTION
**task:** https://oat-sa.atlassian.net/browse/TAO-8725
**description:** 
on hybrid laptops ( both with keyboard and touchscreen) all plugins (widgets) of test runner were unable to move through the touchscreen instead of mouse or touchpad. 

**solution**
interactjs lib which is responsible for all interface interactions was updated to newer version which supports modern " pointer events" browser API which solved the issue.

**related PR**
https://github.com/oat-sa/tao-test-runner-qti-fe/pull/21
https://github.com/oat-sa/tao-core-libs-fe/pull/8
