### PR TITLE
Release 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/keyNavigation/navigableDomElement.js
+++ b/src/keyNavigation/navigableDomElement.js
@@ -132,7 +132,11 @@ export default function navigableDomElement(element) {
                     (e, key) => {
                         const $target = $(e.target);
                         if (!isInput($target)) {
-                            if (!$target.is('img') && !$target.hasClass('key-navigation-scrollable')) {
+                            if (!$target.is('img') &&
+                                !$target.hasClass('key-navigation-scrollable') &&
+                                !($target.hasClass('key-navigation-scrollable-up') && (key === 'up' || key === 'left')) &&
+                                !($target.hasClass('key-navigation-scrollable-down') && (key === 'down' || key === 'right'))
+                            ) {
                                 // prevent scrolling of parent element
                                 e.preventDefault();
                             }
@@ -147,8 +151,10 @@ export default function navigableDomElement(element) {
                     'enter',
                     e => {
                         if (!isInput($(e.target))) {
-                            //prevent activating the element when typing a text
-                            e.preventDefault();
+                            if (!e.target.classList.contains('key-navigation-actionable')) {
+                                //prevent activating the element when typing a text
+                                e.preventDefault();
+                            }
                             keyboard('enter', e.target);
                         }
                     },


### PR DESCRIPTION
Version 1.5.0

**Release notes :**
- [feature] [TCA-634](https://oat-sa.atlassian.net/browse/TCA-634)

Add more possibilities to allow browser native behavior on keyboard navigable elements:
- the CSS class `key-navigation-scrollable-up` avoid preventing the `up` and `left` key to apply
- the CSS class `key-navigation-scrollable-down` avoid preventing the `down` and `right` key to apply
- the CSS class `key-navigation-actionable` avoid preventing the `enter` key to apply

Please see the companion PR for more info: https://github.com/oat-sa/tao-test-runner-qti-fe/pull/266

https://github.com/oat-sa/tao-core-ui-fe/pull/144