### PR TITLE
Fix MS 334 - Item author cant scroll sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_select2.scss
+++ b/scss/inc/_select2.scss
@@ -25,7 +25,6 @@
 .select2-container {
 
     margin: 0;
-    position: relative;
     display: inline-block;
     /* inline-block for ie7 */
     zoom: 1;
@@ -53,7 +52,6 @@
     height: 26px;
     padding: 0 0 0 8px;
     overflow: hidden;
-    position: relative;
 
     @include simple-border();
     @include border-radius(1);

--- a/scss/inc/_select2.scss
+++ b/scss/inc/_select2.scss
@@ -511,7 +511,7 @@ disabled look for disabled choices in the results dropdown
     user-select: none;
 
     background-color: blacken($uiClickableDefaultBg, .1);
-    
+
     &.partial {
         background-color: whiten($uiClickableDefaultBg, .6);
     }
@@ -588,7 +588,7 @@ disabled look for disabled choices in the results dropdown
     margin: 0 !important;
     padding: 0 !important;
     overflow: hidden !important;
-    position: absolute !important;
+    position: fixed !important;
     outline: 0 !important;
     left: 0px !important;
     top: 0px !important;


### PR DESCRIPTION
**Description**

When user creates an item, go to response and want to scroll down right side bar to add new outcome f.e. - he is not able to do that (with and without mouse). The issue reproduces on screens less than 17'. Workaround is to zoom out by clicking 'ctrl' + '' on Windows and 'cmd' + '' on Mac.

**Steps to reproduce**

1. Login as admin
2. Go to Items tab
3. Create a new item and go to Authoring mode
4. Add Choice interaction to the canvas and go to response
5. Add new Outcome, click 'pencil' icon to edit and try to scroll down

**Actual result:** user is not able to scroll down.
**Expected result:** user is able to scroll down.
**Workaround:** zoom out by clicking "ctrl" + "-" (Windows).