### PR TITLE
[Fix] CON 122 - Graphic design match mockup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.0",
+    "version": "1.20.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.0",
+    "version": "1.20.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_select2.scss
+++ b/scss/inc/_select2.scss
@@ -215,8 +215,7 @@
     width: 100%;
     min-height: 26px;
     margin: 0;
-    padding-left: 4px;
-    padding-right: 4px;
+    padding: 4px 4px 0 4px;
 
     position: relative;
     z-index: 100000;

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -10,12 +10,10 @@ $invalidCriteriaBorder: #266d9c;
         padding-right: 20px;
         position: relative;
         .icon-add {
-            @include font-size(16);
+            font-size: 1.6rem;
             position: relative;
             top: 2px;
-            left: 2px;
-            color: $info;
-            padding-right: 8px
+            margin-right: 8px;
         }
         a {
             text-decoration: none;

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -10,7 +10,12 @@ $invalidCriteriaBorder: #266d9c;
         padding-right: 20px;
         position: relative;
         .icon-add {
-            font-size: 1.6rem;
+            @include font-size(16);
+            position: relative;
+            top: 2px;
+            left: 2px;
+            color: $info;
+            padding-right: 8px
         }
         a {
             text-decoration: none;

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -253,8 +253,9 @@ $classTreeVariables: (
             > .icon-find,
             > .icon-folder {
                 position: absolute;
-                top: 5px;
+                top: 7px;
                 left: 5px;
+                color: #666;
             }
             .icon-down {
                 position: absolute;


### PR DESCRIPTION
**Issues**

https://oat-sa.atlassian.net/browse/CON-122

**Related issues**

https://github.com/oat-sa/extension-tao-itemqti/pull/1600

**Mockup**

https://projects.invisionapp.com/d/main#/console/20371039/431571617/preview

**Fix**

- [x] **4. Criteria dropdown**: use a 4px padding-top for class="select2-search" .
- [x] **8. Add criteria button (in advance search)**: spacing between icon and label. Use the same look and feel as for the add choice button for drop downs.
- [x] **5. Inputs field/dropdown**: Properly vertically align the folder and search icon inside the respective field.
- [x] **Input field/dropdown**: Tint down the icons to #666
- [x] **Bonus**: Center the icon

**Before**

- 8 ![imagen](https://user-images.githubusercontent.com/34692207/102265509-7bdfe300-3f17-11eb-86a5-e33da97f9574.png)
- 4 ![imagen](https://user-images.githubusercontent.com/34692207/102266195-66b78400-3f18-11eb-9a1d-d8c171a7a596.png)
- 5 ![imagen](https://user-images.githubusercontent.com/34692207/102338837-a6bc4c80-3f94-11eb-8ad0-ee0b878b95a6.png)
- 6 ![imagen](https://user-images.githubusercontent.com/34692207/102339683-cd2eb780-3f95-11eb-989a-beda4da0f8d5.png)
- 2 ![imagen](https://user-images.githubusercontent.com/34692207/102468832-51467500-4052-11eb-9d18-07515a63a49a.png)
- 2.1 (on focus) ![imagen](https://user-images.githubusercontent.com/34692207/102468910-66bb9f00-4052-11eb-9b79-21e47dbe3efe.png)

**After**

- 8 ![imagen](https://user-images.githubusercontent.com/34692207/102265465-708cb780-3f17-11eb-9b19-130f4e5ec2d7.png)
- 4 ![imagen](https://user-images.githubusercontent.com/34692207/102266394-a8482f00-3f18-11eb-9915-68c6dbfd8638.png)
- 5 ![imagen](https://user-images.githubusercontent.com/34692207/102338795-9906c700-3f94-11eb-916c-63e3bf1cfced.png)
- 6 ![imagen](https://user-images.githubusercontent.com/34692207/102339646-bf793200-3f95-11eb-9a08-496a41b1868f.png)
- 2 ![imagen](https://user-images.githubusercontent.com/34692207/102468598-04629e80-4052-11eb-843a-5ba82eaf9169.png)
- 2.1 (on focus) ![imagen](https://user-images.githubusercontent.com/34692207/102468669-1fcda980-4052-11eb-95a0-eaeb327776a8.png)