### PR TITLE
[UNO-492] Error when selecting root when assets is loading 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.10.4",
+    "version": "1.10.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.10.4",
+    "version": "1.10.5",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -11,11 +11,12 @@ export default function(options) {
     var $divContainer = $('.' + root, $fileBrowser);
     var $folderContainer = $('.folders', $divContainer);
     var fileTree = {};
-    //create the tree node for the ROOT folder by default
-    $folderContainer.append('<li class="root"><a class="root-folder" href="#"></a></li>');
 
     //load the content of the ROOT
     getFolderContent(fileTree, path, function(content) {
+        //create the tree node for the ROOT folder by default once the initial content loaded
+        $folderContainer.append('<li class="root"><a class="root-folder" href="#"></a></li>');
+
         var $rootNode = $('.root-folder', $folderContainer);
         //create an inner list and append found elements
         var $innerList = $('<ul></ul>').insertAfter($rootNode);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/UNO-492
 
Do not add root element until initial load of assets finished
  
#### How to test

- navigate to assets tab
- create a new passage
- navigate to authoring for this passage
- try to add an image
- while content not loaded there should be no folders in navigation tree
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/tao-core/pull/2695