### PR TITLE
fix status message on single terminated session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/bulkActionPopup/tpl/layout.tpl
+++ b/src/bulkActionPopup/tpl/layout.tpl
@@ -23,12 +23,14 @@
     </div>
         {{/if}}
     {{/if}}
-    
+
     {{#if deniedResources.length}}
         {{#if singleDenied}}
     <div class="single" data-resource="{{deniedResources.0.id}}">
         <p>
-            {{__ "The action will not be applied to "}} {{resourceType}} <span class="resource-label">{{deniedResources.0.label}}</span>
+            {{__ "The action will not be applied to "}} {{resourceType}}
+            <span class="resource-label">{{deniedResources.0.label}}</span>
+            <span class="reason">({{deniedResources.0.reason}})</span>
         </p>
     </div>
         {{else}}
@@ -45,7 +47,7 @@
     </ul>
         {{/if}}
     {{/if}}
-    
+
     {{#if reason}}
     <div class="reason">
         <p>
@@ -66,10 +68,10 @@
             {{message}}
         </div>
     {{/if}}
-    
+
     <div class="actions">
         <button class="btn btn-info small done">{{__ "OK"}}</button>
         <a href="#" class="btn cancel" title="{{__ "cancel the action"}}">{{__ "cancel"}}</a>
     </div>
-    
+
 </div>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-726
 
Fix message status for disallowed terminated session on proctor screen.
  
#### How to test

- open 2 sessions via LTI
- terminate 1 session
- select and try to terminate both session - active and terminated
- check the error status on already terminated session
 
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/tao-core/pull/2641