### PR TITLE
Fix/ACTP-224/Translate english text on spanish interface

### DIFF
--- a/src/bulkActionPopup/tpl/layout.tpl
+++ b/src/bulkActionPopup/tpl/layout.tpl
@@ -5,13 +5,13 @@
         {{#if single}}
     <div class="single" data-resource="{{allowedResources.0.id}}">
         <p>
-            {{__ "The action will be applied to"}} {{resourceType}} <span class="resource-label">{{allowedResources.0.label}}</span>
+            {{__ "The action will be applied to"}} {{__ resourceType}} <span class="resource-label">{{allowedResources.0.label}}</span>
         </p>
     </div>
         {{else}}
     <div class="multiple">
         <p>
-            {{__ "The action will be applied to the following"}} <span class="resource-count">{{resourceCount}}</span> {{resourceTypes}}:
+            {{__ "The action will be applied to the following"}} <span class="resource-count">{{resourceCount}}</span> {{__ resourceTypes}}:
         </p>
         <ul class="plain applicables">
             {{#each allowedResources}}
@@ -28,12 +28,12 @@
         {{#if singleDenied}}
     <div class="single" data-resource="{{deniedResources.0.id}}">
         <p>
-            {{__ "The action will not be applied to "}} {{resourceType}} <span class="resource-label">{{deniedResources.0.label}}</span>
+            {{__ "The action will not be applied to "}} {{__ resourceType}} <span class="resource-label">{{deniedResources.0.label}}</span>
         </p>
     </div>
         {{else}}
     <p>
-        {{__ "The action will not be applied to the following"}} {{resourceTypes}}:
+        {{__ "The action will not be applied to the following"}} {{__ resourceTypes}}:
     </p>
     <ul class="plain no-applicables">
             {{#each deniedResources}}


### PR DESCRIPTION
Related to: [https://oat-sa.atlassian.net/browse/ACTP-224](https://oat-sa.atlassian.net/browse/ACTP-224)

Use translation function for the next variables: **resourceType** and **resourceTypes**.
Translations to the related words (**session** and **sessions**) added in the **tao** extension (es-MX).

#### How to test
 
Precondition:
* Change proctor language interface to `Mexican Spanish`;
* You need to have some test-takers on proctor screen;
* Use the following command to update translations: `php tao/scripts/taoUpdate.php`.

Log in as proctor.
On the proctor screen select one or multiple test-takers and try to authorize/terminate them.
You will see a model with list of test-takers that will be processed (or not) during this action.

Requires :
 - [ ] https://github.com/oat-sa/tao-core/pull/2393