### PR TITLE
feature/TR-916/support-rtl-checkbox-hidden

### DIFF
--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -470,9 +470,6 @@ label {
     }
 }
 
-
-
-
 // Edge styles go here, they cannot be include in the rule set below :-(
 @supports (-ms-ime-align:auto) {
     label {

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -434,6 +434,10 @@ label {
         position: absolute;
         left: -10000px;
         top: 0;
+
+        [dir="rtl"] & {
+            left: 10000px;
+        }
         &:focus ~ [class^="icon-"],
         &:focus ~ [class*=" icon-"],
         &:active ~ [class^="icon-"],
@@ -465,6 +469,9 @@ label {
         }
     }
 }
+
+
+
 
 // Edge styles go here, they cannot be include in the rule set below :-(
 @supports (-ms-ime-align:auto) {

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -431,13 +431,10 @@ label {
     }
     input[type="radio"],
     input[type="checkbox"] {
+        visibility: hidden;
+        pointer-events: none;
         position: absolute;
-        left: -10000px;
-        top: 0;
 
-        body[dir="rtl"] & {
-            left: 10000px;
-        }
         &:focus ~ [class^="icon-"],
         &:focus ~ [class*=" icon-"],
         &:active ~ [class^="icon-"],

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -435,7 +435,7 @@ label {
         left: -10000px;
         top: 0;
 
-        [dir="rtl"] & {
+        body[dir="rtl"] & {
             left: 10000px;
         }
         &:focus ~ [class^="icon-"],


### PR DESCRIPTION
**Related to:** [TR-916](https://oat-sa.atlassian.net/browse/TR-916)

**Description:**
Add RTL support to the checkbox input

**Changes:**

- Switch direction value to hide checkbox default input

**How to check:**

- Use a Test-taker with an RTL language to change the layout direction. And test a Choice interaction or a Hottext interaction test.

**Requires:**

- [Tao-core PR](https://github.com/oat-sa/tao-core/pull/3091)