### PR TITLE
Release 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -279,7 +279,8 @@ export default function loginFactory($container, config) {
                 this.hide();
                 this.getElement()
                     .find('form')
-                    .attr('id', 'loginForm');
+                    .attr('id', 'loginForm')
+                    .attr('aria-hidden', 'true');
                 this.getContainer().prepend($fakeForm);
 
                 // submit the form when the user hit the submit button inside the fake form


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-668
 
Add `aria-hidden` attribute to hidden login form
  
#### How to test

- prepare an instance of TAO with taoAct extension
- navigate to login page
- make sure that on hidden form there is `aria-hidden` attribute
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/<EXT>/pull/<ID>