### PR TITLE
Feature/nex 297 add setconfig to themes handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.23.0",
+    "version": "0.24.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.23.0",
+    "version": "0.24.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/themes.js
+++ b/src/themes.js
@@ -40,13 +40,19 @@ export default {
      * @returns {Object}
      */
     getConfig: function getConfig() {
-        var initialConfig;
-
+        // set theme config from module.config() if it is not defined
         if (!themesConfig) {
-            initialConfig = module.config();
-            themesConfig = _.cloneDeep(initialConfig);
+            this.setConfig(module.config());
         }
         return themesConfig;
+    },
+
+    /**
+     * Set themes config
+     * @param {Object} config Themes config
+     */
+    setConfig(config) {
+        themesConfig = _.cloneDeep(config);
     },
 
     /**

--- a/test/themes/test.js
+++ b/test/themes/test.js
@@ -210,4 +210,11 @@ define(['lodash', 'ui/themes'], function(_, themesHandler) {
         assert.deepEqual(themesHandler.getCurrentThemeData('items'), config[itemsNs1], 'returns items_ns1 themes');
         assert.deepEqual(themesHandler.getCurrentThemeData(), config[itemsNs1], 'returns items_ns1 themes');
     });
+
+    QUnit.test('setConfig', function(assert) {
+        assert.expect(1);
+
+        themesHandler.setConfig(config);
+        assert.deepEqual(themesHandler.getConfig(), config, 'getConfig return with previously set config');
+    });
 });


### PR DESCRIPTION
Add `setConfig` functionality to theme handler.

Test: `npm run test`

After merge:
- [ ] release it to npm registry