### PR TITLE
[Fix] ADF-210 - AdSearch: Property becomes buggy during the search if it contains spaces in it's Label.

### DIFF
--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -283,7 +283,7 @@ export default function advancedSearchFactory(config) {
          * that is managed with select2, so we init it here
          */
         if (criterion.type === criteriaTypes.list && criterion.uri) {
-            $(`input[name=${criterion.label}-select]`, $criterionContainer).select2({
+            $(`input[name=${criterion.id}-select]`, $criterionContainer).select2({
                 multiple: true,
                 ajax: {
                     url: criterion.uri,
@@ -329,10 +329,10 @@ export default function advancedSearchFactory(config) {
         } else if (criterion.type === criteriaTypes.list && criterion.uri) {
             // set initial value
             if (criterion.value) {
-                $(`input[name=${criterion.label}-select]`, $criterionContainer).select2('val', criterion.value);
+                $(`input[name=${criterion.id}-select]`, $criterionContainer).select2('val', criterion.value);
             }
             // set event to bind input value to critariaState
-            $(`input[name=${criterion.label}-select]`, $criterionContainer).on('change', event => {
+            $(`input[name=${criterion.id}-select]`, $criterionContainer).on('change', event => {
                 criterion.value = event.val;
             });
         } else {

--- a/src/searchModal/tpl/list-select-criterion.tpl
+++ b/src/searchModal/tpl/list-select-criterion.tpl
@@ -1,6 +1,6 @@
 <div class="filter-container {{criterion.id}}-filter" data-criteria="{{criterion.label}}" data-type="{{criterion.type}}">
     <button class="icon-result-nok" aria-label="{{__ "Remove criteria"}}"></button>    <label> 
         <span class="filter-label-text">{{criterion.label}}</span>
-        <input type='text' name="{{criterion.label}}-select">
+        <input type='text' name="{{criterion.id}}-select">
     </label>
 </div>

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -262,7 +262,8 @@ define([
                 const query = instance.getAdvancedCriteriaQuery();
                 assert.equal(
                     query,
-                    'in-both-text:foo0 AND in-both-list:value1 OR value2 AND in-both-select:value0',
+                    // TODO: change 2nd AND to OR when functionality is developed on BE
+                    'in-both-text:foo0 AND in-both-list:value1 AND value2 AND in-both-select:value0',
                     'advanced search query is correctly built'
                 );
                 instance.destroy();

--- a/test/searchModal/mocks/mocks.json
+++ b/test/searchModal/mocks/mocks.json
@@ -100,20 +100,24 @@
                 "class": "parent-class",
                 "metadata": [
                     {
+                        "id": "in-both-text",
                         "label": "in-both-text",
                         "type": "text"
                     },
                     {
+                        "id": "in-both-list",
                         "label": "in-both-list",
                         "type": "list",
                         "values": ["value0", "value1", "value2", "value3"]
                     },
                     {
+                        "id": "in-both-select",
                         "label": "in-both-select",
                         "type": "list",
                         "uri": "foo"
                     },
                     {
+                        "id": "in-parent-text",
                         "label": "in-parent-text",
                         "type": "text"
                     }


### PR DESCRIPTION
### **Related issue:**
https://oat-sa.atlassian.net/browse/ADF-210

### **Description**

If property label contains space, the search by this certain property becomes buggy. When user adds the property, several errors appear in browser console and the added property cannot be removed by clicking Cross button. Also it is impossible to choose property's criteria because they are absent for it.

**Preconditions:** Having the Class with defined property containing space in it's Label and the object (item/test etc.) in it.

**Steps to reproduce:**

- Click search icon on the tab with created class folder (from Preconditions above).
- Click 'add criteria' and choose created property with space in label.
- Try to add any criteria of this property and remove the property by clicking Cross icon.

**Actual result:** Errors in browser console upon choosing the property, Cross icon unresponsive so the property cannot be removed like that. List of property's elements is empty. The search is not made by this property.
**Expected result:** User is able to add/remove property, choose it's criteria to run the search by the property OR user should be restricted from creating the property with spaces by warning message.

### **Environment**

Deployed to playground, the link is in the ticket