### PR TITLE
Advanced search: Add criteria option is unclickable after opening Modal view.

### DIFF
--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -66,12 +66,12 @@ export default function advancedSearchFactory(config) {
          * @returns {Promise} - Request promise
          */
         updateCriteria: function (route) {
-            const $criteriaIcon = $('.add-criteria-container a span').eq(0);
-            $criteriaIcon.toggleClass('icon-add').toggleClass('icon-loop');
-
             if (!isAdvancedSearchStatusEnabled) {
                 return Promise.resolve();
             }
+
+            const $criteriaIcon = $('.add-criteria-container a span').eq(0);
+            $criteriaIcon.toggleClass('icon-add').toggleClass('icon-loop');
             return request(route)
                 .then(response => {
                     const criteria = formatCriteria(response);


### PR DESCRIPTION
**Ticket**

https://oat-sa.atlassian.net/browse/ADF-343

**Environment to test**

http://aadvanced-search-integration.playground.kitchen.it.taocloud.org:48321

**Description**

The issue is randomly reproduced (about 1 of 10 times) - when the user opens the Modal view by clicking the Search icon, the "add criteria" button is unclickable and the "+" icon on the left of it is replaced with endlessly turning spinner. After clicking the 'Clear' button the user is able to click on the button and to see a dropdown list but the spinner is still there.

**Steps to reproduce**

- Open any tab.
- Click the Search icon to open Modal view.

**Actual result**

About 1 of 10 times the 'add criteria' button becomes unclickable and has a constantly turning spinner icon on its left.

**Expected result**

There's no case when 'add criteria' becomes unclickable right after opening Modal view.