### PR TITLE
Fix/TR-903/Continue dragging element outside of the window

### DIFF
--- a/src/interactUtils.js
+++ b/src/interactUtils.js
@@ -47,10 +47,10 @@ interactHelper = {
      */
     iFrameDragFixOn: function iFrameDragFixOn(simulateDropCb) {
         simulateDrop = simulateDropCb;
-        document.body.addEventListener('mouseleave', iFrameDragFixCb);
+        window.addEventListener('mouseleave', iFrameDragFixCb);
     },
     iFrameDragFixOff: function iFrameDragFixOff() {
-        document.body.removeEventListener('mouseleave', iFrameDragFixCb);
+        window.removeEventListener('mouseleave', iFrameDragFixCb);
     },
 
     /**

--- a/test/interactUtils/test.js
+++ b/test/interactUtils/test.js
@@ -143,10 +143,10 @@ define(['jquery', 'lodash', 'interact', 'ui/interactUtils', 'core/mouseEvent'], 
             ready();
         });
 
-        triggerMouseEvent(document.body, 'mouseleave', {});
+        triggerMouseEvent(window, 'mouseleave', {});
 
         interactUtils.iFrameDragFixOff();
 
-        triggerMouseEvent(document.body, 'mouseleave', {}); // Triggers an error if event listener hasn\'t been removed
+        triggerMouseEvent(window, 'mouseleave', {}); // Triggers an error if event listener hasn\'t been removed
     });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-903

Fix a drag&drop issue while trying to drag the element outside of the window: once back to the window, the link with the dragged element is lost.

How to test:
- check the unit test for the interactUtils module: `npm test interactUtils`
- see the companion PR

Note: the `ui/interactUtils` helper has been added by these PR:
- https://github.com/oat-sa/tao-core/pull/844
- https://github.com/oat-sa/extension-tao-itemqti/pull/691

It looks like it is only used by QTI interactions (cf. https://github.com/search?q=org%3Aoat-sa+iFrameDragFixOn&type=Code).