### PR TITLE
feat: remove item's styles from generic styles

### DIFF
--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -25,10 +25,6 @@ label, .form_desc {
     margin-bottom: 5px;
     padding-right: 10px;
 
-    [dir="rtl"] & {
-        padding-right: 0;
-        padding-left: 10px;
-    }
     abbr {
         color: $info;
         border-bottom: none;
@@ -219,18 +215,9 @@ label, .form_desc {
         margin: 0;
         left: 0;
 
-        [dir="rtl"] & {
-            left: auto;
-            right: 0;
-        }
         & + div {
             cursor: pointer;
             margin-left: 24px;
-
-            [dir="rtl"] & {
-                margin-left: 0;
-                margin-right: 24px;
-            }
         }
     }
     abbr {
@@ -416,17 +403,11 @@ label {
         }
         &:before {
             z-index: 3;
-            [dir="rtl"] & {
-                right: -1em;
-            }
         }
         &:after {
             position: relative;
             z-index: 2;
             left: -1em;
-            [dir="rtl"] & {
-                left: auto;
-            }
         }
     }
     input[type="radio"],
@@ -710,14 +691,11 @@ label {
         width: 35%;
         display:inline-block;
         padding: 0 10px 0 0;
+        vertical-align: top;
 
-        [dir="rtl"] & {
-            padding: 0 0 0 10px;
-        }
         &.hidden-input-label {
             width: auto;
         }
-        vertical-align: top;
 
         & ~ .form-elt-container {
             display: inline-block;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-36
Composer file https://github.com/oat-sa/kitchen-playground/blob/mca/tr8x/files/delivery/composer.json
PHP 7.2, Composer 2

Moved basic checkbox styles that belongs to items from core to itemsqti

Besides of basic RTL/LTR test, here you need to test as a RTL user and looking at LTR item.
![Screenshot 2021-09-23 at 17 05 14](https://user-images.githubusercontent.com/2067027/134542515-1a01049a-19ad-4161-b132-4717c7985fdb.png)

Has dependencies
https://github.com/oat-sa/tao-core/pull/3133
https://github.com/oat-sa/extension-tao-itemqti/pull/1891

2/3