### PR TITLE
Feature/tao 9965/Make the submit button optional in ui/simpleForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.26.1",
+    "version": "0.27.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.26.1",
+    "version": "0.27.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/form/simpleForm.js
+++ b/src/form/simpleForm.js
@@ -29,6 +29,7 @@ import formFactory from 'ui/form/form';
  * @property {String} [submitIcon] - The icon of the submit button
  * @property {String} [resetText] - The caption of the reset button
  * @property {String} [resetIcon] - The icon of the reset button
+ * @property {Boolean} [submit] - Activate the submit button
  * @property {Boolean} [reset] - Activate the reset button
  */
 
@@ -41,6 +42,7 @@ const defaultConfig = {
     submitIcon: 'save',
     resetText: __('Reset'),
     resetIcon: 'reset',
+    submit: true,
     reset: true
 };
 
@@ -77,6 +79,7 @@ const defaultConfig = {
  * @param {String} [config.submitIcon] - The icon of the submit button
  * @param {String} [config.resetText] - The caption of the reset button
  * @param {String} [config.resetIcon] - The icon of the reset button
+ * @param {Boolean} [config.submit] - Activate the submit button
  * @param {Boolean} [config.reset] - Activate the reset button
  * @param {String} [config.title] - An optional title for the form (default none)
  * @param {String} [config.formAction] - The url the form is targeting (default '#')
@@ -101,12 +104,14 @@ function simpleFormFactory(container, config) {
         });
     }
 
-    config.buttons.push({
-        type: 'info',
-        id: 'submit',
-        label: config.submitText,
-        icon: config.submitIcon
-    });
+    if (config.submit) {
+        config.buttons.push({
+            type: 'info',
+            id: 'submit',
+            label: config.submitText,
+            icon: config.submitIcon
+        });
+    }
 
     return formFactory(container, config)
         .on('button-submit', function onButtonSubmit() {

--- a/test/form/dropdownForm/test.html
+++ b/test/form/dropdownForm/test.html
@@ -58,6 +58,7 @@
     <div id="fixture-enable"></div>
     <div id="fixture-destroy"></div>
     <div id="fixture-widgets"></div>
+    <div id="fixture-buttons"></div>
     <div id="fixture-values"></div>
     <div id="fixture-open"></div>
     <div id="fixture-trigger"></div>

--- a/test/form/dropdownForm/test.js
+++ b/test/form/dropdownForm/test.js
@@ -498,6 +498,87 @@ define([
             });
     });
 
+    QUnit.cases.init([{
+        title: 'default',
+        expected: ['submit']
+    }, {
+        title: 'add buttons',
+        config: {
+            widgets: [{
+                widget: 'text',
+                uri: 'title',
+                label: 'Title'
+            }],
+            buttons: [{
+                id: 'foo',
+                label: ' Foo'
+            }]
+        },
+        expected: ['submit', 'foo']
+    }, {
+        title: 'replace buttons',
+        config: {
+            widgets: [{
+                widget: 'text',
+                uri: 'title',
+                label: 'Title'
+            }],
+            buttons: [{
+                id: 'foo',
+                label: ' Foo'
+            }],
+            submit: false
+        },
+        expected: ['foo']
+    }]).test('buttons', function (data, assert) {
+        var ready = assert.async();
+        var $container = $('#fixture-buttons');
+        var instance;
+        var submitAllowed = !data.config || data.config.submit !== false;
+
+        assert.expect(8 + _.size(data.config && data.config.widgets) + _.size(data.expected));
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        instance = dropdownFormFactory($container, data.config);
+
+        instance
+            .on('init', function () {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .on('ready', function () {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal($container.children().is('.dropdown-form'), true, 'The container contains the expected element');
+                assert.equal($container.find('.dropdown-form [data-control="trigger"]').length, 1, 'The component contains the trigger button');
+                assert.equal($container.find('.dropdown-form fieldset').length, 1, 'The component contains a place for the widgets');
+
+                data.expected.forEach(function(id) {
+                    assert.equal($container.find('.dropdown-form [data-control="' + id + '"]').length, 1, 'The component contains the button ' + id);
+                });
+
+                assert.equal($container.find('.dropdown-form [data-control="submit"]').length, submitAllowed ? 1 : 0, 'The submit button is set as expected');
+
+                assert.equal($container.find('.dropdown-form fieldset').children().length, _.size(data.config && data.config.widgets), 'The initial widgets are rendered');
+
+                _.forEach(data.config && data.config.widgets, function(widget) {
+                    assert.equal($container.find('.dropdown-form fieldset [name="' + widget.uri + '"]').first().length, 1, 'The widget ' + widget.uri + ' has been rendered');
+                });
+
+                instance.destroy();
+            })
+            .on('destroy', function () {
+                ready();
+            })
+            .on('error', function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+                ready();
+            });
+    });
+
     QUnit.test('values', function (assert) {
         var ready = assert.async();
         var $container = $('#fixture-values');

--- a/test/form/simpleForm/test.js
+++ b/test/form/simpleForm/test.js
@@ -208,6 +208,20 @@ define([
             submit: false
         }
     }, {
+        title: 'no action',
+        config: {
+            widgets: [{
+                widget: 'text',
+                uri: 'text',
+                label: 'Text'
+            }],
+            values: {
+                text: 'foo 2'
+            },
+            submit: false,
+            reset: false
+        }
+    }, {
         title: 'default widget',
         config: {
             widgets: [{

--- a/test/form/simpleForm/test.js
+++ b/test/form/simpleForm/test.js
@@ -195,6 +195,19 @@ define([
             reset: false
         }
     }, {
+        title: 'no submit',
+        config: {
+            widgets: [{
+                widget: 'text',
+                uri: 'text',
+                label: 'Text'
+            }],
+            values: {
+                text: 'foo 2'
+            },
+            submit: false
+        }
+    }, {
         title: 'default widget',
         config: {
             widgets: [{
@@ -220,9 +233,15 @@ define([
         }].concat(data.config && data.config.buttons || []);
         var instance;
 
-        if (data.config && data.config.reset === false) {
-            buttons.shift();
+        if (data.config) {
+            if (data.config.submit === false) {
+                buttons.pop();
+            }
+            if (data.config.reset === false) {
+                buttons.shift();
+            }
         }
+
         assert.expect(9 + _.size(widgets) + _.size(buttons));
 
         assert.equal($container.children().length, 0, 'The container is empty');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9965

The `ui/form` galaxy contains multiple implementations of the form component.

The foundation component is `ui/form`, which implements a basic form container, managing a list of widgets (input fields) and a list of actions (submit, reset, etc.). It also offers management API.

Then we have `ui/simpleForm`, built on top of `ui/form`. It adds default action buttons: `submit` and `reset`, wiring direct properties to ease the configuration of those actions, and binding the default behavior: submitting the form when actioning the `submit` button, and resetting the form when actioning the `reset` button.

Finally, we have `ui/dropdownForm`, composed from `ui/form` and `ui/button`. It offers a convenient way to display a dropdown form.

So far the `simpleForm` component was enforcing the presence of the `submit` button, while making the `reset` button optional.

This PR aims to make the `submit` button optional as well.

The unit tests must still work.

Impacted unit tests:
- `test/form/simpleForm/test.html`
- `test/form/dropdownForm/test.html`

To run the tests:
```bash
npm run build
npm run test
```

**Review Checklist**
- [ ] New code is covered by tests (if applicable)
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful