### PR TITLE
UNO 401 - Proper search text box validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -342,7 +342,7 @@ input[type="password"].viewable-hiddenbox-input {
         }
     }
 
-    + .form-error {
+    & + .form-error {
         color: $error;
         text-align: right;
     }

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -342,7 +342,13 @@ input[type="password"].viewable-hiddenbox-input {
         }
     }
 
-    & + .form-error {
+    &.error {
+        .select2-choices {
+            border-color: $error;
+        }
+    }
+
+    + .form-error {
         color: $error;
         text-align: right;
     }

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -343,8 +343,10 @@ input[type="password"].viewable-hiddenbox-input {
     }
 
     &.error {
-        .select2-choices {
-            border-color: $error;
+        .select2-container {
+            > :first-child {
+                border-color: $error;
+            }
         }
     }
 


### PR DESCRIPTION
**FE fix for this PR**

https://github.com/oat-sa/tao-core/pull/2591

**Related to**

[UNO-401](https://oat-sa.atlassian.net/browse/UNO-401)

**Description**

Now search text box extends `MultipleElement` class and overrides `getRawData`, that returns list to the validator instead of one value. Also, PSR improvements applied.

**Steps to reproduce**

- Create a new Item or a test property via Manage Schema on a directory
- Set the property's type to List – Multiple choice – Search input
- Set the property's list relation
- Set the property Validation Rules to `notEmpty`
- Add a new item/test
- Add a few values to the input
- Try saving the item/test

**Expected**

The item/test is saved without any errors

**Experienced**

This field is required validation error appears next to the field

**Suggested solution**

class.Searchtextbox.php should inherit the class.MultipleElement.php and implement the following method.

```
public function getRawValue()
{
    return $this->values;
}
```