### PR TITLE
Feature/CON-76/Add config hideResourceSelector, placeholder in searchModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.18.0",
+    "version": "1.19.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -308,7 +308,7 @@ export default function searchModalFactory(config) {
                 $.ajax({
                     url: instance.config.url,
                     type: 'POST',
-                    data: { query: query, parentNode: classFilterUri },
+                    data: { query: query, parentNode: classFilterUri, structure: context.shownStructure },
                     dataType: 'json'
                 })
                     .done(data => {

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -66,7 +66,7 @@ export default function searchModalFactory(config) {
     let advancedSearch = null;
 
     // resorce selector
-    const isResourceSelector = !(config.hideResourceSelector || false);
+    const isResourceSelector = !config.hideResourceSelector;
     const rootClassUri = config.rootClassUri;
 
     /**

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -41,6 +41,7 @@ import 'select2';
  * @param {boolean} config.searchOnInit - if init search must be triggered or not (stored results are used instead)
  * @param {string} config.url - search endpoint to be set on datatable
  * @param {string} config.rootClassUri - Uri for the root class of current context, required to init the class filter
+ * @param {bool} config.hideResourceSelector - if resourceSelector must be hidden
  * @returns {searchModal}
  */
 export default function searchModalFactory(config) {
@@ -62,6 +63,10 @@ export default function searchModalFactory(config) {
     let $classFilterInput = null;
     let $classTreeContainer = null;
     let advancedSearch = null;
+
+    // resorce selector
+    const isResourceSelector = !(config.hideResourceSelector || false);
+    const rootClassUri = config.rootClassUri;
 
     /**
      * Creates search modal, inits template selectors, inits search store, and once is created triggers initial search
@@ -120,7 +125,10 @@ export default function searchModalFactory(config) {
      */
     function initClassFilter() {
         return new Promise(resolve => {
-            const rootClassUri = instance.config.rootClassUri;
+            if (!isResourceSelector) {
+                $classFilterContainer.hide();
+                return resolve();
+            }
             const initialClassUri =
                 instance.config.criterias && instance.config.criterias.class
                     ? instance.config.criterias.class
@@ -291,7 +299,7 @@ export default function searchModalFactory(config) {
 
         // build complex query
         const query = buildComplexQuery();
-        const classFilterUri = $classFilterInput.data('uri').trim();
+        const classFilterUri = isResourceSelector ? $classFilterInput.data('uri').trim() : rootClassUri;
 
         //throttle and control to prevent sending too many requests
         const searchHandler = _.throttle(query => {
@@ -409,7 +417,7 @@ export default function searchModalFactory(config) {
             context: context.shownStructure,
             criterias: {
                 search: $searchInput.val(),
-                class: _.map(resourceSelector.getSelection(), 'uri')[0],
+                class: isResourceSelector ? _.map(resourceSelector.getSelection(), 'uri')[0] : rootClassUri,
                 advancedCriteria: advancedSearch.getState()
             }
         });
@@ -448,7 +456,7 @@ export default function searchModalFactory(config) {
     function clear() {
         $searchInput.val('');
         advancedSearch.clear();
-        resourceSelector.select(instance.config.rootClassUri);
+        isResourceSelector && resourceSelector.select(rootClassUri);
         replaceSearchResultsDatatableWithMessage('no-query');
         updateSearchStore({ action: 'clear' });
     }

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -385,8 +385,8 @@ export default function searchModalFactory(config) {
                     {
                         id: 'go-to-item',
                         label: __('Go to item'),
-                        action: function openResource(uri) {
-                            instance.trigger('refresh', uri);
+                        action: function openResource(uri, data) {
+                            instance.trigger('refresh', uri, data);
                             instance.destroy();
                         }
                     }

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -42,7 +42,7 @@ import 'select2';
  * @param {string} config.url - search endpoint to be set on datatable
  * @param {string} config.rootClassUri - Uri for the root class of current context, required to init the class filter
  * @param {bool} config.hideResourceSelector - if resourceSelector must be hidden
- * @param {bool} config.placeholder - placeholder for input in template
+ * @param {string} config.placeholder - placeholder for input in template
  * @returns {searchModal}
  */
 export default function searchModalFactory(config) {

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -312,8 +312,8 @@ export default function searchModalFactory(config) {
                     dataType: 'json'
                 })
                     .done(data => {
-                        appendDefaultDatasetToDatatable(data)
-                            .then(() => buildSearchResultsDatatable(data))
+                        appendDefaultDatasetToDatatable(data.data)
+                            .then(() => buildSearchResultsDatatable(data.data))
                             .catch(e => instance.trigger('error', e));
                     })
                     .always(() => (running = false));

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -42,6 +42,7 @@ import 'select2';
  * @param {string} config.url - search endpoint to be set on datatable
  * @param {string} config.rootClassUri - Uri for the root class of current context, required to init the class filter
  * @param {bool} config.hideResourceSelector - if resourceSelector must be hidden
+ * @param {bool} config.placeholder - placeholder for input in template
  * @returns {searchModal}
  */
 export default function searchModalFactory(config) {

--- a/src/searchModal/tpl/layout.tpl
+++ b/src/searchModal/tpl/layout.tpl
@@ -10,7 +10,7 @@
                     <div class="filter-container class-filter-container">
                         <span class="icon-folder"></span>
                         <span class="icon-down"></span>
-                        <input class="class-filter" type="text" placeholder="{{placeholder}}">
+                        <input class="class-filter" type="text">
                         <div class="class-tree"></div>
                     </div>
                 </div>

--- a/src/searchModal/tpl/layout.tpl
+++ b/src/searchModal/tpl/layout.tpl
@@ -5,12 +5,12 @@
                 <div class="basic-search-container">
                     <div class="filter-container">
                         <span class="icon-find"></span>
-                        <input class="generic-search-input" type="text" placeholder="{{__ "Search Item"}}">
+                        <input class="generic-search-input" type="text" placeholder="{{placeholder}}">
                     </div>
                     <div class="filter-container class-filter-container">
                         <span class="icon-folder"></span>
                         <span class="icon-down"></span>
-                        <input class="class-filter" type="text" placeholder="{{__ "Search Item"}}">
+                        <input class="class-filter" type="text" placeholder="{{placeholder}}">
                         <div class="class-tree"></div>
                     </div>
                 </div>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-76
https://github.com/oat-sa/extension-tao-outcomeui/pull/357
https://github.com/oat-sa/lib-tao-elasticsearch/pull/40
https://github.com/oat-sa/tao-core/pull/2743

Added configs to `searchModal`  `hideResourceSelector` and `placeholder`
Hid `advanceSearch` if it is Result page

How to test:
- go to any page and check that placeholder for search input `Search Item`, `Search Result` used also in searchModal
- go to Results page
- run search (use delivery name or test taker name)
- in searchModal should be hidden `add criteria` button and resource selector
- check table with search results and press `Go To Item`
- delivery result should be loaded 