### PR TITLE
fix/MS-1061/Do not skip the empty text nodes during inlineRanges build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.22.5",
+    "version": "1.22.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-core-ui",
-            "version": "1.22.5",
+            "version": "1.22.6",
             "license": "GPL-2.0",
             "devDependencies": {
                 "@babel/core": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.22.5",
+    "version": "1.22.6",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/highlighter.js
+++ b/src/highlighter.js
@@ -508,7 +508,7 @@ export default function (options) {
                 // an isolated node (= not followed by a highlight table text) with its whole content highlighted
             } else if (
                 isWrappingNode(currentNode) &&
-                !isWrappable(currentNode.nextSibling) &&
+                !isText(currentNode.nextSibling) &&
                 (!isWrappingNode(currentNode.nextSibling) ||
                     currentNode.className === currentNode.nextSibling.className)
             ) {

--- a/src/highlighter.js
+++ b/src/highlighter.js
@@ -371,7 +371,7 @@ export default function (options) {
      * @param {number} groupId - the highlight group
      */
     function wrapTextNode(node, groupId) {
-        if (isWrapping && !isWrappingNode(node.parentNode) && isText(node)) {
+        if (isWrapping && !isWrappingNode(node.parentNode) && isWrappable(node)) {
             $(node).wrap($(getWrapper(groupId)));
         }
     }

--- a/src/highlighter.js
+++ b/src/highlighter.js
@@ -371,7 +371,7 @@ export default function (options) {
      * @param {number} groupId - the highlight group
      */
     function wrapTextNode(node, groupId) {
-        if (isWrapping && !isWrappingNode(node.parentNode) && isWrappable(node)) {
+        if (isWrapping && !isWrappingNode(node.parentNode) && isText(node)) {
             $(node).wrap($(getWrapper(groupId)));
         }
     }

--- a/src/highlighter.js
+++ b/src/highlighter.js
@@ -548,7 +548,10 @@ export default function (options) {
                     }
 
                     inlineOffset += currentNode.textContent.length;
-                    currentNode = isHotNode(currentNode.nextSibling) ? currentNode.nextSibling : null;
+                    currentNode =
+                        isHotNode(currentNode.nextSibling) || isText(currentNode.nextSibling)
+                            ? currentNode.nextSibling
+                            : null;
                     nodesToSkip++;
                 }
                 i += nodesToSkip; // we increase the loop counter to avoid looping over the nodes that we just analyzed
@@ -689,7 +692,7 @@ export default function (options) {
      * @returns {boolean}
      */
     function isWrappable(node) {
-        return isText(node) && !isBlacklisted(node) && node.textContent.length > 0;
+        return isText(node) && !isBlacklisted(node) && node.textContent.trim().length > 0;
     }
 
     /**


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/MS-1061
**Description:** In case of two highlights has node with an empty space(could be any number of spaces or line break) between, during the building highlights indexes, the process creates inline ranges.
The inline ranges build phase were skipping the text node that empty(i.g contains space) that cause the wrong order of setting indexes.
<img width="569" alt="Screenshot 2021-03-24 at 17 38 01" src="https://user-images.githubusercontent.com/6339002/112348003-b059fc80-8cc7-11eb-8ae1-60646eb1d9de.png">

**How to test:** 
- Login as Scorer
- Highlight 2 or more nodes to leave an empty space between
- Reload the page.
- The highlighting parts must be restored correctly