### PR TITLE
Feature/MS-561/intercept request for filtering on client side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.14.1",
+    "version": "1.15.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.14.1",
+    "version": "1.15.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -342,8 +342,7 @@ const dataTable = {
         }
 
         if (typeof options.requestInterceptor === 'function') {
-            options
-                .requestInterceptor(parameters)
+            Promise.resolve(options.requestInterceptor(parameters))
                 .then(data => {
                     self._render($elt, data);
                 })

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -234,6 +234,7 @@ const dataTable = {
      * @param {String} options.emptyText - text that will be shown when no data found for showing in the grid.
      * @param {Boolean} options.pageSizeSelector - flag that indicates if control for changing page size should be displayed
      * @param {Boolean} options.atomicUpdate - allowed to keep the datatable state to be able on "render" event, compare with new state and atomically update the table cells.
+     * @param {Function} options.requestInterceptor - Intercept sending AJAX request. The call of function must returns promise with provided data.
      * @param {Object} [data] - inject predefined data to avoid the first query.
      * @fires dataTable#create.datatable
      * @returns {jQueryElement} for chaining
@@ -328,6 +329,16 @@ const dataTable = {
 
         // disable pagination to not press multiple on it
         disablePagination($elt.paginations);
+
+        if (options.requestInterceptor){
+            options.requestInterceptor(parameters).then((data)=>{
+                self._render($elt, data);
+            }).catch((error)=> {
+                $elt.trigger('error.' + ns, [error]);
+                self._render($elt, {});
+            })
+            return;
+        }
 
         /**
          * @event dataTable#query.datatable

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -330,6 +330,17 @@ const dataTable = {
         // disable pagination to not press multiple on it
         disablePagination($elt.paginations);
 
+        /**
+         * @event dataTable#query.datatable
+         * @param {Object} ajaxConfig - The config object used to setup the AJAX request
+         */
+        $elt.trigger('query.' + ns, [ajaxConfig]);
+
+        // display the loading state
+        if (options.status) {
+            $elt.find('.loading').removeClass(hiddenCls);
+        }
+
         if (typeof options.requestInterceptor === 'function') {
             options
                 .requestInterceptor(parameters)
@@ -341,17 +352,6 @@ const dataTable = {
                     self._render($elt, {});
                 });
             return;
-        }
-
-        /**
-         * @event dataTable#query.datatable
-         * @param {Object} ajaxConfig - The config object used to setup the AJAX request
-         */
-        $elt.trigger('query.' + ns, [ajaxConfig]);
-
-        // display the loading state
-        if (options.status) {
-            $elt.find('.loading').removeClass(hiddenCls);
         }
 
         $.ajax(ajaxConfig)

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -169,7 +169,7 @@ const dataTable = {
      * @property {String} [icon] Generate button icon
      * @property {Boolean} [hidden] When present, button is hidden
      * @property {Function} [action] Handler on button click
-    */
+     */
 
     /**
      * Used for generating action button from Object
@@ -177,7 +177,7 @@ const dataTable = {
      * @typedef  {{
      *  [key: Action.id & Action.icon & Action.title ]: Action.action,
      * }} ActionsObject
-     * 
+     *
      * @example
      * {
      *  actions: {
@@ -185,7 +185,7 @@ const dataTable = {
      *    remove: removeUser,
      *  }
      * }
-     * 
+     *
      * ! IMPORTANT USE INSTEAD:
      * {
      *   actions: [
@@ -330,13 +330,16 @@ const dataTable = {
         // disable pagination to not press multiple on it
         disablePagination($elt.paginations);
 
-        if (options.requestInterceptor){
-            options.requestInterceptor(parameters).then((data)=>{
-                self._render($elt, data);
-            }).catch((error)=> {
-                $elt.trigger('error.' + ns, [error]);
-                self._render($elt, {});
-            })
+        if (typeof options.requestInterceptor === 'function') {
+            options
+                .requestInterceptor(parameters)
+                .then(data => {
+                    self._render($elt, data);
+                })
+                .catch(error => {
+                    $elt.trigger('error.' + ns, [error]);
+                    self._render($elt, {});
+                });
             return;
         }
 

--- a/test/datatable/test.js
+++ b/test/datatable/test.js
@@ -260,6 +260,30 @@ define([
         });
     });
 
+    QUnit.test('Option requestInterceptor failed', function(assert){
+        const $container = $('#container-1');
+        const done = assert.async();
+        assert.expect(1);
+
+        $container.on('error.datatable', function(error) {
+            assert.ok(true, 'Interceptor is failed');
+            done();
+        });
+
+        $container.datatable({
+            url: '/test/datatable/data.json',
+            model: [{
+                id: 'name',
+                label: 'Name',
+            }],
+            requestInterceptor: function(){
+                return new Promise(function(resolve, reject){
+                    reject('Failed');
+                })
+            }
+        });
+    });
+
     QUnit.test('Model loading using AJAX', function(assert) {
         var ready3 = assert.async();
         var ready2 = assert.async();

--- a/test/datatable/test.js
+++ b/test/datatable/test.js
@@ -222,13 +222,16 @@ define([
 
     QUnit.test('Option requestInterceptor', function(assert){
         const $container = $('#container-1');
+        const done = assert.async();
 
         $.mockjax(function() {
             assert.ok(false, 'AJAX request must be intercepted');
+            done();
         });
 
         $container.on('load.datatable', function() {
             assert.verifySteps(['intercept'])
+            done();
         });
 
         $container.datatable({

--- a/test/datatable/test.js
+++ b/test/datatable/test.js
@@ -220,6 +220,43 @@ define([
         });
     });
 
+    QUnit.test('Option requestInterceptor', function(assert){
+        const $container = $('#container-1');
+
+        $.mockjax(function() {
+            assert.ok(false, 'AJAX request must be intercepted');
+        });
+
+        $container.on('load.datatable', function() {
+            assert.verifySteps(['intercept'])
+        });
+
+        $container.datatable({
+            url: '/test/datatable/data.json',
+            model: [{
+                id: 'name',
+                label: 'Name',
+            }],
+            requestInterceptor: function(){
+                return new Promise(function(resolve, reject){
+                    assert.step('intercept');
+                    resolve({
+                        data: [{
+                            id: 1,
+                            name: 'John',
+                            email: 'john.smith@mail.com'
+                        }, {
+                            id: 2,
+                            name: 'Jane',
+                            email: 'jane.doe@mail.com'
+                        }]
+                    });
+                    
+                })
+            }
+        });
+    });
+
     QUnit.test('Model loading using AJAX', function(assert) {
         var ready3 = assert.async();
         var ready2 = assert.async();
@@ -1783,8 +1820,6 @@ define([
             rows: 50,
         });
     });
-
-
 
     QUnit.cases.init([
         {


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/MS-561
- https://github.com/oat-sa/extension-tao-nccer-delivery/pull/1148

**Description:** New option `requestInterceptor` is added. The option is needed to intercept AJAX request.
The value of the option must be a function returns a Promise. The Promise resolve call must provide a data for a table.

**Unit tests cli:** `npm run test`