### PR TITLE
ACTP-312 Add accessibility compatibility to login errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_feedback.scss
+++ b/scss/inc/_feedback.scss
@@ -33,6 +33,9 @@
         }
         &.icon-close {
             right: 7px;
+            background: none;
+            padding: 0px;
+            height: auto;
         }
     }
     &.popup {

--- a/scss/inc/_feedback.scss
+++ b/scss/inc/_feedback.scss
@@ -33,9 +33,6 @@
         }
         &.icon-close {
             right: 7px;
-            background: none;
-            padding: 0px;
-            height: auto;
         }
     }
     &.popup {

--- a/src/feedback/feedback.tpl
+++ b/src/feedback/feedback.tpl
@@ -1,7 +1,9 @@
-<div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}">
+<div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}"
+     role="dialog" aria-describedby="{{dompurify msg}}" >
     <span class="icon-{{level}}"></span>
-    <div>
+    <div aria-live="{{dompurify msg}}">
         {{{dompurify msg}}}
     </div>
-    <span title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback"></span>
+    <button title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback"
+            aria-label="{{__ 'Close message'}}"></button>
 </div>

--- a/src/feedback/feedback.tpl
+++ b/src/feedback/feedback.tpl
@@ -1,6 +1,6 @@
 <div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}" role="alert" >
     <span class="icon-{{level}}"></span>
-    <div aria-live="assertive">
+    <div>
         {{{dompurify msg}}}
     </div>
     <span title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback" role="button" tabindex="0"></span>

--- a/src/feedback/feedback.tpl
+++ b/src/feedback/feedback.tpl
@@ -1,6 +1,6 @@
 <div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}" role="alert" >
     <span class="icon-{{level}}"></span>
-    <div aria-live="assertive" aria-label="{{{dompurify msg}}}">
+    <div aria-live="assertive">
         {{{dompurify msg}}}
     </div>
     <span title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback" role="button" tabindex="0"></span>

--- a/src/feedback/feedback.tpl
+++ b/src/feedback/feedback.tpl
@@ -1,9 +1,7 @@
-<div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}"
-     role="dialog" aria-describedby="{{dompurify msg}}" >
+<div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}" role="alert" >
     <span class="icon-{{level}}"></span>
-    <div aria-live="{{dompurify msg}}">
+    <div aria-live="assertive" aria-label="{{{dompurify msg}}}">
         {{{dompurify msg}}}
     </div>
-    <button title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback"
-            aria-label="{{__ 'Close message'}}"></button>
+    <span title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback" role="button" tabindex="0"></span>
 </div>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-312

Add accessibility compatibility to login errors

**How to test:**
- checkout /tao-core-ui-fe repo
- switch to branch `feature/ACTP-312/add-accessibility-compatibility-to-login-errors`
- go to repo directory and run `npm link`
- go to your TAO installation directory
- go to path `tao/views` subdir
- run `npm link @oat-sa/tao-core-ui-fe`
- go to path `tao/view/build` subdir
- run `npm install` to install depencies
- run `npx grunt sass:tao` to build styles
- open TAO login url and try to enter wrong data for show the error message
- check shown popup for accessibility compatibility

**Related documents**
https://oat-sa.atlassian.net/wiki/spaces/OP/pages/203096620/Investigate+Pages+in+TestRunner+on+Screen+Reader+Access+and+Navigation+LOG+IN+INDEX+PROCTOR#InvestigatePagesinTestRunneronScreenReaderAccessandNavigation(LOGIN,INDEX,PROCTOR)-Addaccessibilitycompatibilitytologinerrors
