### PR TITLE
Fix/tao 9767/datatable render empty text if filter applied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -343,7 +343,7 @@ var dataTable = {
         }
 
         options.model = model;
-        renderEmptyText = options.emptyText && (!!options.filterquery || !!options.filtercolumns);
+        renderEmptyText = !!(options.emptyText && (options.filterquery || options.filtercolumns && _.size(options.filtercolumns)));
         // Call the rendering
         $rendering = $(layout({ options: options, dataset: dataset, renderEmptyText: renderEmptyText }));
 

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -283,6 +283,7 @@ var dataTable = {
         var amount;
         var transforms;
         var model = [];
+        var renderEmptyText;
 
         var join = function join(input) {
             return typeof input !== 'object' ? input : input.join(', ');
@@ -342,8 +343,9 @@ var dataTable = {
         }
 
         options.model = model;
+        renderEmptyText = options.emptyText && (!!options.filterquery || !!options.filtercolumns);
         // Call the rendering
-        $rendering = $(layout({ options: options, dataset: dataset }));
+        $rendering = $(layout({ options: options, dataset: dataset, renderEmptyText: renderEmptyText }));
 
         // the readonly property contains an associative array where keys are the ids of the items (lines)
         // the value can be a boolean (true for disable buttons, false to enable)

--- a/src/datatable/tpl/layout.tpl
+++ b/src/datatable/tpl/layout.tpl
@@ -145,7 +145,7 @@
             </tbody>
         </table>
         {{#unless dataset.data}}
-            {{#if options.emptyText}}
+            {{#if renderEmptyText}}
                 <div class="empty">
                     {{ options.emptyText }}
                 </div>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9767
Related to: https://oat-sa.atlassian.net/browse/TAO-9686

In datatable `emptyText` will be displayed only if some filter is applied.