### PR TITLE
Feature/uio 1 create integer validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.24.2",
+    "version": "0.25.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.24.2",
+    "version": "0.25.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/validator/validators.js
+++ b/src/validator/validators.js
@@ -78,6 +78,17 @@ var validators = {
             }
         }
     },
+    integer: {
+        name: 'integer',
+        message: __('The value of this field must be an integer'),
+        options: {},
+        validate: function(value, callback) {
+            var r = typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
+            if (typeof callback === 'function') {
+                callback.call(null, r);
+            }
+        }
+    },
     notEmpty: {
         name: 'notEmpty',
         message: __('this is required'),

--- a/src/validator/validators.js
+++ b/src/validator/validators.js
@@ -83,7 +83,8 @@ var validators = {
         message: __('The value of this field must be an integer'),
         options: {},
         validate: function(value, callback) {
-            var r = typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
+            const parsedValue = parseInt(value, 10);
+            var r = value === parsedValue.toString() && isFinite(parsedValue) && Math.floor(parsedValue) === parsedValue;
             if (typeof callback === 'function') {
                 callback.call(null, r);
             }

--- a/test/validator/test.html
+++ b/test/validator/test.html
@@ -42,6 +42,12 @@
                     type="text"
                     data-validate="$numeric"
                 />
+                <input
+                    name="field_4"
+                    id="field_4"
+                    type="text"
+                    data-validate="$integer"
+                />
             </form>
         </div>
     </body>

--- a/test/validator/test.js
+++ b/test/validator/test.js
@@ -1,4 +1,4 @@
-define(['lodash', 'jquery', 'ui/validator'], function(_, $, FormValidator) {
+define(['lodash', 'jquery', 'ui/validator'], function(_, $) {
     'use strict';
 
     QUnit.test('validate', function(assert) {
@@ -7,11 +7,13 @@ define(['lodash', 'jquery', 'ui/validator'], function(_, $, FormValidator) {
         $('#field_1').validator();
         $('#field_2').validator();
         $('#field_3').validator();
+        $('#field_4').validator();
 
         assert.equal($('#field_0').data('validator-instance').rules[0].name, 'notEmpty');
         assert.equal($('#field_1').data('validator-instance').rules[0].name, 'notEmpty');
         assert.equal($('#field_2').data('validator-instance').rules[0].name, 'notEmpty');
         assert.equal($('#field_3').data('validator-instance').rules[0].name, 'numeric');
+        assert.equal($('#field_4').data('validator-instance').rules[0].name, 'integer');
 
         assert.equal($('#field_0').data('validator-instance').rules[1].name, 'pattern');
         assert.equal($('#field_1').data('validator-instance').rules[1].name, 'pattern');


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/UIO-1

Implement `integer` validator. I was not able to use `Number.isInteger`, because of IE11, so I used the polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill

Test:
`npm run test`

- [ ] Publish to npm registry