### PR TITLE
[Fix] package-lock.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.3",
+    "version": "1.20.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
https://github.com/oat-sa/tao-core-ui-fe/pull/236/files that was recently merged is missing version update in package-lock.json