### PR TITLE
[Feature] CON 18 - Enable disabled add criteria

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -115,7 +115,7 @@ export default function advancedSearchFactory(config) {
             initAddCriteriaSelector().then(() => {
                 initCriteriaState();
                 instance.trigger('ready');
-            });
+            }).catch(e => instance.trigger('error', e));
         });
 
     /**

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -137,7 +137,6 @@ export default function advancedSearchFactory(config) {
         const route = urlUtil.route('status', 'AdvancedSearch', 'tao');
         request(route).then(function (response) {
             if (!response.enabled) {
-                $addCriteria.addClass('disabled');
                 return;
             }
             $addCriteria.removeClass('disabled');

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -112,8 +112,10 @@ export default function advancedSearchFactory(config) {
         .setTemplate(advancedSearchTpl)
         .on('render', () => {
             initUiSelectors();
-            initAddCriteriaSelector();
-            initCriteriaState();
+            initAddCriteriaSelector().then(() => {
+                initCriteriaState();
+                instance.trigger('ready');
+            });
         });
 
     /**

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -137,7 +137,7 @@ export default function advancedSearchFactory(config) {
      */
     function initAddCriteriaSelector() {
         const route = urlUtil.route('status', 'AdvancedSearch', 'tao');
-        request(route).then(function (response) {
+        return request(route).then(function (response) {
             if (!response.enabled) {
                 return;
             }

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -134,12 +134,8 @@ export default function advancedSearchFactory(config) {
      * Inits select2 on criteria select and its UX logic
      */
     function initAddCriteriaSelector() {
-        const route = urlUtil.route('status', 'advanced_search', 'tao');
-        /*
-          TODO: Use real request when backend provide endpoint
-          Sustitute finally for then
-        */
-        request(route).finally(function (response = { enabled: false }) {
+        const route = urlUtil.route('status', 'AdvancedSearch', 'tao');
+        request(route).then(function (response) {
             if (!response.enabled) {
                 $addCriteria.addClass('disabled');
                 return;
@@ -172,7 +168,7 @@ export default function advancedSearchFactory(config) {
             });
         })
         .catch(function (e) {
-          return instance.trigger('error', e);
+            return instance.trigger('error', e);
         });
     }
 

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -21,6 +21,9 @@ $invalidCriteriaBorder: #266d9c;
             left: 0;
             width: 70%;
         }
+        &.disabled {
+            display: none;
+        }
     }
     .advanced-criteria-container {
         padding-top: 16px;

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -35,6 +35,16 @@ define([
         dataType: 'json',
         responseText: mocks.mockedAdvancedCriteria
     });
+    $.mockjax({
+        url: 'undefined/tao/AdvancedSearch/status',
+        dataType: 'json',
+        responseText: {
+            success: true,
+            data: {
+                enabled: true
+            }
+        }
+    });
     QUnit.module('advancedSearch');
     QUnit.test('module', function (assert) {
         assert.expect(1);
@@ -99,8 +109,16 @@ define([
 
     QUnit.module('advanced search logic');
     QUnit.cases.init([
-        { enabled: true },
-        { enabled: false }
+        {
+            response: {
+                enabled: true
+            },
+        },
+        {
+            response: {
+                enabled: false
+            },
+        }
     ]).test('advancedSearch criteria manipulation', function (data, assert) {
         const instance = searchModalFactory({
             criterias: { search: 'example' },
@@ -108,13 +126,18 @@ define([
             renderTo: '#testable-container',
             rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item'
         });
-        $.mockjax({
-            url: new RegExp(/\/*/),
-            dataType: 'json',
-            responseText: data.enabled
-        });
+
         const ready = assert.async();
-        assert.expect(14);
+        assert.expect(13);
+
+        $.mockjax({
+            url: 'undefined/tao/AdvancedSearch/status',
+            dataType: 'json',
+            responseText: {
+                success: true,
+                data: data.response
+            }
+        });
 
         instance.on('criteriaListUpdated', function () {
             const $container = $('.advanced-search-container');
@@ -125,7 +148,6 @@ define([
             let $optionToSelect = $criteriaSelect.find('option[value="in-both-text"]');
 
             // check initial state
-            assert.equal(!$addCriteria.hasClass('disabled'), data.enabled, 'critera select is initially disabled');
             assert.equal($optionToSelect.length, 1, 'criterion to select is initially on select options');
 
             // select a criterion

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -24,6 +24,9 @@ define([
     'json!test/ui/searchModal/mocks/mocks.json',
     'jquery.mockjax'
 ], function ($, _, searchModalFactory, advancedSearchFactory, store, mocks) {
+
+    // Prevent the AJAX mocks to pollute the logs
+    $.mockjaxSettings.logger = null;
     $.mockjaxSettings.responseTime = 1;
     $.mockjax({
         url: 'undefined/tao/RestResource/getAll',

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -98,12 +98,20 @@ define([
     });
 
     QUnit.module('advanced search logic');
-    QUnit.test('advancedSearch criteria manipulation', function (assert) {
+    QUnit. QUnit.cases.init([
+        { enabled: true },
+        { enabled: false }
+    ]).test('advancedSearch criteria manipulation', function (data, assert) {
         const instance = searchModalFactory({
             criterias: { search: 'example' },
             url: '/test/searchModal/mocks/with-occurrences/search.json',
             renderTo: '#testable-container',
             rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item'
+        });
+        $.mockjax({
+            url: new RegExp(/\/*/),
+            dataType: 'json',
+            responseText: data.enabled
         });
         const ready = assert.async();
         assert.expect(14);
@@ -111,12 +119,13 @@ define([
         instance.on('criteriaListUpdated', function () {
             const $container = $('.advanced-search-container');
             const $criteriaContainer = $container.find('.advanced-criteria-container');
+            const $addCriteria = $('.add-criteria-container', $container);
             const $addCriteriaInput = $('.add-criteria-container a', $container);
             const $criteriaSelect = $('.add-criteria-container select', $container);
             let $optionToSelect = $criteriaSelect.find('option[value="in-both-text"]');
 
             // check initial state
-            assert.equal($criteriaSelect.select2('opened'), false, 'critera select is initially closed');
+            assert.equal(!$addCriteria.hasClass('disabled'), data.enabled, 'critera select is initially disabled');
             assert.equal($optionToSelect.length, 1, 'criterion to select is initially on select options');
 
             // select a criterion
@@ -160,6 +169,14 @@ define([
                 instance.destroy();
                 ready();
                 $.mockjax.handler(1).responseText = mocks.mockedAdvancedCriteria;
+            });
+
+            instance.off('ready').on('ready', function () {
+                if (data.enabled) {
+                    assert.equal(!$addCriteria.hasClass('disabled'), data.enabled, 'critera select is enabled because status is enabled');
+                    return;
+                }
+                assert.equal($addCriteria.hasClass('disabled'), data.enabled, 'critera select is disabled because status is disabled');
             });
         });
     });


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/CON-18

**Related to this PR**

https://github.com/oat-sa/tao-core/pull/2719

**Description**

**as a** TAO user with access to advanced search
**I want** to be able to see and use the advanced search filters
**when** using search component

**as a** TAO user with no access to advanced search
**I want** not to see or use the advanced search filters
**when** using  search component

**AC**

1. For an environment with advanced search enabled*, ‘add criteria’ button is displayed according to mockups

2. For an environment with advanced search disabled*, ‘add criteria’ button is not displayed

*Advanced search is enabled by operations, so each AC must be tested on a different deployment OR environment variable can be updated dynamically by Luis or Andre so QA can test each AC on the same environment.