### PR TITLE
Fix/TRN 1140/Highlighter: take blacklisting into account when building highlight index

### DIFF
--- a/src/highlighter.js
+++ b/src/highlighter.js
@@ -796,14 +796,17 @@ export default function (options) {
      */
     /**
      * For `keepEmptyNodes` option, creates data model of highlights.
-     * Additionally returns array of hilghlight nodes. Traverses DOM tree.
+     * Additionally returns array of highlight nodes. Traverses DOM tree.
      * @param {Node} rootNode
      * @returns {BuildModelResultKeepEmpty|null} result
      */
     function buildHighlightModelKeepEmpty(rootNode) {
         const classNames = options.colors ? Object.values(options.colors) : [className];
         const wrapperNodesSelector = classNames.map(cls => containerSelector + ' .' + cls).join(', ');
-        const wrapperNodes = document.querySelectorAll(wrapperNodesSelector);
+        const wrapperNodes = Array.from(document.querySelectorAll(wrapperNodesSelector))
+            .filter(node => {
+                return node.childNodes.length && !isBlacklisted(node.childNodes[0])
+            });
 
         if (!wrapperNodes.length) {
             return null;


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TRN-1140

Small change needed to make NUI highlighter work with passages embedded in items.
Blacklisted nodes were not taken into account when building the highlights model.

TODO: unit test