### PR TITLE
Fix/NCC-63/datetime/picker does not load the locale

### DIFF
--- a/src/datetime/picker.js
+++ b/src/datetime/picker.js
@@ -111,7 +111,7 @@ var supportedConstraints = ['minDate', 'maxDate', 'enable', 'disable'];
  * @param {String} locale
  * @returns {Boolean}
  */
-const hasTranslationsForLocale = locale => _.isObject(flatpickrLocalization.default[locale]);
+const hasTranslationsForLocale = locale => _.isObject(flatpickrLocalization[locale]);
 
 /**
  * Detects document language


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NCC-63

Fix an issue introduced with #93 as the check for the existing locale was done on the wrong object.

How to test:
- install the package: `npm i`
- run the tests: `npm test`

Note: this only fixes the failing test for the datetime/picker. Other unit tests still fail (searchModal component)