### PR TITLE
Fix/ncc 63/capitalise days and months naming in the calendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/datetime/scss/picker.scss
+++ b/src/datetime/scss/picker.scss
@@ -56,6 +56,10 @@ $picker-field-height: 37px;
             width: inherit;
         }
 
+        .flatpickr-weekday {
+            text-transform: capitalize;
+        }
+
         .numInputWrapper {
             height: $picker-field-height;
         }
@@ -68,6 +72,7 @@ $picker-field-height: 37px;
                 height: $picker-field-height;
                 line-height: $picker-field-height;
                 .cur-month {
+                    text-transform: capitalize;
                     margin: 0 0.5ch;
 
                     & :hover {


### PR DESCRIPTION
**Related to task:**   https://oat-sa.atlassian.net/browse/NCC-63
**Description:**  For some languages text in the calendar in lowercase
The bugfix is displaying days and months naming in the same format for all languages in calendar
**Unit tests visual:**

Before | After
------------ | -------------
![Screenshot 2020-02-18 at 17 11 50](https://user-images.githubusercontent.com/6339002/74754690-4aa07300-5272-11ea-8190-3ad9fbd1b9d8.png) | ![Screenshot 2020-02-18 at 17 10 58](https://user-images.githubusercontent.com/6339002/74754696-4d02cd00-5272-11ea-9eb9-e2f9222439ef.png)

**How to test:**  `tao-core` version for testing https://github.com/oat-sa/tao-core/pull/2401