### PR TITLE
Feature [CON-336]: Be able to search by criteria alone, without a search text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.4",
+    "version": "1.21.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.20.4",
+    "version": "1.21.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -291,13 +291,6 @@ export default function searchModalFactory(config) {
      * Request search results and manages its results
      */
     function search() {
-        // if query is empty just clear datatable
-        if ($searchInput.val() === '') {
-            clear();
-            return;
-        }
-
-        // build complex query
         const query = buildComplexQuery();
         const classFilterUri = isResourceSelector ? $classFilterInput.data('uri').trim() : rootClassUri;
 
@@ -330,7 +323,7 @@ export default function searchModalFactory(config) {
         const $searchInputValue = $searchInput.val().trim();
 
         let query = $searchInputValue;
-        query += advancedSearch.getAdvancedCriteriaQuery();
+        query += advancedSearch.getAdvancedCriteriaQuery(query !== '');
 
         return query;
     }

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -96,7 +96,7 @@ export default function advancedSearchFactory(config) {
             let query = '';
 
             advancedSearchCriteria.forEach(renderedCriterion => {
-                if (hasSearchInput || query.trim().length !== 0) {
+                if ((hasSearchInput || query.trim().length !== 0) && renderedCriterion.value) {
                     query += ' AND ';
                 }
                 if (renderedCriterion.type === criteriaTypes.text) {

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -91,18 +91,21 @@ export default function advancedSearchFactory(config) {
         /**
          * Builds substring of search query with the advanced criteria conditions
          */
-        getAdvancedCriteriaQuery: function () {
+        getAdvancedCriteriaQuery: function (hasSearchInput) {
             const advancedSearchCriteria = _.filter(criteriaState, criterion => criterion.rendered === true);
             let query = '';
 
             advancedSearchCriteria.forEach(renderedCriterion => {
+                if (hasSearchInput || query.trim().length !== 0) {
+                    query += ' AND ';
+                }
                 if (renderedCriterion.type === criteriaTypes.text) {
                     if (renderedCriterion.value && renderedCriterion.value.trim() !== '') {
-                        query += ` AND ${renderedCriterion.label}:${renderedCriterion.value.trim()}`;
+                        query += `${renderedCriterion.label}:${renderedCriterion.value.trim()}`;
                     }
                 } else if (renderedCriterion.type === criteriaTypes.list) {
                     if (renderedCriterion.value && renderedCriterion.value.length > 0) {
-                        query += ` AND ${renderedCriterion.label}:${renderedCriterion.value.join(' OR ')}`;
+                        query += `${renderedCriterion.label}:${renderedCriterion.value.join(' OR ')}`;
                     }
                 }
             });

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -264,7 +264,7 @@ define([
             const query = instance.getAdvancedCriteriaQuery();
             assert.equal(
                 query,
-                ' AND in-both-text:foo0 AND in-both-list:value1 OR value2 AND in-both-select:value0',
+                'in-both-text:foo0 AND in-both-list:value1 OR value2 AND in-both-select:value0',
                 'advanced search query is correctly built'
             );
             instance.destroy();


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-336

**Description**

**As** an OAT user
I **would** like to be able to search by any combination of existing resource properties (as criteria)
without searching for a default text within those resource properties
**so that** I am still able to find resources for which I don't know the text

**Example**

The user should be able to initiate a search with the following criteria

![imagen](https://user-images.githubusercontent.com/34692207/104472393-3537e400-55bc-11eb-9e57-0e733c914570.png)

**AC**

- Be able to search for any resource (items, tests, test-takers, groups, deliveries, assets) only by property value defined as criteria, without including a text in the search field
- Be able to search for any resource (items, tests, test-takers, groups, deliveries, assets) by any combination of properties values defined as criteria, with or without including a label
- A search can be initiated when at least the search text OR valid search criteria are defined