### PR TITLE
feature/AUT-396/added removed node to deleter.deleted event

### DIFF
--- a/src/deleter.js
+++ b/src/deleter.js
@@ -103,7 +103,7 @@ var deleter = {
                  * The target has been closed/removed.
                  * @event deleter#deleted.deleter
                  */
-                $evtTrigger.trigger('deleted.' + ns);
+                $evtTrigger.trigger('deleted.' + ns, [$target]);
             }
         };
         if (options && !$elt.hasClass(options.disableClass)) {


### PR DESCRIPTION
**Ticket**: [AUT-396](https://oat-sa.atlassian.net/browse/AUT-396)

**Description**
Added deleted node to `deleted.deleter` event. It is important because this event fires on the parent node, and we should have a possibility to detect which node was removed.

_NOTE_: Unit tests have already been broken, and they aren't related to the current change.