### PR TITLE
feat/AUT-800/Add the text to wrap pictures behind a feature flag

### DIFF
--- a/src/image/ImgStateActive.js
+++ b/src/image/ImgStateActive.js
@@ -20,8 +20,20 @@ import 'nouislider';
 import 'ui/resourcemgr';
 import 'ui/tooltip';
 import _ from 'lodash';
+import module from 'module';
 import initAll, { initAdvanced } from './ImgStateActive/initHelper';
 import initMediaEditor  from './ImgStateActive/initMediaEditor';
+
+const config = module.config() || {};
+const mediaAlignment = typeof config.mediaAlignment === "undefined" ? true : config.mediaAlignment;
+const options = {
+    mediaDimension: {
+        active: true
+    },
+    mediaAlignment: {
+        active: mediaAlignment
+    }
+};
 
 const formCallbacks = ({ widget, formElement, mediaEditor, togglePlaceholder }) => {
     const $img = widget.$original;
@@ -40,7 +52,7 @@ const formCallbacks = ({ widget, formElement, mediaEditor, togglePlaceholder }) 
             if (img.attr('off-media-editor') === 1) {
                 img.removeAttr('off-media-editor');
             } else {
-                initMediaEditor(widget, mediaEditor);
+                initMediaEditor(widget, mediaEditor, options);
             }
         }, 1000),
         alt: function (img, value) {
@@ -61,7 +73,7 @@ const initForm = ({ widget, formElement, formTpl, mediaEditor, togglePlaceholder
     );
 
     // init upload, advanced and media editor
-    initAll(widget, mediaEditor);
+    initAll(widget, mediaEditor, options);
 
     // init standard ui widget
     formElement.initWidget(widget.$form);

--- a/src/image/ImgStateActive.js
+++ b/src/image/ImgStateActive.js
@@ -25,7 +25,7 @@ import initAll, { initAdvanced } from './ImgStateActive/initHelper';
 import initMediaEditor  from './ImgStateActive/initMediaEditor';
 
 const config = module.config() || {};
-const mediaAlignment = typeof config.mediaAlignment === "undefined" ? true : config.mediaAlignment;
+const mediaAlignment = typeof config.mediaAlignment === "undefined" ? false : config.mediaAlignment;
 const options = {
     mediaDimension: {
         active: true

--- a/src/image/ImgStateActive/initHelper.js
+++ b/src/image/ImgStateActive/initHelper.js
@@ -127,9 +127,9 @@ export const initUpload = function (widget) {
     }
 };
 
-export default function initAll(widget, mediaEditor) {
+export default function initAll(widget, mediaEditor, options) {
     initAdvanced(widget);
-    initMediaEditor(widget, mediaEditor);
+    initMediaEditor(widget, mediaEditor, options);
     initUpload(widget);
 }
 

--- a/src/image/ImgStateActive/initMediaEditor.js
+++ b/src/image/ImgStateActive/initMediaEditor.js
@@ -62,16 +62,8 @@ const getMedia = (imgQtiElement, $imgNode, cb) => {
     }
 };
 
-const getMediaCb = (media, widget, mediaEditor) => {
+const getMediaCb = (media, widget, mediaEditor, options) => {
     const $mediaResizer = widget.$form.find('.img-resizer');
-    var options = {
-        mediaDimension: {
-            active: true
-        },
-        mediaAlignment: {
-            active: true
-        }
-    };
     media.$container = widget.$container.parents('.widget-box');
     if (media.$container.length) {
         // eslint-disable-next-line no-unused-vars
@@ -86,7 +78,7 @@ const getMediaCb = (media, widget, mediaEditor) => {
     }
 };
 
-export default function initMediaEditor(widget, mediaEditor) {
+export default function initMediaEditor(widget, mediaEditor, options) {
     if (mediaEditor) {
         mediaEditor.destroy();
     }
@@ -95,5 +87,5 @@ export default function initMediaEditor(widget, mediaEditor) {
         return;
     }
 
-    getMedia(widget.element, widget.$original, (m) => getMediaCb(m, widget, mediaEditor));
+    getMedia(widget.element, widget.$original, (m) => getMediaCb(m, widget, mediaEditor, options));
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-800
https://github.com/oat-sa/tao-core/pull/3041

 Add ability to disable/enable `mediaAlignment` plugin  by configuration.

**Unit test for `test/incrementer/test.html` fail because of https://github.com/oat-sa/tao-core-ui-fe/pull/327, and will be fixed separately.**

How to test:
- use branch, run `php ./tao/scripts/taoUpdate.php`
- check that mediaAlignment plugin is disabled
- set in `config/tao/client_lib_config_registry.conf.php` configs
```
        'ui/image/ImgStateActive' => array(
            'mediaAlignment' => true
        ),
```
- check that mediaAlignment plugin is displayed
- remove config, check that by default mediaAlignment plugin is disabled

![image](https://user-images.githubusercontent.com/25976342/128342118-05339ef6-01f4-402d-a411-e79eb8d86a52.png) ![image](https://user-images.githubusercontent.com/25976342/128341966-1d5e7ec4-2d2d-4d29-8bb2-10b462f71030.png) 
