### PR TITLE
Fix UNO 588 - Item author cant scroll sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_select2.scss
+++ b/scss/inc/_select2.scss
@@ -25,6 +25,7 @@
 .select2-container {
 
     margin: 0;
+    position: relative;
     display: inline-block;
     /* inline-block for ie7 */
     zoom: 1;


### PR DESCRIPTION
**Related to this PR**

https://github.com/oat-sa/tao-core-ui-fe/pull/165

**Related to this issues**

https://oat-sa.atlassian.net/browse/CGA-138

https://oat-sa.atlassian.net/browse/UNO-588

**Description**

When user creates an item, go to response and want to scroll down right side bar to add new outcome f.e. - he is not able to do that (with and without mouse). The issue reproduces on screens less than 17'. Workaround is to zoom out by clicking 'ctrl' + '' on Windows and 'cmd' + '' on Mac.

**Steps to reproduce**

- Login as admin
- Go to Items tab
- Create a new item and go to Authoring mode
- Add Choice interaction to the canvas and go to response
- Add new Outcome, click 'pencil' icon to edit and try to scroll down

**Actual result**

User is not able to scroll down.

**Expected result**

User is able to scroll down.

**Workaround**

Zoom out by clicking "ctrl" + "-" (Windows).