### PR TITLE
Fix: use uri in advanced search criteria

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -187,7 +187,7 @@ export default function searchModalFactory(config) {
                 const classUri = _.map(selectedValue, 'classUri')[0];
                 const label = _.map(selectedValue, 'label')[0];
                 const uri = _.map(selectedValue, 'uri')[0];
-                const route = urlUtil.route('get', 'ClassMetadata', 'tao', {
+                const route = urlUtil.route('getWithMapping', 'ClassMetadata', 'tao', {
                     classUri,
                     maxListSize: instance.config.maxListSize
                 });

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -298,7 +298,7 @@ export default function advancedSearchFactory(config) {
                         };
                     },
                     results: (response) => ({ 
-                          results: response.data.map(option => ({ id: valueMapping !== 'uri' ? option.uri : option.label, text: option.label }))
+                          results: response.data.map(option => ({ id: valueMapping === 'uri' ? option.uri : option.label, text: option.label }))
                     })
                 },
                 initSelection: function (element, callback) {

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -321,7 +321,10 @@ export default function advancedSearchFactory(config) {
     function getInitialCriterionLabel(criterion) {
         const valueMapping = criteriaMapping[criterion.type];
         if (valueMapping !== 'uri' || !criterion.value) {
-            return Promise.resolve(criterion.value);
+            return Promise.resolve({
+                id: criterion.value,
+                text: criterion.value
+            });
         }
         return $.ajax({
             type: 'GET',
@@ -334,7 +337,11 @@ export default function advancedSearchFactory(config) {
                     text: (data.find(d => d.uri === v) || {}).label
                 }))
             }
-            return (data.find(d => d.uri === criterion.value) || {}).label
+            let c = (data.find(d => d.uri === criterion.value) || {})
+            return {
+                text: c.label,
+                id: criterion.value,
+            }
         })
     }
 

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -25,6 +25,7 @@
     'json!test/ui/searchModal/mocks/mocks.json',
     'jquery.mockjax'
 ], function ($, _, searchModalFactory, advancedSearchFactory, store, mocks) {
+    const nextTick = (wait = 0) => new Promise((r) => setTimeout(r, wait));
     // Prevent the AJAX mocks to pollute the logs
     $.mockjaxSettings.logger = null;
     $.mockjaxSettings.responseTime = 1;
@@ -37,6 +38,16 @@
         url: new RegExp(/.+ClassMetadata.+/),
         dataType: 'json',
         responseText: mocks.mockedAdvancedCriteria
+    });
+    $.mockjax({
+        url: new RegExp(/.+PropertyValues.+/),
+        dataType: 'json',
+        responseText: mocks.mockedCriteriaSelect
+    });
+    $.mockjax({
+        url: new RegExp(/in\-both\-[list|select]/),
+        dataType: 'json',
+        responseText: mocks.mockedCriteriaSelect
     });
     $.mockjax({
         url: 'undefined/tao/AdvancedSearch/status',
@@ -68,7 +79,7 @@
                     const $container = $('.advanced-search-container');
                     const $invalidCriteriaContainer = $container.find('.invalid-criteria-warning-container');
 
-                    assert.equal($invalidCriteriaContainer.length, 0, 'invalid criteira is not initially rendered');
+                    assert.equal($invalidCriteriaContainer.length, 0, 'invalid criteria is not initially rendered');
                     _.forEach(mocks.mockedCriteriaStore, criterionToRender => {
                         // check for each stored criterion if it is rendered when criterion.rendered is true, and viceversa
                         assert.equal(
@@ -209,7 +220,7 @@
         assert.expect(8);
 
         instance.on('ready', function () {
-            instance.updateCriteria('undefined/tao/ClassMetadata/').then(function () {
+            instance.updateCriteria('undefined/tao/ClassMetadata/').then(async function () {
                 const $container = $('.advanced-search-container');
                 const $criteriaContainer = $container.find('.advanced-criteria-container');
                 const $criteriaSelect = $('.add-criteria-container select', $container);
@@ -236,6 +247,7 @@
                     });
 
                 // check default value on each criterion type
+                await nextTick();
                 assert.equal($criterionTextInput.val(), 'default value0', 'text criterion correctly initialized');
                 assert.deepEqual(
                     $criterionSelectInput.select2('val'),

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -239,12 +239,16 @@
                 $criteriaSelect.select2('val', 'in-both-list').trigger('change');
                 const $criterionTextInput = $criteriaContainer.find('.inbothtext-filter input');
                 const $criterionSelectInput = $criteriaContainer.find('.inbothselect-filter input');
-                const $criterionListSelected = $criteriaContainer
-                    .find('.inbothlist-filter input[type=checkbox]:checked')
-                    .get()
-                    .map(checkbox => {
-                        return checkbox.value;
-                    });
+
+                // Checkboxes are temporary replaced with select2
+                // const $criterionListSelected = $criteriaContainer
+                //     .find('.-filter input[type=checkbox]:checked')
+                //     .get()
+                //     .map(checkbox => {
+                //         return checkbox.value;
+                //     });
+
+                const $criterionListSelected = $criteriaContainer.find('.inbothlist-filter input');
 
                 // check default value on each criterion type
                 await nextTick();
@@ -254,15 +258,21 @@
                     ['value0'],
                     'select criterion correctly initialized'
                 );
-                assert.deepEqual($criterionListSelected, ['value1'], 'list criterion correctly initialized');
+
+                assert.deepEqual($criterionListSelected.select2('val'), ['value1'], 'list criterion correctly initialized');
 
                 // update value on each criterion
                 $criterionTextInput.val('foo0').trigger('change');
-                $criteriaContainer
-                    .find('.inbothlist-filter input[type=checkbox][value=value2]')
-                    .prop('checked', true)
-                    .trigger('change');
-
+                
+                // Checkboxes are temporary replaced with select2
+                // $criteriaContainer
+                //     .find('.inbothlist-filter input[type=checkbox][value=value2]')
+                //     .prop('checked', true)
+                //     .trigger('change');
+                $criteriaContainer.find('.inbothlist-filter .select2-choices').click();
+                await nextTick(200);
+                $('.select2-results .select2-selected + * .select2-result-label').mouseup();
+                await nextTick(200);
                 // check updated value on each criterion
                 assert.equal(instance.getState()['in-both-text'].value, 'foo0', 'text criterion correctly updated');
                 assert.deepEqual(

--- a/test/searchModal/mocks/mocks.json
+++ b/test/searchModal/mocks/mocks.json
@@ -95,58 +95,83 @@
     },
     "mockedAdvancedCriteria": {
         "success": true,
-        "data": [
-            {
-                "class": "parent-class",
-                "metadata": [
-                    {
-                        "id": "in-both-text",
-                        "label": "in-both-text",
-                        "type": "text"
-                    },
-                    {
-                        "id": "in-both-list",
-                        "label": "in-both-list",
-                        "type": "list",
-                        "values": ["value0", "value1", "value2", "value3"]
-                    },
-                    {
-                        "id": "in-both-select",
-                        "label": "in-both-select",
-                        "type": "list",
-                        "uri": "foo"
-                    },
-                    {
-                        "id": "in-parent-text",
-                        "label": "in-parent-text",
-                        "type": "text"
-                    }
-                ]
-            },
-            {
-                "class": "child-class",
-                "metadata": [
-                    {
-                        "label": "in-both-text",
-                        "type": "text"
-                    },
-                    {
-                        "label": "in-both-list",
-                        "type": "list",
-                        "values": ["value0", "value1", "value2", "value3"]
-                    },
-                    {
-                        "label": "in-both-select",
-                        "type": "list",
-                        "uri": "foo"
-                    },
-                    {
-                        "label": "in-child-text",
-                        "type": "text"
-                    }
-                ]
+        "data": {
+            "classDefinition": [
+                {
+                    "class": "parent-class",
+                    "metadata": [
+                        {
+                            "id": "in-both-text",
+                            "label": "in-both-text",
+                            "uri": "in-both-text",
+                            "propertyUri": "in-both-text",
+                            "type": "text"
+                        },
+                        {
+                            "id": "in-both-list",
+                            "label": "in-both-list",
+                            "uri": "in-both-list",
+                            "propertyUri": "in-both-list",
+                            "type": "list",
+                            "values": [
+                                "value0",
+                                "value1",
+                                "value2",
+                                "value3"
+                            ]
+                        },
+                        {
+                            "id": "in-both-select",
+                            "label": "in-both-select",
+                            "type": "list",
+                            "uri": "in-both-select",
+                            "propertyUri": "in-both-select"
+                        },
+                        {
+                            "id": "in-parent-text",
+                            "label": "in-parent-text",
+                            "type": "text",
+                            "uri": "in-parent-text-uri"
+                        }
+                    ]
+                },
+                {
+                    "class": "child-class",
+                    "metadata": [
+                        {
+                            "label": "in-both-text",
+                            "type": "text",
+                            "uri": "in-both-text-uri"
+                        },
+                        {
+                            "label": "in-both-list",
+                            "type": "list",
+                            "values": [
+                                "value0",
+                                "value1",
+                                "value2",
+                                "value3"
+                            ],
+                            "uri": "in-both-list-uri"
+                        },
+                        {
+                            "label": "in-both-select",
+                            "type": "list",
+                            "uri": "foo"
+                        },
+                        {
+                            "label": "in-child-text",
+                            "type": "text",
+                            "uri": "in-child-text-uri"
+                        }
+                    ]
+                }
+            ],
+            "criteriaMapping": {
+                "list": "uri",
+                "text": "label"
             }
-        ]
+        }
     },
     "mockedAdvancedCriteriaInChildClass": {
         "success": true,
@@ -182,7 +207,7 @@
             "id": "inbothlist",
             "type": "list",
             "values": ["easy", "medium", "hard"],
-            "uri": null,
+            "uri": "in-both-list",
             "rendered": true,
             "value": ["easy"]
         },
@@ -191,7 +216,7 @@
             "id": "inbothtext",
             "type": "text",
             "values": null,
-            "uri": null,
+            "uri": "in-both-text",
             "rendered": true,
             "value": "foo"
         },
@@ -210,5 +235,22 @@
         "data": {
             "enabled": true
         }
+    },
+    "mockedCriteriaSelect": {
+        "success": true,
+        "data": [
+            {
+                "uri": "value0",
+                "label": "value0"
+            },
+            {
+                "uri": "value1",
+                "label": "value1"
+            },
+            {
+                "uri": "value2",
+                "label": "value2"
+            }
+        ]
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-570
https://oat-sa.atlassian.net/browse/ADF-515

AC:
* Search term should be either uri or label depending on mapping that we get from API
* In query we need to use uri instead of label

For example, instead of "Comment" and "Language" we need to pass uris of these criteria
![search query screenshot](https://user-images.githubusercontent.com/11773029/127609626-cc883035-8596-495a-8420-74e2f7981786.png)
