### PR TITLE
Fix UNO-339 don't highlight internal select2's input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -14,7 +14,7 @@ textarea {
     &:focus {
         outline: none;
     }
-    &:not(.error):focus {
+    &:not(.error):not(.select2-input):focus {
         @include focus-style;
     }
 }
@@ -539,7 +539,7 @@ label {
 
         }
         h3 {
-            margin: 0px 0px 12px;
+            margin: 0 0 12px;
         }
     }
 


### PR DESCRIPTION
Uncovered while working on [UNO-339](https://oat-sa.atlassian.net/browse/UNO-339).

The internal `select2` input should never have borders.

### Example:
![image](https://user-images.githubusercontent.com/2943256/84742495-cb694480-afb0-11ea-9603-ad0163435697.png)
