### PR TITLE
fix: use criteria id instead of label for selectors and name attribute

### DIFF
--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -283,7 +283,7 @@ export default function advancedSearchFactory(config) {
          * that is managed with select2, so we init it here
          */
         if (criterion.type === criteriaTypes.list && criterion.uri) {
-            $(`input[name=${criterion.label}-select]`, $criterionContainer).select2({
+            $(`input[name=${criterion.id}-select]`, $criterionContainer).select2({
                 multiple: true,
                 ajax: {
                     url: criterion.uri,
@@ -329,10 +329,10 @@ export default function advancedSearchFactory(config) {
         } else if (criterion.type === criteriaTypes.list && criterion.uri) {
             // set initial value
             if (criterion.value) {
-                $(`input[name=${criterion.label}-select]`, $criterionContainer).select2('val', criterion.value);
+                $(`input[name=${criterion.id}-select]`, $criterionContainer).select2('val', criterion.value);
             }
             // set event to bind input value to critariaState
-            $(`input[name=${criterion.label}-select]`, $criterionContainer).on('change', event => {
+            $(`input[name=${criterion.id}-select]`, $criterionContainer).on('change', event => {
                 criterion.value = event.val;
             });
         } else {

--- a/src/searchModal/tpl/list-select-criterion.tpl
+++ b/src/searchModal/tpl/list-select-criterion.tpl
@@ -1,6 +1,6 @@
 <div class="filter-container {{criterion.id}}-filter" data-criteria="{{criterion.label}}" data-type="{{criterion.type}}">
     <button class="icon-result-nok" aria-label="{{__ "Remove criteria"}}"></button>    <label> 
         <span class="filter-label-text">{{criterion.label}}</span>
-        <input type='text' name="{{criterion.label}}-select">
+        <input type='text' name="{{criterion.id}}-select">
     </label>
 </div>

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -262,6 +262,7 @@ define([
                 const query = instance.getAdvancedCriteriaQuery();
                 assert.equal(
                     query,
+                    // TODO: change 2nd AND to OR when functionality is developed on BE
                     'in-both-text:foo0 AND in-both-list:value1 AND value2 AND in-both-select:value0',
                     'advanced search query is correctly built'
                 );

--- a/test/searchModal/mocks/mocks.json
+++ b/test/searchModal/mocks/mocks.json
@@ -100,20 +100,24 @@
                 "class": "parent-class",
                 "metadata": [
                     {
+                        "id": "in-both-text",
                         "label": "in-both-text",
                         "type": "text"
                     },
                     {
+                        "id": "in-both-list",
                         "label": "in-both-list",
                         "type": "list",
                         "values": ["value0", "value1", "value2", "value3"]
                     },
                     {
+                        "id": "in-both-select",
                         "label": "in-both-select",
                         "type": "list",
                         "uri": "foo"
                     },
                     {
+                        "id": "in-parent-text",
                         "label": "in-parent-text",
                         "type": "text"
                     }


### PR DESCRIPTION
Duplicate of https://github.com/oat-sa/tao-core-ui-fe/pull/290 that was reverted in https://github.com/oat-sa/tao-core-ui-fe/pull/295 to finish release of v1.24.0

Playground is updated & switched to this branch