### PR TITLE
Fix/tr 84 fix navigation plugin focusout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.16.1",
+    "version": "1.16.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.16.1",
+    "version": "1.16.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/keyNavigation/navigator.js
+++ b/src/keyNavigation/navigator.js
@@ -76,6 +76,7 @@ export default function keyNavigatorFactory(config) {
 
     const navigableElements = navigatorConfig.elements || [];
     let lastPosition = -1;
+    let focusOutObserver;
 
     /**
      * Checks if the navigable element is available
@@ -145,6 +146,16 @@ export default function keyNavigatorFactory(config) {
                             $group.removeClass('focusin');
                         }
                     });
+                
+                focusOutObserver = new MutationObserver(() => {
+                    if (!this.isVisible() && $group.hasClass('focusin')) {
+                        $group.removeClass('focusin');
+                    }
+                });
+                focusOutObserver.observe($group.get(0), {
+                    childList: true,
+                    subtree: true
+                });
             }
 
             navigableElements.forEach(navigable => {
@@ -182,6 +193,10 @@ export default function keyNavigatorFactory(config) {
                 $group
                     .off(`.${this.getId()}`)
                     .removeClass('focusin');
+            }
+
+            if (focusOutObserver) {
+                focusOutObserver.disconnect();
             }
 
             navigableElements.forEach(navigable => {

--- a/src/keyNavigation/navigator.js
+++ b/src/keyNavigation/navigator.js
@@ -152,9 +152,11 @@ export default function keyNavigatorFactory(config) {
                         $group.removeClass('focusin');
                     }
                 });
-                focusOutObserver.observe($group.get(0), {
-                    childList: true,
-                    subtree: true
+                $group.each(index => {
+                    focusOutObserver.observe($group.get(index), {
+                      childList: true,
+                      subtree: true
+                    });
                 });
             }
 

--- a/src/keyNavigation/navigator.js
+++ b/src/keyNavigation/navigator.js
@@ -154,8 +154,8 @@ export default function keyNavigatorFactory(config) {
                 });
                 $group.each(index => {
                     focusOutObserver.observe($group.get(index), {
-                      childList: true,
-                      subtree: true
+                        childList: true,
+                        subtree: true
                     });
                 });
             }

--- a/test/keyNavigation/keyNavigator/test.html
+++ b/test/keyNavigation/keyNavigator/test.html
@@ -45,6 +45,9 @@
                 <a class="nav group-1">Foo 4</a>
                 <input class="nav group-2" type="text" />
             </nav>
+            <nav class="nav-4">
+                <div class="nav">A</div>
+            </nav>
         </div>
     </body>
 </html>

--- a/test/keyNavigation/keyNavigator/test.js
+++ b/test/keyNavigation/keyNavigator/test.js
@@ -930,6 +930,34 @@ define([
         assert.ok(!keyNavigator.isFocused(), 'the navigator is now blurred');
     });
 
+    QUnit.test('isFocused when nav is deleted', function (assert) {
+        var ready = assert.async();
+        var keyNavigator;
+        var $container = $('#qunit-fixture .nav-4');
+        var $elements = $container.find('.nav');
+        var elements = navigableDomElement.createFromDoms($elements);
+
+        assert.expect(2);
+
+        keyNavigator = keyNavigatorFactory({elements: elements, group: $container});
+        keyNavigator.focus();
+
+        new Promise(function(resolve) {
+            setTimeout(resolve, testDelay);
+        })
+        .then(function() {
+            return new Promise(function(resolve) {
+                assert.ok($container.hasClass('focusin'), 'container has focusin class');
+                $elements.remove();
+                setTimeout(resolve, testDelay);
+            });
+        })
+        .then(function () {
+            assert.ok(!$container.hasClass('focusin'), 'container has no focusin class anymore');
+            ready();
+        });
+    });
+
     QUnit.test('loop', function (assert) {
         var ready = assert.async();
         var keyNavigator;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-84

Add `focusout` Mutation observer for `keyNavigator` to check the case, when the focused element was removed, because firefox does not fire `focusout` event in that case.

Test:
- `npm run test`
- Check behavior in https://github.com/oat-sa/tao-core/pull/2732 branch with following steps in the ticket