### PR TITLE
[Fix] TAO 10087 - Import button does not become disabled when user removes file which is uploaded for importing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -386,6 +386,7 @@ var uploader = {
 
         options.$uploadBtn.prop('disabled', true);
         options.$resetBtn.prop('disabled', true);
+        options.$form[0][9].setAttribute('disabled', true);
 
         if (options.$progressBar) {
             options.$progressBar

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -386,7 +386,11 @@ var uploader = {
 
         options.$uploadBtn.prop('disabled', true);
         options.$resetBtn.prop('disabled', true);
-        options.$form[0][9].setAttribute('disabled', true);
+
+        var importButton = options.$form[0].querySelector('button');
+        if (importButton) {
+            importButton.setAttribute('disabled', true);
+        }
 
         if (options.$progressBar) {
             options.$progressBar

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -387,7 +387,7 @@ var uploader = {
         options.$uploadBtn.prop('disabled', true);
         options.$resetBtn.prop('disabled', true);
 
-        var importButton = options.$form[0].querySelector('button');
+        const importButton = options.$form[0].querySelector('button');
         if (importButton) {
             importButton.setAttribute('disabled', true);
         }


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/TAO-10087

**Description**

When user is trying to Import any kind of file (item, test, media etc.) he has to upload it first by pressing Browse and choosing necessary file. After the file is uploaded, it can be imported by pressing Import button.

The issue is when user removes uploaded file by clicking Cross icon in the upper right corner of uploading window, the Import button remains active and it is still possible to import it.

**Steps to reproduce**

- Go to Media tab (for example).
- Select class and press Import.
- In Import window choose import format (f.e. File).
- Click 'Browse...', select any file and click 'Open'.
- Wait until file will be uploaded and click Cross icon in the upper right corner of uploading window.

**Actual result**

Uploading window is empty, Import button is active. File still can be imported.

**Expected result**

Uploading window is empty, Import button is active. User cannot import removed file.
