### PR TITLE
Fix/tao 10561/improve management of private classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.10.4",
+    "version": "1.10.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.10.4",
+    "version": "1.10.5",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -173,7 +173,7 @@ export default function searchModalFactory(config) {
      */
     function manageClassTreePermissions(classTree) {
         const disableBlockedClasses = function (resources) {
-            resources.forEach((resource, index, array) => {
+            _.forEach(resources, (resource, index, array) => {
                 if (
                     classTree.permissions.data[resource.uri] &&
                     classTree.permissions.data[resource.uri].find(permission => permission === 'READ')

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -132,7 +132,11 @@ export default function searchModalFactory(config) {
                 const route = urlUtil.route('getAll', 'RestResource', 'tao');
                 request(route, classOnlyParams)
                     .then(response => {
-                        if (response.permissions.supportedRights && response.permissions.supportedRights.length > 0) {
+                        if (
+                            response.permissions &&
+                            response.permissions.supportedRights &&
+                            response.permissions.supportedRights.length > 0
+                        ) {
                             manageClassTreePermissions(response);
                         }
                         resourceSelector.update(response.resources, classOnlyParams);
@@ -169,7 +173,10 @@ export default function searchModalFactory(config) {
     function manageClassTreePermissions(classTree) {
         const disableBlockedClasses = function (resources) {
             resources.forEach((resource, index, array) => {
-                if (classTree.permissions.data[resource.uri].find(permission => permission === 'READ')) {
+                if (
+                    classTree.permissions.data[resource.uri] &&
+                    classTree.permissions.data[resource.uri].find(permission => permission === 'READ')
+                ) {
                     if (resource.children) {
                         disableBlockedClasses(resource.children);
                     }

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -134,6 +134,7 @@ export default function searchModalFactory(config) {
                     .then(response => {
                         if (
                             response.permissions &&
+                            response.permissions.data &&
                             response.permissions.supportedRights &&
                             response.permissions.supportedRights.length > 0
                         ) {

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -231,7 +231,7 @@ $classTreeVariables: (
     height: 100% !important;
     padding: 0px !important;
     .navi-container {
-        display: flex;
+        display: flex !important;
         flex-direction: column;
         justify-content: space-between;
         padding: 40px 20px 20px 20px;

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -96,7 +96,7 @@ $classTreeVariables: (
         }
     }
 
-    .navi-container {
+    .ui-container {
         display: none;
         background: $canvas;
         @include simple-flex-box($treeSidebar * 1px);
@@ -230,8 +230,8 @@ $classTreeVariables: (
 .search-modal {
     height: 100% !important;
     padding: 0px !important;
-    .navi-container {
-        display: flex !important;
+    .ui-container {
+        display: flex;
         flex-direction: column;
         justify-content: space-between;
         padding: 40px 20px 20px 20px;

--- a/src/searchModal/tpl/layout.tpl
+++ b/src/searchModal/tpl/layout.tpl
@@ -1,6 +1,6 @@
 <div class="search-modal section-container">
     <div class="clear content-wrapper content-panel">
-        <div class="navi-container">
+        <div class="ui-container">
             <div class="filters-container">
                 <div class="filter-container">
                     <span class="icon-find"></span>

--- a/test/searchModal/mocks/mocks.json
+++ b/test/searchModal/mocks/mocks.json
@@ -43,5 +43,54 @@
             }
         },
         "version": "3.4.0-sprint135"
+    },
+    "mockedClassTreeWithPermissions": {
+        "success": true,
+        "data": {
+            "resources": [
+                {
+                    "label": "Item",
+                    "type": "class",
+                    "uri": "http://www.tao.lu/Ontologies/TAOItem.rdf#Item",
+                    "classUri": null,
+                    "signature": "dc36445fa73ce3b87d63a0073cc6fadc4802b434da0ff69352105624f091060e",
+                    "state": "open",
+                    "count": 0,
+                    "children": [
+                        {
+                            "label": "QTI Interactions",
+                            "type": "class",
+                            "uri": "https://tao0.docker.localhost/ontologies/tao.rdf#i5f71ac09abde474b5fa37ef76d2415d",
+                            "classUri": "http://www.tao.lu/Ontologies/TAOItem.rdf#Item",
+                            "signature": "f08b300e7757cef1d61177e38565eff31ef918c3f99c0fb3610ce03f559b4374",
+                            "state": "closed",
+                            "count": 0
+                        },
+                        {
+                            "label": "private0",
+                            "type": "class",
+                            "uri": "https://tao0.docker.localhost/ontologies/tao.rdf#i5f743e3ee869d685f55538dbd01531",
+                            "classUri": "http://www.tao.lu/Ontologies/TAOItem.rdf#Item",
+                            "signature": "573e3f191e0aad0b3dd409253750e26bbd120dfe41b2a3c2ac5f7cde3db6414f",
+                            "state": false,
+                            "count": 0
+                        }
+                    ]
+                }
+            ],
+            "permissions": {
+                "supportedRights": ["GRANT", "WRITE", "READ"],
+                "data": {
+                    "http://www.tao.lu/Ontologies/TAOItem.rdf#Item": ["GRANT", "READ", "WRITE"],
+                    "https://tao0.docker.localhost/ontologies/tao.rdf#i5f71ac09abde474b5fa37ef76d2415d": [
+                        "GRANT",
+                        "READ",
+                        "WRITE"
+                    ],
+                    "https://tao0.docker.localhost/ontologies/tao.rdf#i5f743e3ee869d685f55538dbd01531": []
+                }
+            }
+        },
+        "version": "3.4.0-sprint135"
     }
 }

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -271,6 +271,24 @@ define([
             ready();
         });
     });
+    QUnit.test('class filter disables private classes', function (assert) {
+        const ready = assert.async();
+        $.mockjax.handler(0).responseText = mocks.mockedClassTreeWithPermissions;
+        assert.expect(1);
+        const instance = searchModalFactory({
+            criterias: { search: 'example' },
+            url: '/test/searchModal/mocks/with-occurrences/search.json',
+            renderTo: '#testable-container',
+            rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item'
+        });
+
+        instance.on('ready', function () {
+            assert.equal($('.resource-tree').find('[data-access="denied"]').length, 1, 'private class is disabled');
+            instance.destroy();
+            ready();
+            $.mockjax.handler(0).responseText = mocks.mockedClassTree;
+        });
+    });
 
     QUnit.module('searchStore');
     QUnit.test('searchStore saves all required information', function (assert) {


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TAO-10561

**Description**
If `taoDacSimple` extension is installed users should not be able to read classes or items with no read access. Although this was working, there was no visual indication of private classes. Now, if received class tree contains the `supportedRights` array, property `accessMode` is set to `denied` on classes with no `read` permission, so they are rendered as disabled nodes by `tree` component. 

Also item previewing was causing a style issue by setting `.navi-container` to `display:none`. This is fixed so a 
 `.navi-container` inside of a `.search-modal` always has `display: flex`.

![access-control-pr](https://user-images.githubusercontent.com/14041944/94786319-19c01900-03d1-11eb-8d18-f4cfd089afab.gif)