### PR TITLE
Release 0.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1922,9 +1922,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.360",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.360.tgz",
-            "integrity": "sha512-RE1pv2sjQiDRRN1nI0fJ0eQHZ9le4oobu16OArnwEUV5ycAU5SNjFyvzjZ1gPUAqBa2Ud1XagtW8j3ZXfHuQHA==",
+            "version": "1.3.361",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.361.tgz",
+            "integrity": "sha512-OzSVjWpsRhJyr9PSAXkeloSe6e9viU2ToGt1wXlXFsGcxuI9vlsnalL+V/AM59Z2pEo3wRxIddtOGsT7Y6x/sQ==",
             "dev": true
         },
         "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/feedback/feedback.tpl
+++ b/src/feedback/feedback.tpl
@@ -1,7 +1,7 @@
-<div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}">
+<div id="{{id}}" class="feedback feedback-{{level}} {{#if popup}}popup{{/if}}" role="alert" >
     <span class="icon-{{level}}"></span>
     <div>
         {{{dompurify msg}}}
     </div>
-    <span title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback"></span>
+    <span title="{{__ 'Close message'}}" class="icon-close" data-close=":parent .feedback" role="button" tabindex="0"></span>
 </div>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-312

Add accessibility compatibility to login errors

**How to test:**
- checkout /tao-core-ui-fe repo
- switch to branch `feature/ACTP-312/add-accessibility-compatibility-to-login-errors`
- go to repo directory and run `npm link`
- go to your TAO installation directory
- go to path `tao/views` subdir
- run `npm link @oat-sa/tao-core-ui-fe`
- go to path `tao/view/build` subdir
- run `npm install` to install depencies
- run `npx grunt sass:tao` to build styles
- open TAO login url and try to enter wrong data for show the error message
- check shown popup for accessibility compatibility

**Related documents**
https://oat-sa.atlassian.net/wiki/spaces/OP/pages/203096620/Investigate+Pages+in+TestRunner+on+Screen+Reader+Access+and+Navigation+LOG+IN+INDEX+PROCTOR#InvestigatePagesinTestRunneronScreenReaderAccessandNavigation(LOGIN,INDEX,PROCTOR)-Addaccessibilitycompatibilitytologinerrors
