### PR TITLE
[ACTP-355] "Show password" button is not correctly announced by NVDA when activated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -176,7 +176,7 @@ export default function loginFactory($container, config) {
                 $pwdInput.focus();
             };
 
-            var hide = function hide() {
+            var hide = function hide(moveFocus) {
                 $hideIcon.hide();
                 $viewIcon.show();
 
@@ -184,6 +184,10 @@ export default function loginFactory($container, config) {
                 $pwdInput.autocomplete = self.isAutocompleteDisabled() ? 'off' : 'on';
 
                 window.removeEventListener('mousedown', autoHide);
+
+                if (moveFocus) {
+                    $pwdInput.focus();
+                }
             };
 
             $form = this.getForm();
@@ -199,7 +203,7 @@ export default function loginFactory($container, config) {
                 if ($pwdInput.type === 'password') {
                     show();
                 } else {
-                    hide();
+                    hide(true);
                 }
             });
 
@@ -208,7 +212,7 @@ export default function loginFactory($container, config) {
                     if ($pwdInput.type === 'password') {
                         show();
                     } else {
-                        hide();
+                        hide(true);
                     }
                 }
             });

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -198,10 +198,8 @@ export default function loginFactory($container, config) {
             $inputToggle.on('click', function() {
                 if ($pwdInput.type === 'password') {
                     show();
-                    $inputToggle.attr('aria-checked', 'true');
                 } else {
                     hide();
-                    $inputToggle.attr('aria-checked', 'false');
                 }
             });
 
@@ -209,10 +207,8 @@ export default function loginFactory($container, config) {
                 if (e.key === ' ') {
                     if ($pwdInput.type === 'password') {
                         show();
-                        $inputToggle.attr('aria-checked', 'true');
                     } else {
                         hide();
-                        $inputToggle.attr('aria-checked', 'false');
                     }
                 }
             });

--- a/src/login/tpl/login.tpl
+++ b/src/login/tpl/login.tpl
@@ -7,7 +7,7 @@
         <div>
             <label class="form_desc" for="login">
                 {{__ "Login"}}
-            </label><input type="text" name="login" id="login" {{#unless disableAutofocus}}autofocus="autofocus"{{/unless}} {{#if disableAutocomplete}} autocomplete="off"{{/if}}>
+            </label><input type="text" name="login" id="login" {{#unless disableAutofocus}}autofocus="autofocus"{{/unless}} {{#if disableAutocomplete}} autocomplete="off"{{/if}} aria-required="true">
             {{#if fieldMessages.login}}
                 <div class="form-error">
                     {{fieldMessages.login}}
@@ -17,7 +17,7 @@
         <div>
             <label class="form_desc" for="password">
                 {{__ "Password"}}
-            </label><input type="password" name="password" id="password"{{#if disableAutocomplete}} autocomplete="off"{{/if}}>
+            </label><input type="password" name="password" id="password"{{#if disableAutocomplete}} autocomplete="off"{{/if}} aria-required="true">
             {{#if fieldMessages.password}}
                 <div class="form-error">
                     {{fieldMessages.login}}

--- a/src/login/tpl/passwordReveal.tpl
+++ b/src/login/tpl/passwordReveal.tpl
@@ -1,7 +1,7 @@
 <span class="viewable-hiddenbox">
     {{{elements}}}
-    <span aria-label="Show password" aria-checked="false" class="viewable-hiddenbox-toggle" role="switch" tabindex="0">
-        <span class="icon-preview"></span>
-        <span class="icon-eye-slash" style="display: none;"></span>
+    <span class="viewable-hiddenbox-toggle">
+        <span aria-label="{{__ "Show password"}}" class="icon-preview" role="button" tabindex="0"></span>
+        <span aria-label="{{__ "Hide password"}}" class="icon-eye-slash" style="display: none;" role="button" tabindex="0"></span>
     </span>
 </span>

--- a/test/login/test.js
+++ b/test/login/test.js
@@ -158,7 +158,7 @@ define(['jquery', 'ui/login/login'], function($, loginFactory) {
         var ready = assert.async();
         var $container = $('#qunit-fixture');
 
-        assert.expect(6);
+        assert.expect(7);
 
         assert.equal($('.login-component', $container).length, 0, 'No resource tree in the container');
 
@@ -174,9 +174,14 @@ define(['jquery', 'ui/login/login'], function($, loginFactory) {
                 'The component has the password reveal button'
             );
             assert.equal(
-                $('.viewable-hiddenbox-toggle', $element).attr('tabindex'),
+                $('.icon-preview', $element).attr('tabindex'),
                 0,
-                'Password reveal button can be accessed from keyboard'
+                'Show password button can be accessed from keyboard'
+            );
+            assert.equal(
+                $('.icon-eye-slash', $element).attr('tabindex'),
+                0,
+                'Hide password button can be accessed from keyboard'
             );
             assert.equal(
                 $('.viewable-hiddenbox-toggle span.icon-preview', $element).is(':visible'),
@@ -244,7 +249,7 @@ define(['jquery', 'ui/login/login'], function($, loginFactory) {
         var ready = assert.async();
         var $container = $('#qunit-fixture');
 
-        assert.expect(9);
+        assert.expect(10);
 
         assert.equal($('.login-component', $container).length, 0, 'No resource tree in the container');
 
@@ -282,9 +287,14 @@ define(['jquery', 'ui/login/login'], function($, loginFactory) {
                 'The component has the password reveal button'
             );
             assert.equal(
-                $('.viewable-hiddenbox-toggle', $container).attr('tabindex'),
+                $('.icon-preview', $container).attr('tabindex'),
                 0,
-                'Password reveal button can be accessed from keyboard'
+                'Show password button can be accessed from keyboard'
+            );
+            assert.equal(
+                $('.icon-eye-slash', $container).attr('tabindex'),
+                0,
+                'Hide password button can be accessed from keyboard'
             );
             assert.equal(
                 $('.viewable-hiddenbox-toggle span.icon-preview', $container).is(':visible'),


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/ACTP-355
 
Change show password control role to button. Add aria required attribute to login form fields 
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- navigate to login page
- check that NVDA correctly announce show password button
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1328
 - [ ] https://github.com/oat-sa/tao-core/pull/2418