### PR TITLE
CUNO-1853 / ADF-695: User without access to assets can save images trough the item

### DIFF
--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -53,11 +53,17 @@ export default function (options) {
             $rootNode.addClass('opened');
         }
         updateFolders(content, $innerList);
-        //internal event to set the file-selector content
-        $('.file-browser').find('li.active').removeClass('active');
-        updateSelectedClass(content.path, content.total, content.childrenLimit);
-        $container.trigger(`folderselect.${ns}`, [content.label, getPage(content.children), content.path]);
-        renderPagination();
+
+      if (content.permissions.read && !options.hasAlreadySelected) {
+          $$1('.file-browser').find('li.active').removeClass('active');
+          updateSelectedClass(content.path, content.total, content.childrenLimit);
+          $container.trigger("folderselect.".concat(ns), [content.label, getPage(content.children), content.path, content]);
+          renderPagination();
+
+          if (root !== 'local') {
+            options.hasAlreadySelected = true;
+          }
+      }
     });
 
     // by clicking on the tree (using a live binding  because content is not complete yet)

--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -55,7 +55,7 @@ export default function (options) {
         updateFolders(content, $innerList);
 
       if (content.permissions.read && !options.hasAlreadySelected) {
-          $$1('.file-browser').find('li.active').removeClass('active');
+          $('.file-browser').find('li.active').removeClass('active');
           updateSelectedClass(content.path, content.total, content.childrenLimit);
           $container.trigger("folderselect.".concat(ns), [content.label, getPage(content.children), content.path, content]);
           renderPagination();


### PR DESCRIPTION
**Jira issue**
https://oat-sa.atlassian.net/browse/ADF-695

**Related PR**
https://github.com/oat-sa/tao-core/pull/3151

**AC**
- Preselect item gallery when user doesn't have access to Assets.
- Preselect Assets when user does have access.
- Make "Add file" button appear without having to click a folder. (If permissions allow it).

**How to test**
- Make access to Assets forbidden for user. (By restricting access only to Global Manager role)(make it recursive)
- Login with user and author an item
- Try to insert media/image

