### PR TITLE
[Fix] CON 122 - Graphic design match mockup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.2",
+    "version": "1.20.3",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.1",
+    "version": "1.20.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -115,7 +115,6 @@ export default function searchModalFactory(config) {
             .modal({
                 disableEscape: false,
                 width: $(window).width(),
-                minHeight: $(window).height(),
                 modalCloseClass: 'modal-close-left'
             })
             .focus();

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -4,9 +4,15 @@ $invalidCriteriaBackground: #cfdfe9;
 $invalidCriteriaBorder: #266d9c;
 
 .advanced-search-container {
-    margin-top: 16px;
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    &:not(:empty) {
+        padding: 0 0 16px 0;
+    }
     .add-criteria-container {
-        margin-top: 16px;
+        padding-top: 16px;
         padding-right: 20px;
         position: relative;
         .icon-add {
@@ -29,17 +35,30 @@ $invalidCriteriaBorder: #266d9c;
         }
     }
     .advanced-criteria-container {
-        padding-top: 16px;
         overflow-y: auto;
         padding-right: 20px;
-        max-height: 72vh;
+        max-height: 100%;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        &:not(:empty) {
+            padding-top: 16px;
+        }
         .filter-container {
-            margin-bottom: 30px;
+            margin-bottom: 32px;
+            &:last-child {
+                margin-bottom: 16px;
+            }
             .icon-result-nok {
                 right: 0;
                 top: 2px;
                 cursor: pointer;
                 position: absolute;
+                font-size: 1.6rem;
+            }
+            .filter-label-text {
+                padding-bottom:4px;
+                display: inline-block;
             }
             &[data-type='text'] {
                 input {

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -9,7 +9,7 @@ $invalidCriteriaBorder: #266d9c;
     display: flex;
     flex-direction: column;
     &:not(:empty) {
-        padding: 0 0 16px 0;
+        padding: 0 0 32px 0;
     }
     .add-criteria-container {
         padding-top: 16px;

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -245,7 +245,7 @@ $classTreeVariables: (
         display: flex;
         flex-direction: column;
         justify-content: space-between;
-        padding: 60px 0px 20px 20px;
+        padding: 64px 0px 20px 20px;
         .filters-container {
             flex: 1 1 auto;
             height: 100%;
@@ -263,12 +263,15 @@ $classTreeVariables: (
         }
         .filter-container {
             position: relative;
-            margin-bottom: 10px;
+            margin-bottom: 8px;
+            &:last-child {
+                padding-bottom: 16px;
+            }
             > .icon-find,
             > .icon-folder {
                 position: absolute;
                 top: 7px;
-                left: 5px;
+                left: 8px;
                 color: #666;
             }
             .icon-down {
@@ -278,7 +281,7 @@ $classTreeVariables: (
             }
             > input {
                 width: 100%;
-                padding-left: 25px;
+                padding-left: 28px;
             }
             .class-filter {
                 cursor: pointer;
@@ -299,11 +302,12 @@ $classTreeVariables: (
         }
         .buttons-container {
             flex: 0 0 auto;
-            padding-right: 20px;
+            padding-right: 4px;
             display: flex;
-            justify-content: space-around;
+            justify-content: space-between;
             button {
-                width: 45%;
+                flex: 1 1 auto;
+                margin-right: 16px;
                 vertical-align: top;
             }
             .btn-transparent {
@@ -315,6 +319,9 @@ $classTreeVariables: (
         }
     }
     .content-container {
+        @media screen and (min-width: 840px) {
+            padding: 64px !important;
+        }
         .no-datatable-container {
             display: flex;
             flex-direction: column;
@@ -349,9 +356,9 @@ $classTreeVariables: (
         color: $textColor !important;
         background-color: transparent;
         padding: 0;
-        height: 20px;
+        height: 24px;
         .icon-close {
-            font-size: 2rem;
+            font-size: 2.4rem;
         }
     }
 }

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -233,15 +233,29 @@ $classTreeVariables: (
 }
 
 .search-modal {
-    height: 100% !important;
-    padding: 0px !important;
+    width: 100% !important;
+    // Increasing specificity
+    &.search-modal {
+        max-height: 100%;
+        min-height: 320px;    
+        height: 100%;
+        padding: 0px;
+    }
     .ui-container {
         display: flex;
         flex-direction: column;
         justify-content: space-between;
         padding: 60px 0px 20px 20px;
+        .filters-container {
+            flex: 1 1 auto;
+            height: 100%;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+        }
         .basic-search-container {
             padding-right: 20px;
+            flex: 0 0 auto;
             .class-filter-container {
                 cursor: pointer;
                 z-index: 2;
@@ -284,11 +298,13 @@ $classTreeVariables: (
             }
         }
         .buttons-container {
+            flex: 0 0 auto;
             padding-right: 20px;
             display: flex;
             justify-content: space-around;
             button {
                 width: 45%;
+                vertical-align: top;
             }
             .btn-transparent {
                 background-color: transparent;

--- a/src/searchModal/tpl/list-select-criterion.tpl
+++ b/src/searchModal/tpl/list-select-criterion.tpl
@@ -1,5 +1,5 @@
 <div class="filter-container {{criterion.id}}-filter" data-criteria="{{criterion.label}}" data-type="{{criterion.type}}">
     <span class="icon-result-nok"></span>
-    <span>{{criterion.label}}</span>
+    <span class="filter-label-text">{{criterion.label}}</span>
     <input type='text' name="{{criterion.label}}-select">
 </div>

--- a/src/searchModal/tpl/text-criterion.tpl
+++ b/src/searchModal/tpl/text-criterion.tpl
@@ -1,5 +1,5 @@
 <div class="filter-container {{criterion.id}}-filter" data-criteria="{{criterion.label}}" data-type="{{criterion.type}}">
     <span class="icon-result-nok"></span>
-    <span>{{criterion.label}}</span>
+    <span class="filter-label-text">{{criterion.label}}</span>
     <input type="text" placeholder="{{criterion.label}}">
 </div>


### PR DESCRIPTION
**Issues**

https://oat-sa.atlassian.net/browse/CON-122

**Fix**

- [x] Advanced search modal responsive height and width

The clear/search buttons are not properly positioned in the page if the window is resized with a smaller height. For instance if I open the search modal, and then I resize the window to a smaller size, I end up with this (notice that the buttons are not visible anymore).  

![Screenshot](https://user-images.githubusercontent.com/11773029/103172173-a492a180-4862-11eb-8e79-727a98a126be.png)

- [x] Overflow when multiple criteria don't fit the container height

After adding several search criteria to the point when they don’t fit vertically, the height of the left bar is bigger than the height of the modal, 2 scrollbars show up instead of one and bottom buttons are overflowing. 

![Screenshot](https://user-images.githubusercontent.com/11773029/103172231-18cd4500-4863-11eb-8030-d718676e5de1.png)

- [x] All [spacing issues](https://invis.io/2YYAZRZZ4XU#/431571617_7-1-2_Vertical_-_Query_Builder_-_Filter_Selection_Overflow)

