### PR TITLE
Fix TAO 10464 - Uncaught type error upon dragging the Media Interaction on canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/mediasizer.js
+++ b/src/mediasizer.js
@@ -553,7 +553,7 @@ MediaSizer = {
 
             // compatibility layer naturalWidth|Height vs. naturalHeight
             // internally width/height are used
-            options.width = options.width || options.naturalWidth || defaults.size;
+            options.width = options.width || options.naturalWidth || options.maxWidth || defaults.size;
             options.height = options.height || options.naturalHeight || defaults.size;
             options.naturalWidth = options.naturalWidth || options.width || defaults.size;
             options.naturalHeight = options.naturalHeight || options.height || defaults.size;

--- a/src/mediasizer.js
+++ b/src/mediasizer.js
@@ -53,7 +53,8 @@ var defaults = {
     responsive: true,
     showResponsiveToggle: true,
     showReset: true,
-    showSync: true
+    showSync: true,
+    size: 100
 };
 
 /**
@@ -552,10 +553,10 @@ MediaSizer = {
 
             // compatibility layer naturalWidth|Height vs. naturalHeight
             // internally width/height are used
-            options.width = options.width || options.naturalWidth || 100;
-            options.height = options.height || options.naturalHeight || 100;
-            options.naturalWidth = options.naturalWidth || options.width || 100;
-            options.naturalHeight = options.naturalHeight || options.height || 100;
+            options.width = options.width || options.naturalWidth || defaults.size;
+            options.height = options.height || options.naturalHeight || defaults.size;
+            options.naturalWidth = options.naturalWidth || options.width || defaults.size;
+            options.naturalHeight = options.naturalHeight || options.height || defaults.size;
 
             options.hasSize =
                 options.width && options.height && _.isFinite(+options.width) && _.isFinite(+options.height);

--- a/src/mediasizer.js
+++ b/src/mediasizer.js
@@ -558,8 +558,7 @@ MediaSizer = {
             options.naturalWidth = options.naturalWidth || options.width || defaults.size;
             options.naturalHeight = options.naturalHeight || options.height || defaults.size;
 
-            options.hasSize =
-                options.width && options.height && _.isFinite(+options.width) && _.isFinite(+options.height);
+            options.hasSize = _.isFinite(+options.width) && _.isFinite(+options.height);
 
             // incomplete or conflicting configurations
             // no target provided, also no width and/or no height

--- a/src/mediasizer.js
+++ b/src/mediasizer.js
@@ -552,10 +552,10 @@ MediaSizer = {
 
             // compatibility layer naturalWidth|Height vs. naturalHeight
             // internally width/height are used
-            options.width = options.width || options.naturalWidth;
-            options.height = options.height || options.naturalHeight;
-            options.naturalWidth = options.naturalWidth || options.width;
-            options.naturalHeight = options.naturalHeight || options.height;
+            options.width = options.width || options.naturalWidth || 100;
+            options.height = options.height || options.naturalHeight || 100;
+            options.naturalWidth = options.naturalWidth || options.width || 100;
+            options.naturalHeight = options.naturalHeight || options.height || 100;
 
             options.hasSize =
                 options.width && options.height && _.isFinite(+options.width) && _.isFinite(+options.height);


### PR DESCRIPTION
**Related to this issue**

https://oat-sa.atlassian.net/browse/TAO-10464

**Description**

When the user drags the Media Interaction on the canvas, there's no file selection window opens. Instead 'Uncaught type error' appears on the browser console and the widow opens only after clicking empty space outside the interaction and clicking it again.

**Steps to reproduce**

- Go to the Items tab.
- Create a new item and go to Authoring.
- Drag and drop Media Interaction on the canvas.

**Actual result**

Error in console, the file selection window is not opened.

**Expected result**

The file selection window shows up without any errors.