### PR TITLE
Fix/tao 9716/password field eye icon on edge browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.26.0",
+    "version": "0.26.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -271,6 +271,9 @@ body {
         &::-ms-clear {
             display: none;
         }
+        &::-ms-reveal {
+            display: none;
+        }
     }
 
     button,

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -39,9 +39,6 @@ label, .form_desc {
             display:none;
         }
     }
-    input::-ms-reveal {
-        display: none;
-    }
 }
 
 .uploader .file-upload.grid-row {

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -39,6 +39,9 @@ label, .form_desc {
             display:none;
         }
     }
+    input::-ms-reveal {
+        display: none;
+    }
 }
 
 .uploader .file-upload.grid-row {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9716
 
Password input field in login form has unexpected element (native "password reveal" element) in Edge Browser.

#### Steps to reproduce
- set focus on password field and begin typing
  
#### How to test
- prepare TAO instance, go to tao/views/package.json and replace current depencies
`  "dependencies": {
    ...
    "@oat-sa/tao-core-ui": "0.26.0",
  }`
with this branch:
`  "dependencies": {
    ...
    "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#fix/TAO-9716/password-field-eye-icon-on-edge-browser"
  }`
- run `npm install` in directory `YOUR_PROJECT_ROOT/tao/views/`
- run `npm install` in directory `YOUR_PROJECT_ROOT/tao/views/build/`
- run `npx grunt sass:tao` in directory `YOUR_PROJECT_ROOT/tao/views/build/`
- open installed instance in Edge browser
- set focus on password field and begin typing, eye icon disappears