### PR TITLE
Fix/NCC-63/provide proper calendar locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/datetime/picker.js
+++ b/src/datetime/picker.js
@@ -111,19 +111,18 @@ var supportedConstraints = ['minDate', 'maxDate', 'enable', 'disable'];
  * @param {String} locale
  * @returns {Boolean}
  */
-var hasTranslationsForLocale = function(locale) {
-    return _.isObject(flatpickrLocalization.default[locale]);
-};
+const hasTranslationsForLocale = locale => _.isObject(flatpickrLocalization.default[locale]);
 
 /**
  * Detects document language
  * @returns {String | undefined}
  */
-var getDefaultLocale = function getDefaultLocale() {
-    var documentLang = window.document.documentElement.getAttribute('lang');
+const getDefaultLocale = () => {
+    const documentLang = window.document.documentElement.getAttribute('lang');
+    const documentLocale = documentLang && documentLang.split('-')[0];
 
-    if (documentLang && hasTranslationsForLocale(documentLang.split('-')[0])) {
-        return documentLang;
+    if (documentLocale && hasTranslationsForLocale(documentLocale)) {
+        return documentLocale;
     }
 };
 

--- a/src/datetime/picker.js
+++ b/src/datetime/picker.js
@@ -107,13 +107,34 @@ var setups = {
 var supportedConstraints = ['minDate', 'maxDate', 'enable', 'disable'];
 
 /**
+ * Checks translation existing for given locale
+ * @param {String} locale
+ * @returns {Boolean}
+ */
+var hasTranslationsForLocale = function(locale) {
+    return _.isObject(flatpickrLocalization.default[locale]);
+};
+
+/**
+ * Detects document language
+ * @returns {String | undefined}
+ */
+var getDefaultLocale = function getDefaultLocale() {
+    var documentLang = window.document.documentElement.getAttribute('lang');
+
+    if (documentLang && hasTranslationsForLocale(documentLang.split('-')[0])) {
+        return documentLang;
+    }
+};
+
+/**
  * The default configuration
  * @see dateTimePickerFactory
  */
 var defaultConfig = {
     setup: 'date',
     controlButtons: false,
-    locale: false,
+    locale: getDefaultLocale(),
     useLocalizedFormat: false,
     constraints: {}
 };
@@ -334,7 +355,7 @@ export default function dateTimePickerFactory(container, options) {
             var setup = setups[this.config.setup] || setups.datetime;
 
             //map the locale from the options to the picker locale
-            if (this.config.locale && _.isObject(flatpickrLocalization.default[this.config.locale])) {
+            if (this.config.locale && hasTranslationsForLocale(this.config.locale)) {
                 locale = this.config.locale;
             }
 

--- a/src/datetime/scss/picker.scss
+++ b/src/datetime/scss/picker.scss
@@ -75,6 +75,7 @@ $picker-field-height: 37px;
                     }
                 }
                 .cur-year {
+                    padding: 0 0 0 0.5ch;
                     height: $picker-field-height;
                 }
             }

--- a/src/datetime/scss/picker.scss
+++ b/src/datetime/scss/picker.scss
@@ -179,4 +179,9 @@ $picker-field-height: 37px;
             }
         }
     }
+
+    > input.flatpickr-input.flatpickr-input.flatpickr-input {
+        padding: 4px;
+        min-width: 130px;
+    }
 }


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NCC-63
**Description:** Provide default `locale` value to the [flatpickr](https://flatpickr.js.org/localization/) instance from document `lang` attribute (**'default'** value used as a fallback)
Fix calendar missalignment by predefined input presentation minimum width.
Enhance `flatpickr` selectors and set back library styles which are overridden by TAO table styles
**Unit tests cli:** `npm run test`
