### PR TITLE
fix: use em for sup,sub

### DIFF
--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -217,7 +217,7 @@ body {
     }
 
     sup {
-        top: -0.5rem;
+        top: -0.5em;
     }
 
     sub {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-931

Issue with `sup, sub` font-size should be in `em` not `rem`