### PR TITLE
Fix TAO 10122 - IE11 graphic gap interaction when navigate to question since response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.5.1",
+    "version": "1.5.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -71,6 +71,8 @@ interactHelper = {
      */
     tapOn: function tapOn(element, cb, delay) {
         var domElement,
+            firstEvent,
+            secondEvent,
             eventOptions = {
                 bubbles: true,
                 pointerId: 1,
@@ -83,8 +85,6 @@ interactHelper = {
         if (element) {
             domElement = element instanceof $ ? element.get(0) : element;
 
-            var firstEvent;
-            var secondEvent;
             if (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0) {
                 firstEvent = document.createEvent('HTMLEvents');
                 firstEvent.initEvent('pointerdown', false, true);
@@ -92,7 +92,7 @@ interactHelper = {
                 secondEvent.initEvent('pointerup', false, true);
             } else {
                 firstEvent = new PointerEvent('pointerdown', eventOptions);
-                secondEvent = new PointerEvent('pointerup', eventOptions)
+                secondEvent = new PointerEvent('pointerup', eventOptions);
             }
             domElement.dispatchEvent(firstEvent);
             domElement.dispatchEvent(secondEvent);

--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -84,8 +84,19 @@ interactHelper = {
         if (element) {
             domElement = element instanceof $ ? element.get(0) : element;
 
-            triggerCustomEvent(domElement, 'CustomEvent', eventOptions);
-            triggerCustomEvent(domElement, 'CustomEvent', eventOptions);
+            var firstEvent;
+            var secondEvent;
+            if (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0) {
+                firstEvent = document.createEvent('HTMLEvents');
+                firstEvent.initEvent('pointerdown', false, true);
+                secondEvent = document.createEvent('HTMLEvents');
+                secondEvent.initEvent('pointerup', false, true);
+            } else {
+                firstEvent = new PointerEvent('pointerdown', eventOptions);
+                secondEvent = new PointerEvent('pointerup', eventOptions)
+            }
+            domElement.dispatchEvent(firstEvent);
+            domElement.dispatchEvent(secondEvent);
 
             if (cb) {
                 _.delay(cb, delay || 0);

--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -24,6 +24,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import interact from 'interact';
 import 'core/mouseEvent';
+import triggerCustomEvent from '@oat-sa/tao-core-sdk/src/core/customEvent';
 
 var interactHelper, simulateDrop;
 
@@ -74,8 +75,8 @@ interactHelper = {
             eventOptions = {
                 bubbles: true,
                 pointerId: 1,
-                bubbles: true, 
-                cancelable: true, 
+                bubbles: true,
+                cancelable: true,
                 pointerType: "touch",
                 width: 100,
                 height: 100,
@@ -84,8 +85,8 @@ interactHelper = {
         if (element) {
             domElement = element instanceof $ ? element.get(0) : element;
 
-            domElement.dispatchEvent(new PointerEvent('pointerdown', eventOptions));
-            domElement.dispatchEvent(new PointerEvent('pointerup', eventOptions));
+            triggerCustomEvent(domElement, 'pointerdown', new PointerEvent('pointerdown', eventOptions));
+            triggerCustomEvent(domElement, 'pointerup', new PointerEvent('pointerup', eventOptions));
 
             if (cb) {
                 _.delay(cb, delay || 0);

--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -24,7 +24,6 @@ import $ from 'jquery';
 import _ from 'lodash';
 import interact from 'interact';
 import 'core/mouseEvent';
-import triggerCustomEvent from '@oat-sa/tao-core-sdk/src/core/customEvent';
 
 var interactHelper, simulateDrop;
 

--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -75,9 +75,8 @@ interactHelper = {
             eventOptions = {
                 bubbles: true,
                 pointerId: 1,
-                bubbles: true,
                 cancelable: true,
-                pointerType: "touch",
+                pointerType: 'touch',
                 width: 100,
                 height: 100,
                 isPrimary: true
@@ -85,8 +84,8 @@ interactHelper = {
         if (element) {
             domElement = element instanceof $ ? element.get(0) : element;
 
-            triggerCustomEvent(domElement, 'pointerdown', new PointerEvent('pointerdown', eventOptions));
-            triggerCustomEvent(domElement, 'pointerup', new PointerEvent('pointerup', eventOptions));
+            triggerCustomEvent(domElement, 'CustomEvent', eventOptions);
+            triggerCustomEvent(domElement, 'CustomEvent', eventOptions);
 
             if (cb) {
                 _.delay(cb, delay || 0);


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/TAO-10122

**Description**

InternetExplorer: Have created a Graphic Gap interactions with images and matched them in response
When I do different actions with functionality, at some point, I can't seem to edit the size of the "Gap match slots" 
I am not experiencing the same problems in f.eks Chrome

Workaround: Click outside the interaction and try again

**How to test it**

- Add graphic 'Gap match' interaction to the canvas in the Internet Explorer browser
- Select a file and click 'Select'
- Click the "Plus in circle" icon
- Select `file` and click 'Select' 
- Click 'Response' and set the added picture to the gap 
-  Click 'Question' and find media sizer in the Interaction properties panel

**Experienced Behavior**

The interaction properties panel is missing.

**Expected Behavior**

The interaction properties panel is displayed as soon as 'Question' is clicked in interaction.