### PR TITLE
Fix/udi 73/autocomplete scroll dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "0.29.3",
+    "version": "0.29.4",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2015-2020 (original work) Open Assessment Technologies SA ;
  */
 /**
  * Wraps a jQuery autocomplete plugin inside a component.

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -307,7 +307,7 @@ var autocompleter = {
                 self.on(name.substr(2), value);
             } else {
                 // not a component option, forward it to the plugin instance
-                options[name] = value;
+                pluginOptions[name] = value;
             }
         });
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/UDI-73
Related to: 
https://github.com/oat-sa/extension-tao-dac-simple/pull/110
https://github.com/oat-sa/tao-core/pull/2434

Fix forwarding not a component `option` to the `pluginOptions`

How to test:
1. Login
2. Navigate to either Items/Access Control or Tests/Access Control
3. Make sure Users and Roles are populated to the point where they get their own scrollbar
4. Search for users/roles and wait for the results dropdown to show
5. Scroll the parent page (not the scrollbars incorporated in the page)
6. The result dropdown should move with the search field.