### PR TITLE
[Fix] - ADF-7 - Replace OR with AND in Advanced search criteria 

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -13,8 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
+
 import $ from 'jquery';
 import _ from 'lodash';
 import __ from 'i18n';
@@ -256,7 +257,7 @@ export default function searchModalFactory(config) {
         });
 
         /**
-         * Pressing space, enter, esc, backspace 
+         * Pressing space, enter, esc, backspace
          * on class filter input will toggle resource selector
          */
         const shortcuts = shortcutRegistry($classFilterInput);
@@ -271,7 +272,7 @@ export default function searchModalFactory(config) {
         $classFilterContainer.on('click', e => {
             $classTreeContainer.toggle();
         });
-        
+
         /**
          * clicking on class filter container will
          * stopPropagation to prevent be closed

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -13,8 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
+
 import $ from 'jquery';
 import _ from 'lodash';
 import __ from 'i18n';

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -116,7 +116,8 @@ export default function advancedSearchFactory(config) {
                     }
                 } else if (renderedCriterion.type === criteriaTypes.list) {
                     if (renderedCriterion.value && renderedCriterion.value.length > 0) {
-                        query += `${renderedCriterion.label}:${renderedCriterion.value.join(' OR ')}`;
+                        /* Temp replaced OR with AND. See ADF-7 for details */
+                        query += `${renderedCriterion.label}:${renderedCriterion.value.join(' AND ')}`;
                     }
                 }
             });

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -203,12 +203,12 @@ define([
     });
     QUnit.test('bind between view and model is correctly set', function (assert) {
         const instance = advancedSearchFactory({
-            renderTo: '#testable-container',
-            isAdvancedSearchStatusEnabled: true
+            renderTo: '#testable-container'
         });
         const ready = assert.async();
         assert.expect(8);
-        instance.off('ready').on('ready', function () {
+
+        instance.on('ready', function () {
             instance.updateCriteria('undefined/tao/ClassMetadata/').then(function () {
                 const $container = $('.advanced-search-container');
                 const $criteriaContainer = $container.find('.advanced-criteria-container');

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -41,13 +41,9 @@ define([
     $.mockjax({
         url: 'undefined/tao/AdvancedSearch/status',
         dataType: 'json',
-        responseText: {
-            success: true,
-            data: {
-                enabled: true
-            }
-        }
+        responseText: mocks.mockedStatusEnabled
     });
+
     QUnit.module('advancedSearch');
     QUnit.test('module', function (assert) {
         assert.expect(1);

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -13,8 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
+
 define([
     'jquery',
     'lodash',
@@ -24,7 +25,6 @@ define([
     'json!test/ui/searchModal/mocks/mocks.json',
     'jquery.mockjax'
 ], function ($, _, searchModalFactory, advancedSearchFactory, store, mocks) {
-
     // Prevent the AJAX mocks to pollute the logs
     $.mockjaxSettings.logger = null;
     $.mockjaxSettings.responseTime = 1;

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -207,68 +207,71 @@ define([
     });
     QUnit.test('bind between view and model is correctly set', function (assert) {
         const instance = advancedSearchFactory({
-            renderTo: '#testable-container'
+            renderTo: '#testable-container',
+            isAdvancedSearchStatusEnabled: true
         });
         const ready = assert.async();
         assert.expect(8);
-        instance.updateCriteria('undefined/tao/ClassMetadata/').then(function () {
-            const $container = $('.advanced-search-container');
-            const $criteriaContainer = $container.find('.advanced-criteria-container');
-            const $criteriaSelect = $('.add-criteria-container select', $container);
-            // check initial state
-            assert.equal($criteriaContainer.length, 1, 'container for criteria is rendered');
-            assert.equal($criteriaContainer.children().length, 0, 'container for criteria is empty');
+        instance.off('ready').on('ready', function () {
+            instance.updateCriteria('undefined/tao/ClassMetadata/').then(function () {
+                const $container = $('.advanced-search-container');
+                const $criteriaContainer = $container.find('.advanced-criteria-container');
+                const $criteriaSelect = $('.add-criteria-container select', $container);
+                // check initial state
+                assert.equal($criteriaContainer.length, 1, 'container for criteria is rendered');
+                assert.equal($criteriaContainer.children().length, 0, 'container for criteria is empty');
 
-            // set a default value for each criterion
-            instance.getState()['in-both-text'].value = 'default value0';
-            instance.getState()['in-both-select'].value = ['value0'];
-            instance.getState()['in-both-list'].value = ['value1'];
+                // set a default value for each criterion
+                instance.getState()['in-both-text'].value = 'default value0';
+                instance.getState()['in-both-select'].value = ['value0'];
+                instance.getState()['in-both-list'].value = ['value1'];
 
-            // render a criterion from each type
-            $criteriaSelect.select2('val', 'in-both-text').trigger('change');
-            $criteriaSelect.select2('val', 'in-both-select').trigger('change');
-            $criteriaSelect.select2('val', 'in-both-list').trigger('change');
-            const $criterionTextInput = $criteriaContainer.find('.inbothtext-filter input');
-            const $criterionSelectInput = $criteriaContainer.find('.inbothselect-filter input');
-            const $criterionListSelected = $criteriaContainer
-                .find('.inbothlist-filter input[type=checkbox]:checked')
-                .get()
-                .map(checkbox => {
-                    return checkbox.value;
-                });
+                // render a criterion from each type
+                $criteriaSelect.select2('val', 'in-both-text').trigger('change');
+                $criteriaSelect.select2('val', 'in-both-select').trigger('change');
+                $criteriaSelect.select2('val', 'in-both-list').trigger('change');
+                const $criterionTextInput = $criteriaContainer.find('.inbothtext-filter input');
+                const $criterionSelectInput = $criteriaContainer.find('.inbothselect-filter input');
+                const $criterionListSelected = $criteriaContainer
+                    .find('.inbothlist-filter input[type=checkbox]:checked')
+                    .get()
+                    .map(checkbox => {
+                        return checkbox.value;
+                    });
 
-            // check default value on each criterion type
-            assert.equal($criterionTextInput.val(), 'default value0', 'text criterion correctly initialized');
-            assert.deepEqual(
-                $criterionSelectInput.select2('val'),
-                ['value0'],
-                'select criterion correctly initialized'
-            );
-            assert.deepEqual($criterionListSelected, ['value1'], 'list criterion correctly initialized');
+                // check default value on each criterion type
+                assert.equal($criterionTextInput.val(), 'default value0', 'text criterion correctly initialized');
+                assert.deepEqual(
+                    $criterionSelectInput.select2('val'),
+                    ['value0'],
+                    'select criterion correctly initialized'
+                );
+                assert.deepEqual($criterionListSelected, ['value1'], 'list criterion correctly initialized');
 
-            // update value on each criterion
-            $criterionTextInput.val('foo0').trigger('change');
-            $criteriaContainer
-                .find('.inbothlist-filter input[type=checkbox][value=value2]')
-                .prop('checked', true)
-                .trigger('change');
+                // update value on each criterion
+                $criterionTextInput.val('foo0').trigger('change');
+                $criteriaContainer
+                    .find('.inbothlist-filter input[type=checkbox][value=value2]')
+                    .prop('checked', true)
+                    .trigger('change');
 
-            // check updated value on each criterion
-            assert.equal(instance.getState()['in-both-text'].value, 'foo0', 'text criterion correctly updated');
-            assert.deepEqual(
-                instance.getState()['in-both-list'].value,
-                ['value1', 'value2'],
-                'list criteria correctly updated'
-            );
+                // check updated value on each criterion
+                assert.equal(instance.getState()['in-both-text'].value, 'foo0', 'text criterion correctly updated');
+                assert.deepEqual(
+                    instance.getState()['in-both-list'].value,
+                    ['value1', 'value2'],
+                    'list criteria correctly updated'
+                );
 
-            const query = instance.getAdvancedCriteriaQuery();
-            assert.equal(
-                query,
-                'in-both-text:foo0 AND in-both-list:value1 OR value2 AND in-both-select:value0',
-                'advanced search query is correctly built'
-            );
-            instance.destroy();
-            ready();
+                const query = instance.getAdvancedCriteriaQuery();
+                assert.equal(
+                    query,
+                    'in-both-text:foo0 AND in-both-list:value1 OR value2 AND in-both-select:value0',
+                    'advanced search query is correctly built'
+                );
+                instance.destroy();
+                ready();
+            });
         });
     });
 

--- a/test/searchModal/mocks/mocks.json
+++ b/test/searchModal/mocks/mocks.json
@@ -200,5 +200,11 @@
             "rendered": true,
             "value": ["English"]
         }
+    },
+    "mockedStatusEnabled": {
+        "success": true,
+        "data": {
+            "enabled": true
+        }
     }
 }

--- a/test/searchModal/mocks/with-no-occurrences/search.json
+++ b/test/searchModal/mocks/with-no-occurrences/search.json
@@ -1,10 +1,18 @@
 {
-    "url": "/test/searchModal/mocks/with-no-occurrences/dataset.json",
-    "model": {
-        "http://www.w3.org/2000/01/rdf-schema#label": {
-            "id": "http://www.w3.org/2000/01/rdf-schema#label",
-            "label": "Label",
-            "sortable": false
-        }
+    "data": {
+        "url": "/test/searchModal/mocks/with-no-occurrences/dataset.json",
+        "model": {
+            "http://www.w3.org/2000/01/rdf-schema#label": {
+                "id": "http://www.w3.org/2000/01/rdf-schema#label",
+                "label": "Label",
+                "sortable": false
+            }
+        },
+        "params": {
+            "rootNode": "http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#Item",
+            "parentNode": "http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#Item",
+            "structure": "items"
+        },
+        "filter": []
     }
 }

--- a/test/searchModal/mocks/with-occurrences/search.json
+++ b/test/searchModal/mocks/with-occurrences/search.json
@@ -1,10 +1,18 @@
 {
-    "url": "/test/searchModal/mocks/with-occurrences/dataset.json",
-    "model": {
-        "http://www.w3.org/2000/01/rdf-schema#label": {
-            "id": "http://www.w3.org/2000/01/rdf-schema#label",
-            "label": "Label",
-            "sortable": false
-        }
+    "data": {
+        "url": "/test/searchModal/mocks/with-occurrences/dataset.json",
+        "model": {
+            "http://www.w3.org/2000/01/rdf-schema#label": {
+                "id": "http://www.w3.org/2000/01/rdf-schema#label",
+                "label": "Label",
+                "sortable": false
+            }
+        },
+        "params": {
+            "rootNode": "http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#Item",
+            "parentNode": "http:\\/\\/www.tao.lu\\/Ontologies\\/TAOItem.rdf#Item",
+            "structure": "items"
+        },
+        "filter": []
     }
 }

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -329,7 +329,7 @@ define([
         const ready = assert.async();
         assert.expect(5);
 
-        instance.off('ready').on('ready', function () {
+        instance.on('ready', function () {
             instance.on('store-updated', function () {
                 const $datatable = $('table.datatable');
                 assert.equal($datatable.length, 1, 'datatable has been created');


### PR DESCRIPTION
**Jira**
https://oat-sa.atlassian.net/browse/ADF-7

**TL;DR**
This is a temp solution.
In order for advanced search to work with criteria when multiple values are chosen the team decided to replace OR operator with AND in search request. This is due to some BE limitations with Elastic. Fix of OR operator is in backlog so we need to go with AND for now.

**Deployed** to playground, link is in the ticket