### PR TITLE
Fix/Add a missing alias to the select2 wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,8 +1046,9 @@
             }
         },
         "@oat-sa/tao-core-libs": {
-            "version": "github:oat-sa/tao-core-libs-fe#7fe3487a4fd306a30713fefcbf55ac910272b5bc",
-            "from": "github:oat-sa/tao-core-libs-fe#fix/missing-alias-for-select2-wrapper",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.4.tgz",
+            "integrity": "sha512-DvleNKX5Ljnnl5fxUp8ss1yFubFSyzO/V3uuTaBjw6EkBPfLuNmvMi915AQ3UgX7tV6ysMc6B0HlbLxcwZp86A==",
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1069,25 +1069,25 @@
             "dev": true
         },
         "@oat-sa/tao-qunit-testrunner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-qunit-testrunner/-/tao-qunit-testrunner-0.1.3.tgz",
-            "integrity": "sha512-BgSzuFTyqAJRKoDdpNcWjWW37dwchfCllPRRqNaYEwyk40vsHQjIxlNMMvDesi/uBSzSDw6F+M2HB6t/uWdtKg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-qunit-testrunner/-/tao-qunit-testrunner-1.0.3.tgz",
+            "integrity": "sha512-1Zo+GxzEL777eaeJekIIY1lw30I9Zm2tb1pRT7j/IfFV1yR8tW05ni+O545MQm1mrxdOuP/HKB4+DuiaYB9GHg==",
             "dev": true,
             "requires": {
                 "body-parser": "^1.19.0",
                 "chalk": "^2.4.2",
                 "connect": "^3.7.0",
-                "fs-extra": "^8.0.1",
+                "fs-extra": "^8.1.0",
                 "get-port": "^5.0.0",
-                "glob": "^7.1.4",
+                "glob": "^7.1.6",
                 "glob-promise": "^3.4.0",
                 "istanbul-lib-instrument": "^3.3.0",
                 "minimatch": "^3.0.4",
-                "node-qunit-puppeteer": "^1.0.13",
+                "node-qunit-puppeteer": "^1.0.16",
                 "promise-limit": "^2.7.0",
                 "serve-index": "^1.9.1",
                 "serve-static": "^1.14.1",
-                "yargs": "^13.2.4"
+                "yargs": "^13.3.0"
             }
         },
         "@types/estree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,9 +1046,8 @@
             }
         },
         "@oat-sa/tao-core-libs": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.3.tgz",
-            "integrity": "sha512-6H4B5ETIWK011gJIPNxOMP2xIdWLNcTpDRsQvLuHO/716KbGG5PCAFCgQwdhmyIBAx9ApUeTF2ee0Xn6Ds0FAA==",
+            "version": "github:oat-sa/tao-core-libs-fe#7fe3487a4fd306a30713fefcbf55ac910272b5bc",
+            "from": "github:oat-sa/tao-core-libs-fe#fix/missing-alias-for-select2-wrapper",
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "github:oat-sa/tao-core-libs-fe#fix/missing-alias-for-select2-wrapper",
+        "@oat-sa/tao-core-libs": "^0.4.4",
         "@oat-sa/tao-core-sdk": "^1.8.1",
         "@oat-sa/tao-core-shared-libs": "1.0.0",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "^1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "^0.4.3",
+        "@oat-sa/tao-core-libs": "github:oat-sa/tao-core-libs-fe#fix/missing-alias-for-select2-wrapper",
         "@oat-sa/tao-core-sdk": "^1.8.1",
         "@oat-sa/tao-core-shared-libs": "1.0.0",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@oat-sa/tao-core-libs": "^0.4.4",
         "@oat-sa/tao-core-sdk": "^1.8.1",
         "@oat-sa/tao-core-shared-libs": "1.0.0",
-        "@oat-sa/tao-qunit-testrunner": "^0.1.3",
+        "@oat-sa/tao-qunit-testrunner": "^1.0.3",
         "async": "^0.2.10",
         "autoprefixer": "^9.5.1",
         "cross-env": "^7.0.2",


### PR DESCRIPTION
Update the library `@oat-sa/tao-core-libs` as it was failing the unit tests since a change made for the `select2` library.

Requires: 
 - [x] https://github.com/oat-sa/tao-core-libs-fe/pull/33
 - [x] Once the companion has been merged, the package.json and package-lock.json files need to be updated with the released version. Pay attention to have the npm package instead of the GitHub repository in the lock file. Pay also attention to not break the package-lock with the issue with the `eve` account on the adobe-webplatform dependency.

To test:
- make sure to have the depencies installed: `npm i`
- launch the unit test: `npm test`
- the datetime/picker is failing, if will be fixed in another pr
- the bulkActionPopup should pass (failing in timeout due to a 404 without the fix)