### PR TITLE
Feature/uno 197/dropdown should show status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/class/scss/selector.scss
+++ b/src/class/scss/selector.scss
@@ -34,6 +34,12 @@
         }
     }
 
+    a.open {
+        &:after {
+            @include icon-up;
+        }
+    }
+
     .options {
 
         position: absolute;

--- a/src/class/selector.js
+++ b/src/class/selector.js
@@ -295,6 +295,7 @@ export default function classesSelectorFactory($container, config) {
 
             $selected.on('click', function(e) {
                 e.preventDefault();
+                $selected.toggleClass('open');
                 $options.toggleClass('folded');
             });
 


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/UNO-197

**Description**

  UDIR Description provided:

- Have created a test
- When I'm adding items
- When I select the drop down for the structure
    --> it is a bit hard to see that this is the choice have done.
- This is maybe because the arrow for the drop down is behaving different than other similar choices where this is illustrated by the arrow. 
- This is a suggestion that may need some analysis. 

Should I be able to "go out" of the choice by clicking outside it, at least I then get out of something I don't understand I have done
Or maybe the arrow  should be ">" before opening it, and pointing down when it has been selected. (or both)

**How to reproduce**

- Go to the “Test” page
- Click “New test” and then go to authoring tab
- Click the arrow at the left under “Select items“ text to open drop-down menu 
- Observe the menu and click out of the menu

**Experienced Behavior**

The behavior of this drop-down menu is different from behavior’s all other drop-down menus all over the site. Drop-down list doesn’t go right from drop-down menu(there is a space between drop-down-menu and drop-down-list) and clicking outside the drop-down list doesn't close down the list(how it happens with all other drop-down menus on the site). Because of these thing, it's not quite clear that drop-down menu is open
Expected Behavior

(should be discussed) It's not a bug, it's an improvement.

**Suggestions for improvement**

- Clicking outside the drop-down menu closes down the list (how it happens with all other drop-down menus on the site).

- When the menu is close the arrow has one position(“up”) and when the menu is open the arrow change the position(“down“) - but then it should be implemented in all drop-downs on the site