### PR TITLE
Feature/CON-12/Create confirmDelete dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/component/scss/components.scss
+++ b/src/component/scss/components.scss
@@ -290,6 +290,12 @@ ul.listbox {
                 }
             }
         }
+        input[type="checkbox"] {
+            &:focus ~ [class^="icon-"],
+            &:focus ~ [class*=" icon-"] {
+                outline: 3px solid $actionLinkColor;
+            }
+        }
     }
 
     &[class^="icon-"], &[class*=" icon-"] { // supports any TAO icon

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -458,7 +458,7 @@ const dialog = {
                     if (!$elt.is(':radio,:checkbox')) {
                         $elt.click();
                     } else {
-                        $elt.prop('checked', !$elt.prop('checked'));
+                        $elt.prop('checked', !$elt.prop('checked')).change();
                     }
                 }, 10)
                 );

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -426,10 +426,16 @@ const dialog = {
                 propagateTab: false
             })
                 .on('right down', function() {
-                    this.next();
+                    if (this.getCursor().position === $items.length - 1) {
+                        this.setCursorAt(1);  // Skip container.
+                    } else {
+                        this.next();
+                    }
                 })
                 .on('left up', function() {
-                    if (this.getCursor().position > 1) { // Skip container.
+                    if (this.getCursor().position === 1) {  // Skip container.
+                        this.last();
+                    } else {
                         this.previous();
                     }
                 })
@@ -447,14 +453,15 @@ const dialog = {
                         this.previous();
                     }
                 })
-                .on('activate', function(cursor) {
+                .on('activate', _.debounce(function(cursor) {
                     const $elt = cursor.navigable.getElement();
                     if (!$elt.is(':radio,:checkbox')) {
                         $elt.click();
                     } else {
                         $elt.prop('checked', !$elt.prop('checked'));
                     }
-                });
+                }, 10)
+                );
             this.navigator.first();
             //added a global shortcut to enable setting focus on tab
             this.globalShortcut = shortcutRegistry($('body')).add('tab shift+tab', () => {

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -412,6 +412,7 @@ const dialog = {
                     }
                 });
             const $items = this.getDom()
+                .add($(_scope).find('input'))
                 .add(this.$buttons.find('button'));
             const closeButton = $(_scope).find('#modal-close-btn')[0];
 
@@ -447,7 +448,12 @@ const dialog = {
                     }
                 })
                 .on('activate', function(cursor) {
-                    cursor.navigable.getElement().click();
+                    const $elt = cursor.navigable.getElement();
+                    if (!$elt.is(':radio,:checkbox')) {
+                        $elt.click();
+                    } else {
+                        $elt.prop('checked', !$elt.prop('checked'));
+                    }
                 });
             this.navigator.first();
             //added a global shortcut to enable setting focus on tab

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -21,7 +21,7 @@
 import _ from 'lodash';
 import __ from 'i18n';
 import dialog from 'ui/dialog';
-import checkBoxTpl from 'ui/dialog/tpl/checkBox.tpl';
+import checkBoxTpl from 'ui/dialog/tpl/checkBox';
 
 /**
  * Displays a confirm message

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -65,7 +65,7 @@ export default function dialogConfirm(message, accept, refuse, options) {
             delete: {
                 id: 'delete',
                 type: 'info',
-                label: options.buttons.labels.ok || _options.buttons.labels.delete,
+                label: options.buttons.labels.delete || _options.buttons.labels.delete,
                 close: true
             },
             cancel: {

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -1,0 +1,96 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Hanna Dzmitryieva <hanna@taotesting.com>
+ */
+import _ from 'lodash';
+import __ from 'i18n';
+import dialog from 'ui/dialog';
+import checkBoxTpl from 'ui/dialog/tpl/checkBox';
+
+/**
+ * Displays a confirm message
+ * @param {String} message - The displayed message
+ * @param {Function} accept - An action called when the message is accepted
+ * @param {Function} refuse - An action called when the message is refused
+ * @param {Object} options - Dialog options
+ * @param {Object} options.confirmationMessage - "I understand that this action is permanent." message
+ * @param {Object} options.buttons - Dialog button options
+ * @param {Object} options.buttons.labels - Dialog button labels
+ * @param {String} options.buttons.labels.delete - "Delete" button label
+ * @param {String} options.buttons.labels.cancel - "Cancel" button label
+ * @returns {dialog} - Returns the dialog instance
+ */
+export default function dialogConfirm(message, accept, refuse, options) {
+    var accepted = false;
+    var _options = {
+        buttons: {
+            labels: {
+                delete: __('Delete'),
+                cancel: __('Cancel')
+            }
+        },
+        confirmationMessage: __('I understand that this action is permanent.')
+    };
+    var dialogOptions;
+    var dlg;
+    options = _.defaults(options || {}, _options);
+    dialogOptions = {
+        message: message,
+        content: checkBoxTpl({id: 'confirm', checked: false, text: options.confirmationMessage}),
+        autoRender: true,
+        autoDestroy: true,
+        onDeleteBtn: function() {
+            accepted = true;
+            if (_.isFunction(accept)) {
+                accept.call(this);
+            }
+        },
+        buttons: {
+            delete: {
+                id: 'delete',
+                type: 'info',
+                label: options.buttons.labels.ok || _options.buttons.labels.delete,
+                close: true
+            },
+            cancel: {
+                id: 'cancel',
+                type: 'regular',
+                label: options.buttons.labels.cancel || _options.buttons.labels.cancel,
+                close: true
+            }
+        }
+    };
+    dlg = dialog(dialogOptions);
+
+    const $html = dlg.getDom();
+    const $deleteButton = $html.find('[data-control="delete"]');
+    $deleteButton.prop('disabled', true);
+    $html.find('#confirm').on('change', function() {
+        $deleteButton.prop('disabled', !this.checked);
+    });
+
+    if (_.isFunction(refuse)) {
+        dlg.on('closed.modal', function() {
+            if (!accepted) {
+                refuse.call(this);
+            }
+        });
+    }
+    return dlg;
+}

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Hanna Dzmitryieva <hanna@taotesting.com>
@@ -36,21 +36,20 @@ import checkBoxTpl from 'ui/dialog/tpl/checkbox';
  * @param {String} options.buttons.labels.cancel - "Cancel" button label
  * @returns {dialog} - Returns the dialog instance
  */
+const defaults = {
+    buttons: {
+        labels: {
+            delete: __('Delete'),
+            cancel: __('Cancel')
+        }
+    },
+    confirmationMessage: __('I understand that this action is permanent.')
+};
+
 export default function dialogConfirm(message, accept, refuse, options) {
-    var accepted = false;
-    var _options = {
-        buttons: {
-            labels: {
-                delete: __('Delete'),
-                cancel: __('Cancel')
-            }
-        },
-        confirmationMessage: __('I understand that this action is permanent.')
-    };
-    var dialogOptions;
-    var dlg;
-    options = _.defaults(options || {}, _options);
-    dialogOptions = {
+    let accepted = false;
+    options = _.defaults(options || {}, defaults);
+    const dialogOptions = {
         message: message,
         content: checkBoxTpl({id: 'confirm', checked: false, text: options.confirmationMessage}),
         autoRender: true,
@@ -65,18 +64,18 @@ export default function dialogConfirm(message, accept, refuse, options) {
             delete: {
                 id: 'delete',
                 type: 'info',
-                label: options.buttons.labels.delete || _options.buttons.labels.delete,
+                label: options.buttons.labels.delete || defaults.buttons.labels.delete,
                 close: true
             },
             cancel: {
                 id: 'cancel',
                 type: 'regular',
-                label: options.buttons.labels.cancel || _options.buttons.labels.cancel,
+                label: options.buttons.labels.cancel || defaults.buttons.labels.cancel,
                 close: true
             }
         }
     };
-    dlg = dialog(dialogOptions);
+    const dlg = dialog(dialogOptions);
 
     const $html = dlg.getDom();
     const $deleteButton = $html.find('[data-control="delete"]');

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -24,7 +24,7 @@ import dialog from 'ui/dialog';
 import checkBoxTpl from 'ui/dialog/tpl/checkbox';
 
 /**
- * Displays a confirm message
+ * Displays a confirm delete message with checkbox
  * @param {String} message - The displayed message
  * @param {Function} accept - An action called when the message is accepted
  * @param {Function} refuse - An action called when the message is refused
@@ -46,7 +46,7 @@ const defaults = {
     confirmationMessage: __('I understand that this action is permanent.')
 };
 
-export default function dialogConfirm(message, accept, refuse, options) {
+export default function dialogConfirmDelete(message, accept, refuse, options) {
     let accepted = false;
     options = _.defaults(options || {}, defaults);
     const dialogOptions = {

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -21,7 +21,7 @@
 import _ from 'lodash';
 import __ from 'i18n';
 import dialog from 'ui/dialog';
-import checkBoxTpl from 'ui/dialog/tpl/checkBox';
+import checkBoxTpl from 'ui/dialog/tpl/checkbox';
 
 /**
  * Displays a confirm message

--- a/src/dialog/confirmDelete.js
+++ b/src/dialog/confirmDelete.js
@@ -21,7 +21,7 @@
 import _ from 'lodash';
 import __ from 'i18n';
 import dialog from 'ui/dialog';
-import checkBoxTpl from 'ui/dialog/tpl/checkBox';
+import checkBoxTpl from 'ui/dialog/tpl/checkBox.tpl';
 
 /**
  * Displays a confirm message

--- a/test/dialogConfirmDelete/test.html
+++ b/test/dialogConfirmDelete/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Ui Test - Modal Dialog Confirm Delete</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/dialogConfirmDelete/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/dialogConfirmDelete/test.js
+++ b/test/dialogConfirmDelete/test.js
@@ -1,0 +1,164 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Hanna Dzmitryieva <hanna@taotesting.com>
+ */
+define(['ui/dialog/confirmDelete'], function(dialogConfirmDelete) {
+    'use strict';
+
+    QUnit.module('dialog/confirmDelete');
+
+    QUnit.test('module', function(assert) {
+        const conf1 = dialogConfirmDelete();
+        const conf2 = dialogConfirmDelete();
+        assert.equal(typeof dialogConfirmDelete, 'function', 'The dialogConfirmDelete module exposes a function');
+        assert.equal(typeof conf1, 'object', 'The dialogConfirmDelete factory produces an object');
+        assert.notStrictEqual(conf1, conf2, 'The dialogConfirmDelete factory provides a different object on each call');
+        conf1.destroy();
+        conf2.destroy();
+    });
+
+    const dialogApi = [
+        { name: 'init', title: 'init' },
+        { name: 'destroy', title: 'destroy' },
+        { name: 'setButtons', title: 'setButtons' },
+        { name: 'render', title: 'render' },
+        { name: 'show', title: 'show' },
+        { name: 'hide', title: 'hide' },
+        { name: 'trigger', title: 'trigger' },
+        { name: 'on', title: 'on' },
+        { name: 'off', title: 'off' },
+        { name: 'getDom', title: 'getDom' }
+    ];
+
+    QUnit.cases.init(dialogApi).test('instance API ', function(data, assert) {
+        const instance = dialogConfirmDelete();
+        assert.equal(
+            typeof instance[data.name],
+            'function',
+            `The dialogConfirmDelete instance exposes a "${data.title}" function`
+        );
+        instance.destroy();
+    });
+
+    const confirmCases = [
+        {
+            message: 'must accept',
+            button: 'delete',
+            title: 'accept'
+        },
+        {
+            message: 'must refuse',
+            button: 'cancel',
+            title: 'refuse',
+            options: {
+                buttons: {
+                    labels: {
+                        delete: 'new delete label',
+                        cancel: 'new cancel label'
+                    }
+                }
+            }
+        }
+    ];
+
+    QUnit.cases.init(confirmCases).test('use ', function(data, assert) {
+        const ready = assert.async();
+        const accept = function() {
+            assert.equal(
+                data.button,
+                'delete',
+                'The dialogConfirmDelete has triggered the accept callback function when hitting the ok button!'
+            );
+            ready();
+        };
+        const refuse = function() {
+            assert.equal(
+                data.button,
+                'cancel',
+                'The dialogConfirmDelete has triggered the refuse callback function when hitting the cancel button!'
+            );
+            ready();
+        };
+        const modal = dialogConfirmDelete(data.message, accept, refuse, data.options || {});
+
+        assert.equal(typeof modal, 'object', 'The dialogConfirmDelete instance is an object');
+        assert.equal(typeof modal.getDom(), 'object', 'The dialogConfirmDelete instance gets a DOM element');
+        assert.ok(!!modal.getDom().length, 'The dialogConfirmDelete instance gets a DOM element');
+        assert.equal(modal.getDom().parent().length, 1, 'The dialogConfirmDelete box is rendered by default');
+        assert.equal(
+            modal
+                .getDom()
+                .find('.message')
+                .text(),
+            data.message,
+            'The dialogConfirmDelete box displays the message'
+        );
+
+        assert.equal(modal.getDom().find('button').length, 3, 'The dialogConfirmDelete box displays 2 buttons');
+        assert.equal(
+            modal.getDom().find('button[data-control="delete"]').length,
+            1,
+            "The dialogConfirmDelete box displays a 'delete' button"
+        );
+        assert.equal(
+            modal.getDom().find('button[data-control="delete"]').is(':disabled'),
+            true,
+            "The dialogConfirmDelete box displays disabled 'delete' button"
+        );
+        assert.equal(
+            modal.getDom().find('button[data-control="cancel"]').length,
+            1,
+            "The dialogConfirmDelete box displays a 'cancel' button"
+        );
+
+        if (data.options && data.options.buttons) {
+            assert.equal(
+                modal
+                    .getDom()
+                    .find('button[data-control="delete"] .label')
+                    .text(),
+                data.options.buttons.labels.delete,
+                'The dialogConfirmDelete box displays correct label'
+            );
+            assert.equal(
+                modal
+                    .getDom()
+                    .find('button[data-control="cancel"] .label')
+                    .text(),
+                data.options.buttons.labels.cancel,
+                'The dialogConfirmDelete box displays correct label'
+            );
+        }
+        modal
+            .getDom()
+            .find('#confirm')
+            .click();
+
+        assert.equal(
+            modal.getDom().find('button[data-control="delete"]').is(':disabled'),
+            false,
+            "The dialogConfirmDelete box displays enabled 'delete' button"
+        );
+
+        modal
+            .getDom()
+            .find(`button[data-control="${data.button}"]`)
+            .click();
+    });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-12
Related to 
https://github.com/oat-sa/extension-tao-item/pull/437
https://github.com/oat-sa/extension-tao-mediamanager/pull/236
https://github.com/oat-sa/tao-core/pull/2721

How to test:
- go to Items page
- try to delete Item
- try to delete Class

Can be tested here http://item-delete_warning.playground.kitchen.it.taocloud.org:49591/

![image](https://user-images.githubusercontent.com/25976342/97896269-e8c36300-1d45-11eb-8bfc-ddb03784cbc5.png)
![image](https://user-images.githubusercontent.com/25976342/97896320-f842ac00-1d45-11eb-88b6-95cd20408777.png)
