### PR TITLE
Feature BSA-147 resource/selector addClass - Add class to classSelector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/resource/selector.js
+++ b/src/resource/selector.js
@@ -105,7 +105,7 @@ var defaultConfig = {
 var filterClasses = function filterClasses(resources) {
     return _(resources)
         .filter({ type: nodeTypes.class })
-        .map(function(resource) {
+        .map(function (resource) {
             var classNode = _.pick(resource, ['uri', 'label', 'state']);
 
             if (resource.children) {
@@ -178,10 +178,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     if (this.filtersComponent) {
                         this.filtersComponent.reset();
                     }
-                    $searchField
-                        .val('')
-                        .attr('title', null)
-                        .attr('placeholder', this.config.searchPlaceholder);
+                    $searchField.val('').attr('title', null).attr('placeholder', this.config.searchPlaceholder);
                 }
             }
             return this.trigger('reset');
@@ -283,7 +280,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
         changeFormat: function changeFormat(format) {
             var $viewFormat;
             if (this.is('rendered') && this.format !== format) {
-                $viewFormat = $viewFormats.filter('[data-view-format="' + format + '"]');
+                $viewFormat = $viewFormats.filter(`[data-view-format="${format}"]`);
                 if ($viewFormat.length === 1 && !$viewFormat.hasClass('active')) {
                     $viewFormats.removeClass('active');
                     $viewFormat.addClass('active');
@@ -354,7 +351,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 if (!_.isFunction(componentFactory)) {
                     return this.trigger(
                         'error',
-                        new TypeError('Unable to load the component for the format ' + this.format)
+                        new TypeError(`Unable to load the component for the format ${this.format}`)
                     );
                 }
 
@@ -375,19 +372,19 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                             this.config
                         )
                     )
-                        .on('query', function(queryParams) {
+                        .on('query', function (queryParams) {
                             self.query(queryParams);
                         })
-                        .on('update', function() {
+                        .on('update', function () {
                             if (_.size(this.getNodes()) === 0 && $('li', $resultArea).length === 0) {
                                 hider.show($noResults);
                             }
                             self.trigger('update');
                         })
-                        .on('change', function(selected, onlyVisible) {
+                        .on('change', function (selected, onlyVisible) {
                             self.trigger('change', selected, onlyVisible);
                         })
-                        .on('error', function(err) {
+                        .on('error', function (err) {
                             self.trigger('error', err);
                         });
                 } else {
@@ -466,6 +463,29 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
         },
 
         /**
+         * Add class to classSelector, no update of selectionComponent
+         *
+         * @param {Object} node - the node to add
+         * @param {String} node.uri
+         * @param {String} node.label
+         * @param {String} [node.type=class] - instance or class
+         * @param {String} parentUri - where to append the new node
+         * @returns {resourceSelector} chains
+         */
+        addClass: function addClass(node, parentUri) {
+            if (this.is('rendered') && node && node.uri && this.classSelector) {
+                if (!this.classSelector.hasNode(node.uri) && this.classSelector.hasNode(parentUri)) {
+                    if (!node.type) {
+                        node.type = nodeTypes.class;
+                    }
+                    //update the class selector
+                    this.classSelector.addNode(node, parentUri);
+                }
+            }
+            return this;
+        },
+
+        /**
          * Does the given node exists ?
          *
          * @param {Object|String} node - the node or directly the URI
@@ -515,7 +535,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 }
                 this.selectionComponent.select(uri);
 
-                $('[data-uri="' + uri + '"]', $resultArea)[0].scrollIntoView({ behavior: 'smooth' });
+                $(`[data-uri="${uri}"]`, $resultArea)[0].scrollIntoView({ behavior: 'smooth' });
             }
             return this;
         },
@@ -535,9 +555,9 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 if (this.hasNode(node)) {
                     this.select(node);
                 } else if (fallback !== false) {
-                    $resource = this.getElement().find('.' + nodeTypes.instance);
+                    $resource = this.getElement().find(`.${nodeTypes.instance}`);
                     if (!$resource.length) {
-                        $resource = this.getElement().find('.' + nodeTypes.class);
+                        $resource = this.getElement().find(`.${nodeTypes.class}`);
                     }
                     if ($resource.length) {
                         this.select($resource.first().data('uri'));
@@ -559,7 +579,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 updateClasses: true
             };
             if (this.is('rendered')) {
-                this.on('update.refresh', function() {
+                this.on('update.refresh', function () {
                     this.off('update.refresh');
                     this.selectDefaultNode(node);
                 });
@@ -578,7 +598,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
      */
     var resourceSelector = component(resourceSelectorApi, defaultConfig)
         .setTemplate(selectorTpl)
-        .on('init', function() {
+        .on('init', function () {
             this.searchQuery = {};
             this.classUri = this.config.classUri;
             this.format = this.config.format || _.findKey(this.config.formats, { active: true });
@@ -588,11 +608,11 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
 
             this.render($container);
         })
-        .on('render', function() {
+        .on('render', function () {
             var self = this;
 
             //we ensure the sub-components are rendered
-            return new Promise(function(resolve) {
+            return new Promise(function (resolve) {
                 var $component = self.getElement();
 
                 $classContainer = $('.class-context', $component);
@@ -610,40 +630,31 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 //the search field
                 $searchField.on(
                     'keyup',
-                    _.debounce(function(e) {
-                        var value = $(this)
-                            .val()
-                            .trim();
+                    _.debounce(function (e) {
+                        var value = $(this).val().trim();
                         if (value.length > 2 || value.length === 0 || e.which === 13) {
                             if (self.config.filters) {
                                 //reset the placeholder
-                                $(this)
-                                    .attr('title', null)
-                                    .attr('placeholder', self.config.searchPlaceholder);
+                                $(this).attr('title', null).attr('placeholder', self.config.searchPlaceholder);
                             }
-                            self.empty()
-                                .changeFormat('list')
-                                .setSearchQuery(value)
-                                .query();
+                            self.empty().changeFormat('list').setSearchQuery(value).query();
                         }
                     }, 300)
                 );
 
                 //the format switcher
-                $viewFormats.on('click', function(e) {
+                $viewFormats.on('click', function (e) {
                     var $target = $(this);
                     var format = $target.data('view-format');
                     e.preventDefault();
 
-                    self.reset()
-                        .changeFormat(format)
-                        .query();
+                    self.reset().changeFormat(format).query();
                 });
 
                 //mode switcher (multiple/single)
                 if (self.config.selectionMode === selectionModes.both) {
                     //click the toggler
-                    $selectionToggle.on('click', function(e) {
+                    $selectionToggle.on('click', function (e) {
                         e.preventDefault();
                         self.changeSelectionMode(
                             self.config.multiple ? selectionModes.single : selectionModes.multiple
@@ -651,20 +662,20 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     });
 
                     //CTRL-Click
-                    $resultArea.on('mousedown', function(e) {
+                    $resultArea.on('mousedown', function (e) {
                         if (e.ctrlKey && !self.config.multiple) {
                             self.changeSelectionMode(selectionModes.multiple);
                         }
                     });
 
                     //switch back to sinlge
-                    $resultArea.on('click', function() {
+                    $resultArea.on('click', function () {
                         self.changeSelectionMode(selectionModes.single);
                     });
                 }
 
                 //the select all control
-                $selectCtrl.on('change', function() {
+                $selectCtrl.on('change', function () {
                     if ($(this).prop('checked') === false) {
                         self.selectionComponent.clearSelection();
                     } else if (self.config.selectAllPolicy === selectAllPolicies.visible) {
@@ -679,23 +690,17 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     self.filtersComponent = filtersFactory($filterContainer, {
                         classUri: self.classUri,
                         data: self.config.filters
-                    }).on('change', function(values) {
+                    }).on('change', function (values) {
                         var textualQuery = this.getTextualQuery();
 
-                        $searchField
-                            .val('')
-                            .attr('title', textualQuery)
-                            .attr('placeholder', textualQuery);
+                        $searchField.val('').attr('title', textualQuery).attr('placeholder', textualQuery);
 
-                        self.empty()
-                            .changeFormat('list')
-                            .setSearchQuery(values)
-                            .query();
+                        self.empty().changeFormat('list').setSearchQuery(values).query();
 
                         $filterContainer.addClass('folded');
                     });
 
-                    $filterToggle.on('click', function(e) {
+                    $filterToggle.on('click', function (e) {
                         var searchVal;
                         e.preventDefault();
 
@@ -714,7 +719,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
 
                 //initialize the class selector
                 self.classSelector = classesSelectorFactory($classContainer, self.config);
-                self.classSelector.on('render', resolve).on('change', function(uri) {
+                self.classSelector.on('render', resolve).on('change', function (uri) {
                     if (uri && uri !== self.classUri) {
                         self.classUri = uri;
 
@@ -737,7 +742,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 self.query();
             });
         })
-        .on('change', function(selected, onlyVisible) {
+        .on('change', function (selected, onlyVisible) {
             var selectedCount = _.size(selected);
             var nodesCount = onlyVisible ? selectedCount : _.size(this.selectionComponent.getNodes());
 
@@ -758,7 +763,7 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
             }
         });
 
-    _.defer(function() {
+    _.defer(function () {
         resourceSelector.init(config);
     });
     return resourceSelector;

--- a/src/resource/selector.js
+++ b/src/resource/selector.js
@@ -134,7 +134,10 @@ var filterClasses = function filterClasses(resources) {
  * @param {Boolean} [config.showSelection = true] - show the selection bar (search, multi switch and select all)
  * @returns {resourceSelector} the component
  */
-var resourceSelectorFactory = function resourceSelectorFactory($container, config) {
+var resourceSelectorFactory = function resourceSelectorFactory(
+    $container,
+    config
+) {
     var $classContainer;
     var $resultArea;
     var $noResults;
@@ -178,7 +181,10 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     if (this.filtersComponent) {
                         this.filtersComponent.reset();
                     }
-                    $searchField.val('').attr('title', null).attr('placeholder', this.config.searchPlaceholder);
+                    $searchField
+                        .val('')
+                        .attr('title', null)
+                        .attr('placeholder', this.config.searchPlaceholder);
                 }
             }
             return this.trigger('reset');
@@ -280,8 +286,13 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
         changeFormat: function changeFormat(format) {
             var $viewFormat;
             if (this.is('rendered') && this.format !== format) {
-                $viewFormat = $viewFormats.filter(`[data-view-format="${format}"]`);
-                if ($viewFormat.length === 1 && !$viewFormat.hasClass('active')) {
+                $viewFormat = $viewFormats.filter(
+                    `[data-view-format="${format}"]`
+                );
+                if (
+                    $viewFormat.length === 1 &&
+                    !$viewFormat.hasClass('active')
+                ) {
                     $viewFormats.removeClass('active');
                     $viewFormat.addClass('active');
 
@@ -306,13 +317,20 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
          * @returns {resourceSelector} chains
          */
         changeSelectionMode: function changeSelectionMode(newMode) {
-            if (this.is('rendered') && this.config.selectionMode !== newMode && selectionModes[newMode]) {
+            if (
+                this.is('rendered') &&
+                this.config.selectionMode !== newMode &&
+                selectionModes[newMode]
+            ) {
                 if (this.config.multiple) {
                     this.clearSelection();
                 }
 
                 this.config.multiple = newMode === selectionModes.multiple;
-                this.selectionComponent.setState('multiple', this.config.multiple);
+                this.selectionComponent.setState(
+                    'multiple',
+                    this.config.multiple
+                );
                 this.setState('multiple', this.config.multiple);
 
                 if (this.config.multiple) {
@@ -347,11 +365,14 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
 
             if (this.is('rendered') && this.format) {
                 componentFactory =
-                    this.config.formats[this.format] && this.config.formats[this.format].componentFactory;
+                    this.config.formats[this.format] &&
+                    this.config.formats[this.format].componentFactory;
                 if (!_.isFunction(componentFactory)) {
                     return this.trigger(
                         'error',
-                        new TypeError(`Unable to load the component for the format ${this.format}`)
+                        new TypeError(
+                            `Unable to load the component for the format ${this.format}`
+                        )
                     );
                 }
 
@@ -376,7 +397,10 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                             self.query(queryParams);
                         })
                         .on('update', function () {
-                            if (_.size(this.getNodes()) === 0 && $('li', $resultArea).length === 0) {
+                            if (
+                                _.size(this.getNodes()) === 0 &&
+                                $('li', $resultArea).length === 0
+                            ) {
                                 hider.show($noResults);
                             }
                             self.trigger('update');
@@ -402,7 +426,11 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
          * @returns {resourceSelector} chains
          */
         updateFilters: function updateFilters(filterConfig) {
-            if (this.is('rendered') && filterConfig !== false && this.filtersComponent) {
+            if (
+                this.is('rendered') &&
+                filterConfig !== false &&
+                this.filtersComponent
+            ) {
                 this.filtersComponent.update(filterConfig);
             }
             return this;
@@ -419,7 +447,10 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
             var uri = _.isString(node) ? node : node.uri;
             if (this.hasNode(uri)) {
                 //update the class selector
-                if (this.getNodeType(node) === nodeTypes.class && this.classSelector) {
+                if (
+                    this.getNodeType(node) === nodeTypes.class &&
+                    this.classSelector
+                ) {
                     this.classSelector.removeNode(node);
                 }
 
@@ -439,7 +470,12 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
          * @returns {resourceSelector} chains
          */
         addNode: function addNode(node, parentUri) {
-            if (this.is('rendered') && node && node.uri && this.selectionComponent) {
+            if (
+                this.is('rendered') &&
+                node &&
+                node.uri &&
+                this.selectionComponent
+            ) {
                 if (!this.selectionComponent.hasNode(node.uri)) {
                     if (!node.type) {
                         node.type = nodeTypes.instance;
@@ -450,11 +486,15 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                         classUri: parentUri || this.classUri,
                         format: this.format,
                         limit: this.config.limit,
-                        updateCount: node.type === nodeTypes.instance ? 1 : false
+                        updateCount:
+                            node.type === nodeTypes.instance ? 1 : false
                     });
 
                     //update the class selector
-                    if (this.getNodeType(node) === nodeTypes.class && this.classSelector) {
+                    if (
+                        this.getNodeType(node) === nodeTypes.class &&
+                        this.classSelector
+                    ) {
                         this.classSelector.addNode(node, parentUri);
                     }
                 }
@@ -473,7 +513,10 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
          */
         addClassNode: function addClassNode(node, parentUri) {
             if (this.is('rendered') && node && node.uri && this.classSelector) {
-                if (!this.classSelector.hasNode(node.uri) && this.classSelector.hasNode(parentUri)) {
+                if (
+                    !this.classSelector.hasNode(node.uri) &&
+                    this.classSelector.hasNode(parentUri)
+                ) {
                     //add node to the class selector
                     this.classSelector.addNode(node, parentUri);
                 }
@@ -531,7 +574,9 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 }
                 this.selectionComponent.select(uri);
 
-                $(`[data-uri="${uri}"]`, $resultArea)[0].scrollIntoView({ behavior: 'smooth' });
+                $(`[data-uri="${uri}"]`, $resultArea)[0].scrollIntoView({
+                    behavior: 'smooth'
+                });
             }
             return this;
         },
@@ -551,9 +596,13 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 if (this.hasNode(node)) {
                     this.select(node);
                 } else if (fallback !== false) {
-                    $resource = this.getElement().find(`.${nodeTypes.instance}`);
+                    $resource = this.getElement().find(
+                        `.${nodeTypes.instance}`
+                    );
                     if (!$resource.length) {
-                        $resource = this.getElement().find(`.${nodeTypes.class}`);
+                        $resource = this.getElement().find(
+                            `.${nodeTypes.class}`
+                        );
                     }
                     if ($resource.length) {
                         this.select($resource.first().data('uri'));
@@ -597,9 +646,13 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
         .on('init', function () {
             this.searchQuery = {};
             this.classUri = this.config.classUri;
-            this.format = this.config.format || _.findKey(this.config.formats, { active: true });
-            this.config.switchMode = this.config.selectionMode === selectionModes.both;
-            this.config.multiple = this.config.selectionMode === selectionModes.multiple;
+            this.format =
+                this.config.format ||
+                _.findKey(this.config.formats, { active: true });
+            this.config.switchMode =
+                this.config.selectionMode === selectionModes.both;
+            this.config.multiple =
+                this.config.selectionMode === selectionModes.multiple;
             this.setState('multiple', this.config.multiple);
 
             this.render($container);
@@ -628,12 +681,24 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     'keyup',
                     _.debounce(function (e) {
                         var value = $(this).val().trim();
-                        if (value.length > 2 || value.length === 0 || e.which === 13) {
+                        if (
+                            value.length > 2 ||
+                            value.length === 0 ||
+                            e.which === 13
+                        ) {
                             if (self.config.filters) {
                                 //reset the placeholder
-                                $(this).attr('title', null).attr('placeholder', self.config.searchPlaceholder);
+                                $(this)
+                                    .attr('title', null)
+                                    .attr(
+                                        'placeholder',
+                                        self.config.searchPlaceholder
+                                    );
                             }
-                            self.empty().changeFormat('list').setSearchQuery(value).query();
+                            self.empty()
+                                .changeFormat('list')
+                                .setSearchQuery(value)
+                                .query();
                         }
                     }, 300)
                 );
@@ -653,7 +718,9 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     $selectionToggle.on('click', function (e) {
                         e.preventDefault();
                         self.changeSelectionMode(
-                            self.config.multiple ? selectionModes.single : selectionModes.multiple
+                            self.config.multiple
+                                ? selectionModes.single
+                                : selectionModes.multiple
                         );
                     });
 
@@ -674,9 +741,14 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 $selectCtrl.on('change', function () {
                     if ($(this).prop('checked') === false) {
                         self.selectionComponent.clearSelection();
-                    } else if (self.config.selectAllPolicy === selectAllPolicies.visible) {
+                    } else if (
+                        self.config.selectAllPolicy ===
+                        selectAllPolicies.visible
+                    ) {
                         self.selectionComponent.selectVisible();
-                    } else if (self.config.selectAllPolicy === selectAllPolicies.loaded) {
+                    } else if (
+                        self.config.selectAllPolicy === selectAllPolicies.loaded
+                    ) {
                         self.selectionComponent.selectAll();
                     }
                 });
@@ -689,9 +761,15 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                     }).on('change', function (values) {
                         var textualQuery = this.getTextualQuery();
 
-                        $searchField.val('').attr('title', textualQuery).attr('placeholder', textualQuery);
+                        $searchField
+                            .val('')
+                            .attr('title', textualQuery)
+                            .attr('placeholder', textualQuery);
 
-                        self.empty().changeFormat('list').setSearchQuery(values).query();
+                        self.empty()
+                            .changeFormat('list')
+                            .setSearchQuery(values)
+                            .query();
 
                         $filterContainer.addClass('folded');
                     });
@@ -704,7 +782,10 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                             //if a value is in the search field, we add it to the label
                             searchVal = $searchField.val().trim();
                             if (!_.isEmpty(searchVal)) {
-                                self.filtersComponent.setValue(labelUri, searchVal);
+                                self.filtersComponent.setValue(
+                                    labelUri,
+                                    searchVal
+                                );
                             }
                             $filterContainer.removeClass('folded');
                         } else {
@@ -714,47 +795,60 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
                 }
 
                 //initialize the class selector
-                self.classSelector = classesSelectorFactory($classContainer, self.config);
-                self.classSelector.on('render', resolve).on('change', function (uri) {
-                    if (uri && uri !== self.classUri) {
-                        self.classUri = uri;
+                self.classSelector = classesSelectorFactory(
+                    $classContainer,
+                    self.config
+                );
+                self.classSelector
+                    .on('render', resolve)
+                    .on('change', function (uri) {
+                        if (uri && uri !== self.classUri) {
+                            self.classUri = uri;
 
-                        //close the filters
-                        if ($filterContainer.length) {
-                            $filterContainer.addClass('folded');
+                            //close the filters
+                            if ($filterContainer.length) {
+                                $filterContainer.addClass('folded');
+                            }
+
+                            /**
+                             * When the component's root class URI changes
+                             * @event resourceSelector#classchange
+                             * @param {String} classUri - the new class URI
+                             */
+                            self.trigger('classchange', uri);
+
+                            self.reset().query();
                         }
-
-                        /**
-                         * When the component's root class URI changes
-                         * @event resourceSelector#classchange
-                         * @param {String} classUri - the new class URI
-                         */
-                        self.trigger('classchange', uri);
-
-                        self.reset().query();
-                    }
-                });
+                    });
 
                 self.query();
             });
         })
         .on('change', function (selected, onlyVisible) {
             var selectedCount = _.size(selected);
-            var nodesCount = onlyVisible ? selectedCount : _.size(this.selectionComponent.getNodes());
+            var nodesCount = onlyVisible
+                ? selectedCount
+                : _.size(this.selectionComponent.getNodes());
 
             //the number selected at the bottom
             $selectNum.text(selectedCount);
 
             //update the state of the "Select All" checkbox
             if (selectedCount === 0) {
-                $selectCtrlLabel.attr('title', __('Select loaded %s', this.config.type));
+                $selectCtrlLabel.attr(
+                    'title',
+                    __('Select loaded %s', this.config.type)
+                );
                 $selectCtrl.prop('checked', false).prop('indeterminate', false);
                 // if all of the nodes are selected (or more in the closed subclasses)
             } else if (selectedCount >= nodesCount) {
                 $selectCtrlLabel.attr('title', __('Clear selection'));
                 $selectCtrl.prop('checked', true).prop('indeterminate', false);
             } else {
-                $selectCtrlLabel.attr('title', __('Select loaded %s', this.config.type));
+                $selectCtrlLabel.attr(
+                    'title',
+                    __('Select loaded %s', this.config.type)
+                );
                 $selectCtrl.prop('checked', false).prop('indeterminate', true);
             }
         });

--- a/src/resource/selector.js
+++ b/src/resource/selector.js
@@ -465,20 +465,16 @@ var resourceSelectorFactory = function resourceSelectorFactory($container, confi
         /**
          * Add class to classSelector, no update of selectionComponent
          *
-         * @param {Object} node - the node to add
+         * @param {Object} node - the class node to add
          * @param {String} node.uri
          * @param {String} node.label
-         * @param {String} [node.type=class] - instance or class
          * @param {String} parentUri - where to append the new node
          * @returns {resourceSelector} chains
          */
-        addClass: function addClass(node, parentUri) {
+        addClassNode: function addClassNode(node, parentUri) {
             if (this.is('rendered') && node && node.uri && this.classSelector) {
                 if (!this.classSelector.hasNode(node.uri) && this.classSelector.hasNode(parentUri)) {
-                    if (!node.type) {
-                        node.type = nodeTypes.class;
-                    }
-                    //update the class selector
+                    //add node to the class selector
                     this.classSelector.addNode(node, parentUri);
                 }
             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/BSA-147
Related to: https://github.com/oat-sa/extension-tao-testqti/pull/1828

Was added a new function `addClass` in `resource/selector`.

There are two slow ajax requests on the test authoring page.
`/taoQtiTest/Items/getItemClasses` and `/taoQtiTest/Items/getItems`
Goal:
`getItems` goes at the same time or before `getItemClasses`

In the current implementation, we can't add Node to classSelector if it not presented in selectionComponent. Need an additional function to add classes to classSelector after selectionComponent is rendered.

How to test:

1. go to Items
2. create subclasses 3 and more levels
3. go to Tests
4. open devTools, tab Network
5. open test Authoring
6. see request `getItems`  goes at the same time as `getItemClasses`
7. check classSelector, tree of classes should be loaded
![image](https://user-images.githubusercontent.com/25976342/84515660-70480100-acd5-11ea-80d3-27bb0695d82c.png)


