### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9965

The previously published package was containing corrupted bundles. A component from a TAO extension has been added somehow in the dist folder.