### PR TITLE
Fix/TR-1131/emit theme applied event

### DIFF
--- a/src/themeLoader.js
+++ b/src/themeLoader.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -26,15 +26,15 @@ import $ from 'jquery';
 import _ from 'lodash';
 
 //used to differentiate the stylesheets
-var prefix = 'custom-theme-';
+const prefix = 'custom-theme-';
 
 //where to attach the stylesheets
-var $container = $('head').length ? $('head') : $('body');
+const $container = $('head').length ? $('head') : $('body');
 
-var ns = 'themeloader';
+const ns = 'themeloader';
 
 /**
- * @typedef Theme
+ * @typedef {Object} Theme
  * @property {String} id - theme identifier (unique)
  * @property {String} path  - theme location
  * @property {String} [name] - name to display
@@ -46,20 +46,20 @@ var ns = 'themeloader';
  *
  * @param themeId
  */
-
-var triggerThemeChange = function triggerThemeChange(themeId) {
-    _.delay(function() {
-        $(document).trigger('themechange.' + ns, [themeId]);
+function triggerThemeChange(themeId) {
+    _.delay(() => {
+        $(document).trigger(`themechange.${ns}`, [themeId]);
     }, 200);
-};
+}
 
 /**
  * Create a stylesheet tag
  * @param {Theme} theme - the theme
- * @return {jQueryElement} the link node
+ * @return {jQuery} the link node
  */
-var createStyleSheet = function createStyleSheet(theme) {
-    var type = theme.id === 'base' ? prefix + 'base' : prefix + 'theme';
+function createStyleSheet(theme) {
+    const suffix = theme.id === 'base' ? 'base' : 'theme';
+    const type = `${prefix}${suffix}`;
     return $('<link>').attr({
         rel: 'stylesheet',
         type: 'text/css',
@@ -68,45 +68,45 @@ var createStyleSheet = function createStyleSheet(theme) {
         'data-name': theme.name || theme.id,
         'data-id': theme.id
     });
-};
+}
 
 /**
  * Get the stylesheet
  * @param {String} id - the theme identifier
- * @returns {jQueryElement} the link
+ * @returns {jQuery} the link
  */
-var getLink = function getLink(id) {
-    return $('link[data-id="' + id + '"][data-type^="' + prefix + '"]', $container);
-};
+function getLink(id) {
+    return $(`link[data-id="${id}"][data-type^="${prefix}"]`, $container);
+}
 
 /**
  * Is the stylesheet attached to the container ?
  * @param {String} id - the theme identifier
  */
-var isAttached = function isAttached(id) {
+function isAttached(id) {
     return getLink(id).length > 0;
-};
+}
 
 /**
  * Enable some nodes
- * @param {jQueryElement} $nodes - the nodes to enable
- * @returns {jQueryElement}
+ * @param {jQuery} $nodes - the nodes to enable
+ * @returns {jQuery}
  */
-var enable = function enable($nodes) {
+function enable($nodes) {
     $nodes
         .prop('disabled', false)
         .removeProp('disabled')
         .removeAttr('disabled');
-};
+}
 
 /**
  * Disable some nodes
- * @param {jQueryElement} $nodes - the nodes to disable
- * @returns {jQueryElement}
+ * @param {jQuery} $nodes - the nodes to disable
+ * @returns {jQuery}
  */
-var disable = function disable($nodes) {
+function disable($nodes) {
     return $nodes.prop('disabled', true).attr('disabled', true); //add attr only for easiest inspection
-};
+}
 
 /**
  * The themeLoader is a factory that returns a loader. Configured to load the given styles.
@@ -118,12 +118,7 @@ var disable = function disable($nodes) {
  * @returns {Object} the loader
  * @throws TypeError if the config hasn't the correct form
  */
-var themeLoader = function themeLoader(config) {
-    var defaultTheme;
-    var activeTheme;
-    var styles = {};
-    var themes;
-    var i;
+function themeLoader(config) {
 
     /*
      * validate config
@@ -140,7 +135,7 @@ var themeLoader = function themeLoader(config) {
         throw new TypeError('No theme declared in the configuration');
     }
 
-    for (i in config.available) {
+    for (let i in config.available) {
         if (
             !_.isPlainObject(config.available[i]) ||
             _.isEmpty(config.available[i].id) ||
@@ -153,20 +148,19 @@ var themeLoader = function themeLoader(config) {
     /*
      * Extract data from config
      */
-    defaultTheme = config.default || _.first(_.pluck(config.available, 'id'));
+    const defaultTheme = config.default || _.first(_.pluck(config.available, 'id'));
 
-    activeTheme = defaultTheme;
+    let activeTheme = defaultTheme;
 
-    themes = [
-        {
-            id: 'base',
-            path: config.base,
-            name: 'TAO'
-        }
-    ];
-    themes = themes.concat(config.available);
+    const themes = [{
+        id: 'base',
+        path: config.base,
+        name: 'TAO'
+    }].concat(config.available);
 
-    _.forEach(themes, function(theme) {
+    const styles = {};
+
+    _.forEach(themes, theme => {
         if (isAttached(theme.id)) {
             styles[theme.id] = getLink(theme.id);
         } else {
@@ -183,13 +177,11 @@ var themeLoader = function themeLoader(config) {
          * @param {Boolean} [preload=false] - Only preload the themes without activating them
          * @returns {Object} chains
          */
-        load: function load(preload) {
-            _.forEach(styles, function($link, id) {
+        load(preload) {
+            _.forEach(styles, ($link, id) => {
                 if (!isAttached(id)) {
                     if (!preload && id === activeTheme) {
-                        $link.on('load', function() {
-                            triggerThemeChange(id);
-                        });
+                        $link.on('load', () => triggerThemeChange(id));
                     }
                     disable($link);
                     $container.append($link);
@@ -212,8 +204,8 @@ var themeLoader = function themeLoader(config) {
          * Unload the stylesheets (disable them)
          * @returns {Object} chains
          */
-        unload: function unload() {
-            disable($('link[data-type^="' + prefix + '"]', $container));
+        unload() {
+            disable($(`link[data-type^="${prefix}"]`, $container));
 
             return this;
         },
@@ -223,7 +215,7 @@ var themeLoader = function themeLoader(config) {
          * @param {String} id - the theme id to use
          * @returns {Object} chains
          */
-        change: function change(id) {
+        change(id) {
             //support to change to the "default" theme regardless it's id
             if (_.contains(['base', 'default'], id) && !isAttached(id)) {
                 id = defaultTheme;
@@ -231,7 +223,7 @@ var themeLoader = function themeLoader(config) {
 
             if (isAttached(id)) {
                 //disable all
-                disable($('link[data-type="' + prefix + 'theme"]', $container));
+                disable($(`link[data-type="${prefix}theme"]`, $container));
 
                 //enable the theme only
                 enable(getLink(id));
@@ -246,11 +238,11 @@ var themeLoader = function themeLoader(config) {
          * Return the current theme
          * @returns {String} activeTheme
          */
-        getActiveTheme: function getActiveTheme() {
+        getActiveTheme() {
             return activeTheme;
         }
     };
-};
+}
 
 /**
  * @exports ui/themeLoader

--- a/src/themeLoader.js
+++ b/src/themeLoader.js
@@ -48,7 +48,9 @@ const ns = 'themeloader';
  */
 function triggerThemeChange(themeId) {
     _.delay(() => {
-        $(document).trigger(`themechange.${ns}`, [themeId]);
+        $(document)
+            .trigger(`themechange.${ns}`, [themeId])
+            .trigger('themeapplied', [themeId]);
     }, 200);
 }
 

--- a/test/themeLoader/test.js
+++ b/test/themeLoader/test.js
@@ -26,10 +26,16 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
     const red = 'rgb(255, 0, 0)';
 
     let eventTriggered = '';
+    let themeApplied = '';
 
     $(document)
         .off('themechange.themeloader')
         .on('themechange.themeloader', (e, data) => eventTriggered = data);
+
+    $(document)
+        .off('themeapplied.test')
+        .on('themeapplied.test', (e, themeId) => themeApplied = themeId);
+
 
     QUnit.module('Theme Loader API');
 
@@ -95,7 +101,7 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
         const loader = themeLoader(config);
         const $container = $('#qti-item');
 
-        assert.expect(6);
+        assert.expect(7);
 
         assert.equal($container.length, 1, 'The container exists');
 
@@ -113,6 +119,11 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
                     eventTriggered,
                     loader.getActiveTheme(),
                     'The themechange event has been triggered along with the correct parameters'
+                );
+                assert.equal(
+                    themeApplied,
+                    loader.getActiveTheme(),
+                    'The themeapplied event has been triggered along with the correct parameters'
                 );
                 ready();
             }, 250);
@@ -187,7 +198,7 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
         const loader = themeLoader(config);
         const $container = $('#qti-item');
 
-        assert.expect(9);
+        assert.expect(10);
 
         assert.equal($container.length, 1, 'The container exists');
 
@@ -213,6 +224,11 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
                         loader.getActiveTheme(),
                         'The themechange event has been triggered along with the correct parameters'
                     );
+                    assert.equal(
+                        themeApplied,
+                        loader.getActiveTheme(),
+                        'The themeapplied event has been triggered along with the correct parameters'
+                    );
                     ready();
                 }, 250);
             }, 50);
@@ -224,7 +240,7 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
         const loader = themeLoader(config);
         const $container = $('#qti-item');
 
-        assert.expect(11);
+        assert.expect(12);
 
         assert.equal($container.length, 1, 'The container exists');
 
@@ -256,6 +272,11 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
                             loader.getActiveTheme(),
                             'The themechange event has been triggered along with the correct parameters'
                         );
+                        assert.equal(
+                            themeApplied,
+                            loader.getActiveTheme(),
+                            'The themeapplied event has been triggered along with the correct parameters'
+                        );
                         ready();
                     }, 250);
                 }, 100);
@@ -268,7 +289,7 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
         const loader = themeLoader(config);
         const $container = $('#qti-item');
 
-        assert.expect(16);
+        assert.expect(17);
 
         assert.equal($container.length, 1, 'The container exists');
 
@@ -309,6 +330,11 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
                                 eventTriggered,
                                 loader2.getActiveTheme(),
                                 'The themechange event has been triggered along with the correct parameters'
+                            );
+                            assert.equal(
+                                themeApplied,
+                                loader2.getActiveTheme(),
+                                'The themeapplied event has been triggered along with the correct parameters'
                             );
                             ready();
                         }, 250);

--- a/test/themeLoader/test.js
+++ b/test/themeLoader/test.js
@@ -1,7 +1,9 @@
-define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
+define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
     'use strict';
 
-    var config = {
+    const getStyleSheets = () => $('link[data-type^="custom-theme"]');
+
+    const config = {
         base: 'base.css',
         default: 'blue',
         available: [
@@ -18,63 +20,51 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         ]
     };
 
-    var pink = 'rgb(255, 192, 203)';
-    var blue = 'rgb(0, 0, 255)';
-    var green = 'rgb(0, 128, 0)';
-    var red = 'rgb(255, 0, 0)';
+    const pink = 'rgb(255, 192, 203)';
+    const blue = 'rgb(0, 0, 255)';
+    const green = 'rgb(0, 128, 0)';
+    const red = 'rgb(255, 0, 0)';
 
-    var eventTriggered = '';
+    let eventTriggered = '';
 
     $(document)
         .off('themechange.themeloader')
-        .on('themechange.themeloader', function(e, data) {
-            eventTriggered = data;
-        });
+        .on('themechange.themeloader', (e, data) => eventTriggered = data);
 
     QUnit.module('Theme Loader API');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', assert => {
         assert.expect(2);
         assert.ok(typeof themeLoader !== 'undefined', 'The module exports something');
         assert.ok(typeof themeLoader === 'function', 'The module exports a function');
     });
 
-    QUnit.test('config format', function(assert) {
+    QUnit.test('config format', assert => {
         assert.expect(4);
 
         assert.throws(
-            function() {
-                themeLoader();
-            },
+            () => themeLoader(),
             TypeError,
             'A config parameter is required'
         );
 
         assert.throws(
-            function() {
-                themeLoader({});
-            },
+            () => themeLoader({}),
             TypeError,
             'A config parameter with a base property is required'
         );
 
         assert.throws(
-            function() {
-                themeLoader({
-                    base: ''
-                });
-            },
+            () => themeLoader({ base: '' }),
             TypeError,
             'A config parameter with available themes property is required'
         );
 
         assert.throws(
-            function() {
-                themeLoader({
-                    base: '',
-                    available: [{}]
-                });
-            },
+            () => themeLoader({
+                base: '',
+                available: [{}]
+            }),
             TypeError,
             'Themes should contain path and id'
         );
@@ -83,8 +73,8 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         themeLoader(config);
     });
 
-    QUnit.test('loader api', function(assert) {
-        var loader = themeLoader(config);
+    QUnit.test('loader api', assert => {
+        const loader = themeLoader(config);
 
         assert.expect(4);
 
@@ -95,32 +85,30 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
     });
 
     QUnit.module('Theme loading', {
-        afterEach: function(assert) {
-            $('head')
-                .find('link[data-type^="custom-theme"]')
-                .remove();
+        afterEach() {
+            getStyleSheets().remove();
         }
     });
 
-    QUnit.test('load', function(assert) {
-        var ready = assert.async();
-        var loader = themeLoader(config);
-        var $container = $('#qti-item');
+    QUnit.test('load', assert => {
+        const ready = assert.async();
+        const loader = themeLoader(config);
+        const $container = $('#qti-item');
 
         assert.expect(6);
 
         assert.equal($container.length, 1, 'The container exists');
 
         loader.load();
-        setTimeout(function() {
-            var $styleSheets = $('link[data-type^="custom-theme"]');
+        setTimeout(() => {
+            const $styleSheets = getStyleSheets();
             assert.ok($styleSheets.length > 0, 'The styleSheets have been inserted');
             assert.equal($styleSheets.length, 3, 'All styleSheets have been inserted');
 
             assert.equal($container.css('background-color'), pink, 'The base style is loaded and computed');
             assert.equal($container.css('color'), blue, 'The theme style is loaded and computed');
 
-            setTimeout(function() {
+            setTimeout(() => {
                 assert.equal(
                     eventTriggered,
                     loader.getActiveTheme(),
@@ -131,32 +119,29 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         }, 50);
     });
 
-    QUnit.test('preload', function(assert) {
-        var ready = assert.async();
-        var preloadConfig = _.cloneDeep(config);
-        var $styleSheets = $('link[data-type^="custom-theme"]');
-        var $container = $('#qti-item');
-        var loader;
+    QUnit.test('preload', assert => {
+        const ready = assert.async();
+        const preloadConfig = _.cloneDeep(config);
+        const $container = $('#qti-item');
 
         preloadConfig.available.push({
             id: 'red',
             path: 'red.css',
             name: 'Red'
         });
-        loader = themeLoader(preloadConfig);
+        const loader = themeLoader(preloadConfig);
 
         assert.expect(7);
 
-        $styleSheets.remove();
-        $styleSheets = $('link[data-type^="custom-theme"]');
-        assert.equal($styleSheets.length, 0, 'All styleSheets have been removed');
+        getStyleSheets().remove();
+        assert.equal(getStyleSheets().length, 0, 'All styleSheets have been removed');
         assert.equal($container.length, 1, 'The container exists');
 
         loader.load(true);
-        setTimeout(function() {
-            $styleSheets = $('link[data-type^="custom-theme"]');
+        setTimeout(() => {
+            const $styleSheets = getStyleSheets();
             assert.equal($styleSheets.length, 4, 'All styleSheets have been inserted');
-            $styleSheets.each(function() {
+            $styleSheets.each(function () {
                 assert.equal(this.getAttribute('disabled'), 'disabled', 'The loaded styleSheet is disabled');
             });
 
@@ -164,18 +149,18 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         }, 50);
     });
 
-    QUnit.test('unload', function(assert) {
-        var ready = assert.async();
-        var loader = themeLoader(config);
-        var $container = $('#qti-item');
+    QUnit.test('unload', assert => {
+        const ready = assert.async();
+        const loader = themeLoader(config);
+        const $container = $('#qti-item');
 
         assert.expect(11);
 
         assert.equal($container.length, 1, 'The container exists');
 
         loader.load();
-        setTimeout(function() {
-            var $styleSheets = $('link[data-type^="custom-theme"]');
+        setTimeout(() => {
+            const $styleSheets = getStyleSheets();
             assert.ok($styleSheets.length > 0, 'The styleSheets have been inserted');
             assert.equal($styleSheets.length, 3, 'All styleSheets have been inserted');
             assert.equal($container.css('background-color'), pink, 'The base style is loaded and computed');
@@ -183,8 +168,8 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
 
             loader.unload();
 
-            setTimeout(function() {
-                assert.equal($('link[data-type^="custom-theme"]').length, 3, 'The stylesheets are still there');
+            setTimeout(() => {
+                assert.equal(getStyleSheets().length, 3, 'The stylesheets are still there');
                 assert.ok($('link[data-id="base"]').prop('disabled'), 'The base stylesheet is disabled');
                 assert.ok($('link[data-id="green"]').prop('disabled'), 'The green stylesheet is disabled');
                 assert.ok($('link[data-id="blue"]').prop('disabled'), 'The blue stylesheet is disabled');
@@ -197,18 +182,18 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         }, 50);
     });
 
-    QUnit.test('change', function(assert) {
-        var ready = assert.async();
-        var loader = themeLoader(config);
-        var $container = $('#qti-item');
+    QUnit.test('change', assert => {
+        const ready = assert.async();
+        const loader = themeLoader(config);
+        const $container = $('#qti-item');
 
         assert.expect(9);
 
         assert.equal($container.length, 1, 'The container exists');
 
         loader.load();
-        setTimeout(function() {
-            var $styleSheets = $('link[data-type^="custom-theme"]');
+        setTimeout(() => {
+            const $styleSheets = getStyleSheets();
             assert.ok($styleSheets.length > 0, 'The styleSheets have been inserted');
             assert.equal($styleSheets.length, 3, 'All styleSheets have been inserted');
 
@@ -217,12 +202,12 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
 
             loader.change('green');
 
-            setTimeout(function() {
+            setTimeout(() => {
                 assert.equal($container.css('background-color'), pink, 'The base style is still loaded');
                 assert.equal($container.css('color'), green, 'The new theme style is loaded and computed');
                 assert.equal(loader.getActiveTheme(), 'green', 'The new theme became the active theme');
 
-                setTimeout(function() {
+                setTimeout(() => {
                     assert.equal(
                         eventTriggered,
                         loader.getActiveTheme(),
@@ -234,18 +219,18 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         }, 50);
     });
 
-    QUnit.test('change back to default', function(assert) {
-        var ready = assert.async();
-        var loader = themeLoader(config);
-        var $container = $('#qti-item');
+    QUnit.test('change back to default', assert => {
+        const ready = assert.async();
+        const loader = themeLoader(config);
+        const $container = $('#qti-item');
 
         assert.expect(11);
 
         assert.equal($container.length, 1, 'The container exists');
 
         loader.load();
-        setTimeout(function() {
-            var $styleSheets = $('link[data-type^="custom-theme"]');
+        setTimeout(() => {
+            const $styleSheets = getStyleSheets();
             assert.ok($styleSheets.length > 0, 'The styleSheets have been inserted');
             assert.equal($styleSheets.length, 3, 'All styleSheets have been inserted');
 
@@ -254,18 +239,18 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
 
             loader.change('green');
 
-            setTimeout(function() {
+            setTimeout(() => {
                 assert.equal($container.css('background-color'), pink, 'The base style is still loaded');
                 assert.equal($container.css('color'), green, 'The new theme style is loaded and computed');
 
                 loader.change('default');
 
-                setTimeout(function() {
+                setTimeout(() => {
                     assert.equal($container.css('background-color'), pink, 'The base style is loaded and computed');
                     assert.equal($container.css('color'), blue, 'The default theme style is loaded');
                     assert.equal(loader.getActiveTheme(), 'blue', 'The active theme has been reset to default');
 
-                    setTimeout(function() {
+                    setTimeout(() => {
                         assert.equal(
                             eventTriggered,
                             loader.getActiveTheme(),
@@ -278,18 +263,18 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
         }, 100);
     });
 
-    QUnit.test('reload and change', function(assert) {
-        var ready = assert.async();
-        var loader = themeLoader(config);
-        var $container = $('#qti-item');
+    QUnit.test('reload and change', assert => {
+        const ready = assert.async();
+        const loader = themeLoader(config);
+        const $container = $('#qti-item');
 
         assert.expect(16);
 
         assert.equal($container.length, 1, 'The container exists');
 
         loader.load();
-        setTimeout(function() {
-            var $styleSheets = $('link[data-type^="custom-theme"]');
+        setTimeout(() => {
+            const $styleSheets = getStyleSheets();
             assert.ok($styleSheets.length > 0, 'The styleSheets have been inserted');
             assert.equal($styleSheets.length, 3, 'All styleSheets have been inserted');
 
@@ -298,30 +283,28 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function(_, $, themeLoader) {
 
             loader.unload();
 
-            setTimeout(function() {
-                var loader2;
-
-                assert.equal($('link[data-type^="custom-theme"]').length, 3, 'The stylesheets are stil there');
+            setTimeout(() => {
+                assert.equal(getStyleSheets().length, 3, 'The stylesheets are stil there');
                 assert.ok($('link[data-id="base"]').prop('disabled'), 'The base stylesheet is disabled');
                 assert.ok($('link[data-id="blue"]').prop('disabled'), 'The blue stylesheet is disabled');
                 assert.ok($('link[data-id="green"]').prop('disabled'), 'The green stylesheet is disabled');
 
-                loader2 = themeLoader(config);
+                const loader2 = themeLoader(config);
                 loader2.load();
 
-                setTimeout(function() {
+                setTimeout(() => {
                     assert.ok(!$('link[data-id="base"]').prop('disabled'), 'The base stylesheet is now enabled');
                     assert.ok(!$('link[data-id="blue"]').prop('disabled'), 'The blue stylesheet is now enabled');
                     assert.ok($('link[data-id="green"]').prop('disabled'), 'The green stylesheet is disabled');
 
                     loader2.change('green');
 
-                    setTimeout(function() {
+                    setTimeout(() => {
                         assert.equal($container.css('background-color'), pink, 'The base style is still loaded');
                         assert.equal($container.css('color'), green, 'The new theme style is loaded and computed');
                         assert.equal(loader2.getActiveTheme(), 'green', 'The new theme became the active theme');
 
-                        setTimeout(function() {
+                        setTimeout(() => {
                             assert.equal(
                                 eventTriggered,
                                 loader2.getActiveTheme(),


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1131

Emit an event when the theme gets applied. Actually, an event was already emitted, but it was scoped for internal purpose and was not namespaceable. We need an event that can be namespaced in order to properly manage the life cycle.

Note: the code was converted to ES6. See this [commit](https://github.com/oat-sa/tao-core-ui-fe/pull/284/commits/189ad034f3dfec84884fa89a56cd60f24d32a74c) for the scoped change.

Impacted unit test: `test/themeLoader/test.html`

How to test: the tests shall pass.
```
npm i
npm test
```
Note: unfortunately, there are still some unit tests failing in develop (advancedSearch component)

The unit test can be launched in the browser as well:
`npm run test:keepAlive`, then open the link in a browser and go to `test/themeLoader/test.html`
