### PR TITLE
Fix/tr 1460/better detection of media disconnection

### DIFF
--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -78,6 +78,7 @@ const defaults = {
         maxPlays: 0,
         replayTimeout: 0,
         stalledTimeout: 2000,
+        stalledUpdate: 5,
         canPause: true,
         canSeek: true,
         loop: false,
@@ -202,6 +203,7 @@ const isResponsiveSize = sizeProps => {
  * @param {Number} [config.maxPlays] - Sets a few number of plays (default: infinite)
  * @param {Number} [config.replayTimeout] - disable the possibility to replay a media after this timeout, in seconds (default: 0)
  * @param {Number} [config.stalledTimeout] - delay before considering stalled playback (default: 2000)
+ * @param {Number} [config.stalledUpdate] - the number of updates before considering stalled playback once the player declared a stalled event (default: 5)
  * @param {Number} [config.volume] - Sets the sound volume (default: 80)
  * @param {Number} [config.width] - Sets the width of the player (default: depends on media type)
  * @param {Number} [config.height] - Sets the height of the player (default: depends on media type)
@@ -1428,7 +1430,7 @@ function mediaplayerFactory(config) {
          * @private
          */
         _onStalled() {
-            this.stalledTimeUpdateCount = 0;
+            this.stalledUpdateCountdown = this.config.stalledUpdate;
             this.stalledTimer = window.setTimeout(() => {
                 const position = this.getPosition();
                 if (position) {
@@ -1445,11 +1447,11 @@ function mediaplayerFactory(config) {
          */
         _onTimeUpdate() {
             if (this.stalledTimer) {
-                if (this.stalledTimeUpdateCount === 5) {
+                if (this.stalledUpdateCountdown <= 0) {
                     window.clearTimeout(this.stalledTimer);
                     this.stalledTimer = null;
                 } else {
-                    this.stalledTimeUpdateCount++;
+                    this.stalledUpdateCountdown--;
                 }
             }
 

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -1607,11 +1607,8 @@ function mediaplayerFactory(config) {
          * @private
          */
         execute(command, ...args) {
-            const ctx = this.player;
-            const method = ctx && ctx[command];
-
-            if (_.isFunction(method)) {
-                return method.apply(ctx, args);
+            if (this.player && 'function' === typeof this.player[command]) {
+                return this.player[command](...args);
             }
         }
     };

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -77,8 +77,6 @@ const defaults = {
         startMuted: false,
         maxPlays: 0,
         replayTimeout: 0,
-        stalledTimeout: 2000,
-        stalledUpdate: 5,
         canPause: true,
         canSeek: true,
         loop: false,
@@ -202,8 +200,6 @@ const isResponsiveSize = sizeProps => {
  * @param {Number} [config.autoStartAt] - The time position at which the player should start
  * @param {Number} [config.maxPlays] - Sets a few number of plays (default: infinite)
  * @param {Number} [config.replayTimeout] - disable the possibility to replay a media after this timeout, in seconds (default: 0)
- * @param {Number} [config.stalledTimeout] - delay before considering stalled playback (default: 2000)
- * @param {Number} [config.stalledUpdate] - the number of updates before considering stalled playback once the player declared a stalled event (default: 5)
  * @param {Number} [config.volume] - Sets the sound volume (default: 80)
  * @param {Number} [config.width] - Sets the width of the player (default: depends on media type)
  * @param {Number} [config.height] - Sets the height of the player (default: depends on media type)
@@ -1430,15 +1426,12 @@ function mediaplayerFactory(config) {
          * @private
          */
         _onStalled() {
-            this.stalledUpdateCountdown = this.config.stalledUpdate;
-            this.stalledTimer = window.setTimeout(() => {
-                const position = this.getPosition();
-                if (position) {
-                    this.positionBeforeStalled = position;
-                }
-                this._setState('stalled', true);
-                this._setState('ready', false);
-            }, this.config.stalledTimeout);
+            const position = this.getPosition();
+            if (position) {
+                this.positionBeforeStalled = position;
+            }
+            this._setState('stalled', true);
+            this._setState('ready', false);
         },
 
         /**
@@ -1446,15 +1439,6 @@ function mediaplayerFactory(config) {
          * @private
          */
         _onTimeUpdate() {
-            if (this.stalledTimer) {
-                if (this.stalledUpdateCountdown <= 0) {
-                    window.clearTimeout(this.stalledTimer);
-                    this.stalledTimer = null;
-                } else {
-                    this.stalledUpdateCountdown--;
-                }
-            }
-
             this._updatePosition(this.player.getPosition());
 
             /**

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -889,7 +889,11 @@ function mediaplayerFactory(config) {
             this._setState('error', error);
             this._setState('nogui', !support.canControl());
             this._setState('preview', this.config.preview);
-            this._setState('loading', true);
+            this._setState('loading', !error);
+            if (error) {
+                this._setState('ready', true);
+                this.trigger('ready');
+            }
         },
 
         /**

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -205,6 +205,7 @@ const isResponsiveSize = sizeProps => {
  * @param {Number} [config.height] - Sets the height of the player (default: depends on media type)
  * @param {Boolean} [config.preview] - Enables the media preview (load media metadata)
  * @param {Boolean} [config.debug] - Enables the debug mode
+ * @param {number} [config.config.stalledDetectionDelay] - The delay before considering a media is stalled
  * @event render - Event triggered when the player is rendering
  * @event error - Event triggered when the player throws an unrecoverable error
  * @event ready - Event triggered when the player is fully ready
@@ -857,7 +858,8 @@ function mediaplayerFactory(config) {
                         type: this.getType(),
                         sources: this.getSources(),
                         preview: this.config.preview,
-                        debug: this.config.debug
+                        debug: this.config.debug,
+                        stalledDetectionDelay: this.config.stalledDetectionDelay
                     };
                     this.player = playerFactory(this.$player, playerConfig)
                         .on('resize', (width, height) => {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -212,10 +212,7 @@ export default function html5PlayerFactory($container, config = {}) {
                 });
             }
 
-            sources.forEach(source => {
-                const { src, type } = source;
-                this.addMedia(src, type);
-            });
+            sources.forEach(source => this.addMedia(source.src, source.type));
 
             return result;
         },
@@ -353,28 +350,28 @@ export default function html5PlayerFactory($container, config = {}) {
             return mute;
         },
 
-        addMedia(src, type) {
-            debug('api call', 'addMedia', src, type);
+        addMedia(src, srcType) {
+            debug('api call', 'addMedia', src, srcType);
 
             if (media) {
-                if (!support.checkSupport(media, type)) {
+                if (!support.checkSupport(media, srcType)) {
                     return false;
                 }
             }
 
             if (src && $media) {
-                $media.append(sourceTpl({ src, type }));
+                $media.append(sourceTpl({ src, type: srcType }));
                 return true;
             }
             return false;
         },
 
-        setMedia(src, type) {
-            debug('api call', 'setMedia', src, type);
+        setMedia(src, srcType) {
+            debug('api call', 'setMedia', src, srcType);
 
             if ($media) {
                 $media.empty();
-                return this.addMedia(src, type);
+                return this.addMedia(src, srcType);
             }
             return false;
         }

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -272,7 +272,9 @@ export default function html5PlayerFactory($container, config = {}) {
                 });
             }
 
-            sources.forEach(source => this.addMedia(source.src, source.type));
+            result =
+                result &&
+                sources.reduce((supported, source) => this.addMedia(source.src, source.type) || supported, false);
 
             return result;
         },

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -91,6 +91,7 @@ const playerEvents = ['end', 'error', 'pause', 'play', 'playing', 'ready', 'resi
  * @param {string} [config.type] - The type of player (video or audio) (default: video)
  * @param {boolean} [config.preview] - Enables the media preview (load media metadata)
  * @param {boolean} [config.debug] - Enables the debug mode
+ * @param {number} [config.config.stalledDetectionDelay] - The delay before considering a media is stalled
  * @returns {object} player
  */
 export default function html5PlayerFactory($container, config = {}) {
@@ -98,6 +99,8 @@ export default function html5PlayerFactory($container, config = {}) {
     const sources = config.sources || [];
     const updateObserver = reminderManagerFactory();
     const timeObserver = timeObserverFactory();
+
+    config.stalledDetectionDelay = config.stalledDetectionDelay || stalledDetectionDelay;
 
     let $media;
     let media;
@@ -302,10 +305,10 @@ export default function html5PlayerFactory($container, config = {}) {
             state.stallDetection = true;
             updateObserver.remind(() => {
                 // The last time update is a bit old, the media is most probably stalled now
-                if (updateObserver.elapsed >= stalledDetectionDelay) {
+                if (updateObserver.elapsed >= config.stalledDetectionDelay) {
                     this.stalled();
                 }
-            }, stalledDetectionDelay);
+            }, config.stalledDetectionDelay);
 
             updateObserver.start();
         },
@@ -331,7 +334,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     }
                     this.stalled();
                 }
-            }, stalledDetectionDelay);
+            }, config.stalledDetectionDelay);
         },
 
         stalled(position) {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -358,6 +358,17 @@ export default function html5PlayerFactory($container, config = {}) {
             state.stalled = false;
             state.stallDetection = false;
             if (media) {
+                // Special processing of video player to prevent visual glitch while reloading
+                if (media.tagName === 'VIDEO') {
+                    // Temporary fix the size of the media to prevent a shrink while reloading it
+                    $media.width($media.width());
+                    $media.height($media.height());
+                    $media.on('loadedmetadata.recover', () => {
+                        $media.off('loadedmetadata.recover');
+                        $media.css({ width: '', height: '' });
+                    });
+                }
+
                 media.load();
                 if (state.stalledAt) {
                     this.seek(state.stalledAt);

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -181,6 +181,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     this.trigger('end');
                 })
                 .on(`timeupdate${ns}`, () => {
+                    state.playing = true;
                     updateObserver.start();
                     timeObserver.update(media.currentTime);
                     this.trigger('timeupdate');
@@ -191,7 +192,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     }
 
                     if (!config.preview && media.networkState === HTMLMediaElement.NETWORK_IDLE) {
-                        this.trigger('ready');
+                        this.ready();
                     }
                 })
                 .on(`waiting${ns}`, () => {
@@ -214,15 +215,17 @@ export default function html5PlayerFactory($container, config = {}) {
                 })
                 .on('loadedmetadata', () => {
                     timeObserver.init(media.currentTime, media.duration);
+                    this.ready();
                 })
                 .on(`canplay${ns}`, () => {
                     if (!state.stalled) {
-                        state.stallDetection = false;
-                        this.trigger('ready');
+                        this.ready();
                     }
                 })
                 .on(`stalled${ns}`, () => {
-                    this.handleError(media.error);
+                    if (state.playing) {
+                        this.handleError(media.error);
+                    }
                 })
                 .on(`playing${ns}`, () => {
                     updateObserver.forget().start();
@@ -259,6 +262,15 @@ export default function html5PlayerFactory($container, config = {}) {
             }, stalledDetectionDelay);
 
             updateObserver.start();
+        },
+
+        ready() {
+            if (!state.ready) {
+                state.ready = true;
+                state.stalled = false;
+                state.stallDetection = false;
+                this.trigger('ready');
+            }
         },
 
         stalled(position) {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -237,7 +237,7 @@ export default function html5PlayerFactory($container, config = {}) {
                 .on(`stalled${ns}`, () => {
                     // The "stalled" event may be triggered once the player is halted after initialisation,
                     // but this does not mean the playback is actually stalled, hence we only take care of the playing state
-                    if (state.playing) {
+                    if (state.playing && !media.paused) {
                         this.handleError(media.error);
                     }
                 })

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -109,7 +109,8 @@ export default function html5PlayerFactory($container, config = {}) {
         return `[html5-${type}(networkState=${networkState},readyState=${readyState}):${action}]`;
     };
     // eslint-disable-next-line
-    const debug = (action, ...args) => config.debug && window.console.log(getDebugContext(action), ...args);
+    const debug = (action, ...args) =>
+        (config.debug === true || config.debug === action) && window.console.log(getDebugContext(action), ...args);
 
     return eventifier({
         init() {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -502,7 +502,9 @@ export default function html5PlayerFactory($container, config = {}) {
             debug('api call', 'pause');
 
             if (media) {
-                state.pausedViaApi = true;
+                if (!media.paused) {
+                    state.pausedViaApi = true;
+                }
                 media.pause();
             }
         },

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -182,7 +182,7 @@ export default function html5PlayerFactory($container, config = {}) {
                 .on(`seeked${ns}`, () => {
                     // When the user try changing the current playing position while the network is down,
                     // the player will end the playback by moving straight to the end.
-                    if (state.seekedViaApi && state.seekAt !== media.currentTime) {
+                    if (state.seekedViaApi && Math.floor(state.seekAt) !== Math.floor(media.currentTime)) {
                         state.stallDetection = true;
                     }
                     state.seekedViaApi = false;

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -237,7 +237,6 @@ export default function html5PlayerFactory($container, config = {}) {
                 })
                 .on(`canplay${ns}`, () => {
                     if (!state.stalled) {
-                        state.stallDetection = false;
                         this.ready();
                     }
                 })

--- a/src/mediaplayer/utils/reminder.js
+++ b/src/mediaplayer/utils/reminder.js
@@ -1,0 +1,184 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Creates a reminder manager.
+ *
+ * A reminder manager allows to register callback functions that will be called after a particular amount of time.
+ * The schedule can be created and cancelled at any time.
+ *
+ * @example
+ * // Create a reminder manager
+ * const manager = reminderManagerFactory();
+ *
+ * // Add a reminder that will be called after 2s (delay is given in milliseconds)
+ * manager.remind(() => console.log('Hello!'), 2000);
+ *
+ * // Start the schedule
+ * manager.start();
+ *
+ * // We can know how many time elapsed since the last schedule
+ * const elapsed = manager.elapsed;
+ *
+ * // The schedule can be cancelled
+ * if (needToCancel) {
+ *     manager.stop();
+ * }
+ *
+ * // The schedule should be cancelled
+ * console.log('schedule running:', manager.running)
+ *
+ * @returns {reminderManager}
+ */
+export default function reminderManagerFactory() {
+    // Keep track of the running state
+    let running = false;
+
+    // Timestamp of the last start
+    let last = 0;
+
+    // A list of reminders to callback
+    const reminders = new Map();
+
+    /**
+     * Cancels a schedule for a particular reminder.
+     * @param {object} state - A sate object containing the timeout handler for the reminder.
+     * @private
+     */
+    const stopReminder = state => {
+        if (state && state.timeout) {
+            clearTimeout(state.timeout);
+            state.timeout = null;
+        }
+    };
+
+    /**
+     * Cancel the schedule for all reminders.
+     * @private
+     */
+    const stopAllReminders = () => reminders.forEach(stopReminder);
+
+    /**
+     * Schedule all reminders.
+     * @private
+     */
+    const startAllReminders = () => {
+        reminders.forEach((state, reminder) => {
+            stopReminder(state);
+            state.timeout = setTimeout(reminder, state.delay);
+        });
+    };
+
+    /**
+     * Defines the API of a reminder manager.
+     *
+     * A reminder manager allows to register callback functions that will be called after a particular amount of time.
+     * The schedule can be created and cancelled at any time.
+     *
+     * @namespace reminderManager
+     */
+    return {
+        /**
+         * Tells whether or not the schedule is running.
+         * @type {boolean}
+         * @member running
+         * @memberOf reminderManager
+         */
+        get running() {
+            return running;
+        },
+
+        /**
+         * Gives the amount of time elapsed since the start of the schedule. It is given in milliseconds.
+         * If the schedule is not running, it will always be 0.
+         * @type {number}
+         * @member running
+         * @memberOf reminderManager
+         */
+        get elapsed() {
+            if (!running) {
+                return 0;
+            }
+            return performance.now() - last;
+        },
+
+        /**
+         * Schedules all reminders from now on.
+         *
+         * @returns {reminderManager}
+         * @function start
+         * @memberOf reminderManager
+         */
+        start() {
+            running = true;
+            last = performance.now();
+            startAllReminders();
+            return this;
+        },
+
+        /**
+         * Cancels all scheduled reminders.
+         *
+         * @returns {reminderManager}
+         * @function stop
+         * @memberOf reminderManager
+         */
+        stop() {
+            running = false;
+            stopAllReminders();
+            return this;
+        },
+
+        /**
+         * Adds a callback to be scheduled.
+         * It won't be scheduled until the schedule is restarted.
+         *
+         * @param {Function} cb - A function to call after the delay elapsed.
+         * @param {number} delay - The delay after what call back the reminder. It is given in milliseconds.
+         * @returns {reminderManager}
+         * @function remind
+         * @memberOf reminderManager
+         */
+        remind(cb, delay) {
+            if ('function' === typeof cb && delay) {
+                stopReminder(reminders.get(cb));
+                reminders.set(cb, { delay });
+            }
+            return this;
+        },
+
+        /**
+         * Removes a scheduled callback. If a schedule was running, it will be cancelled first.
+         *
+         * @param {Function} [cb] - The callback function to remove. If omitted, all reminders will be removed.
+         * @returns {reminderManager}
+         * @function forget
+         * @memberOf reminderManager
+         */
+        forget(cb) {
+            if ('undefined' !== typeof cb) {
+                stopReminder(reminders.get(cb));
+                reminders.delete(cb);
+            } else {
+                stopAllReminders();
+                reminders.clear();
+            }
+            return this;
+        }
+    };
+}

--- a/src/mediaplayer/utils/timeObserver.js
+++ b/src/mediaplayer/utils/timeObserver.js
@@ -118,7 +118,7 @@ export default function timeObserverFactory(interval = 1) {
         update(newPosition) {
             if (newPosition > seek && newPosition - position > interval) {
                 /**
-                 * Notifies an irregularity in in the time update
+                 * Notifies an irregularity in the time update
                  * @event irregularity
                  * @param {number} position - last regular position
                  * @param {number} newPosition - new irregular position

--- a/src/mediaplayer/utils/timeObserver.js
+++ b/src/mediaplayer/utils/timeObserver.js
@@ -120,8 +120,10 @@ export default function timeObserverFactory(interval = 1) {
                 /**
                  * Notifies an irregularity in in the time update
                  * @event irregularity
+                 * @param {number} position - last regular position
+                 * @param {number} newPosition - new irregular position
                  */
-                this.trigger('irregularity');
+                this.trigger('irregularity', position, newPosition);
             }
             position = newPosition;
             return this;

--- a/src/mediaplayer/utils/timeObserver.js
+++ b/src/mediaplayer/utils/timeObserver.js
@@ -1,0 +1,141 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import eventifier from 'core/eventifier';
+
+/**
+ * Creates a time observer.
+ *
+ * It observes the updates applied to a timeline, raising a flag when an irregularity occurs.
+ *
+ * It works as follow:
+ * - an initial state is defined (example: current: 0, duration: 100)
+ * - each time a position is forced (say the position is changed outside of the regular time update), the observer needs
+ *   to be notified.
+ * - each time the position is updated (say regular time update), the observer needs to be called.
+ * - if the difference between the last regular update and the last one is too high, an event is triggered
+ *
+ * @example
+ * // Create a time observer with an expected interval of 2 seconds
+ * const observer = timeObserverFactory(2);
+ *
+ * // Init the state
+ * observer.start(player.position, player.duration);
+ *
+ * // Update on a regular basis
+ * player.on('timeupdate', () => observer.update(player.position));
+ *
+ * // Notify any position change outside of the regular update
+ * player.on('seek', () => observer.seek(player.position));
+ *
+ * // Gets informed from any irregularity
+ * observer.on('irregularity', () => console.log('irregular jump in time');
+ *
+ * @param {number} interval - The typical interval expected between two updates. It is given in seconds.
+ * @returns {timeObserver}
+ */
+export default function timeObserverFactory(interval = 1) {
+    // Current time position
+    let position = 0;
+
+    // Total duration expected
+    let duration = 0;
+
+    // Last position forced
+    let seek = 0;
+
+    /**
+     * Defines the API of a time observer.
+     *
+     * It observes the updates applied to a timeline, raising a flag when an irregularity occurs.
+     *
+     * @namespace timeObserver
+     */
+    return eventifier({
+        /**
+         * Gets the current time position reported to the observer.
+         *
+         * @returns {number}
+         * @type {number}
+         * @member position
+         * @memberOf timeObserver
+         */
+        get position() {
+            return position;
+        },
+
+        /**
+         * Gets the total duration reported to the observer.
+         *
+         * @returns {number}
+         * @type {number}
+         * @member duration
+         * @memberOf timeObserver
+         */
+        get duration() {
+            return duration;
+        },
+
+        /**
+         * Initialises the time state.
+         *
+         * @param {number} initPosition - The initial time position
+         * @param {number} initDuration - The total duration expected
+         * @returns {timeObserver}
+         * @function init
+         * @memberOf timeObserver
+         */
+        init(initPosition, initDuration) {
+            position = seek = initPosition;
+            duration = initDuration;
+            return this;
+        },
+
+        /**
+         * Updates the time position. If the difference with the previous update is too high, an `irregularity` event
+         * will be emitted.
+         *
+         * @param {number} newPosition - The new time position
+         * @returns {timeObserver}
+         *
+         * @fires irregularity
+         */
+        update(newPosition) {
+            if (newPosition > seek && newPosition - position > interval) {
+                /**
+                 * Notifies an irregularity in in the time update
+                 * @event irregularity
+                 */
+                this.trigger('irregularity');
+            }
+            position = newPosition;
+            return this;
+        },
+
+        /**
+         * Notifies the observer about a change in the position outside of the regular update.
+         *
+         * @param {number} seekPosition
+         * @returns {timeObserver}
+         */
+        seek(seekPosition) {
+            position = seek = seekPosition;
+            return this;
+        }
+    });
+}

--- a/test/mediaplayer/utils/reminder/test.html
+++ b/test/mediaplayer/utils/reminder/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test - Media Player - utils - reminder</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/mediaplayer/utils/reminder/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+    </body>
+</html>

--- a/test/mediaplayer/utils/reminder/test.js
+++ b/test/mediaplayer/utils/reminder/test.js
@@ -1,0 +1,115 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+define(['ui/mediaplayer/utils/reminder'], function (reminderManagerFactory) {
+    'use strict';
+
+    let performanceNow;
+
+    QUnit.module('reminderManager', {
+        beforeEach: function() {
+            performanceNow = performance.now;
+        },
+        afterEach: function() {
+            performance.now = performanceNow;
+        }
+    });
+
+    QUnit.test('module', assert => {
+        assert.equal(typeof reminderManagerFactory, 'function', 'The reminderManager module exposes a function');
+        assert.equal(typeof reminderManagerFactory(), 'object', 'The reminderManager factory produces an object');
+        assert.notStrictEqual(
+            reminderManagerFactory(),
+            reminderManagerFactory(),
+            'The reminderManager factory provides a different object on each call'
+        );
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'start' },
+            { title: 'stop' },
+            { title: 'remind' },
+            { title: 'forget' }
+        ])
+        .test('API ', (data, assert) => {
+            const instance = reminderManagerFactory();
+            assert.equal(
+                typeof instance[data.title],
+                'function',
+                `The reminderManager instance exposes a "${data.title}" function`
+            );
+        });
+
+    QUnit.test('Default values', assert => {
+        const reminderManager = reminderManagerFactory();
+        performance.now = () => 1234;
+        assert.equal(reminderManager.running, false, 'reminderManager is stopped');
+        assert.equal(reminderManager.elapsed, 0, 'reminderManager reports zero elapsed time');
+    });
+
+    QUnit.test('Start & stop', assert => {
+        const reminderManager = reminderManagerFactory();
+
+        performance.now = () => 1234;
+        reminderManager.start();
+        performance.now = () => 1334;
+        assert.equal(reminderManager.running, true, 'reminderManager is running');
+        assert.equal(reminderManager.elapsed, 100, 'reminderManager calculates correct elapsed time');
+
+        reminderManager.stop();
+        assert.equal(reminderManager.running, false, 'reminderManager is stopped');
+        assert.equal(reminderManager.elapsed, 0, 'reminderManager reports zero elapsed time');
+    });
+
+    QUnit.test('Add 1 reminder', assert => {
+        const done = assert.async();
+
+        const reminderManager = reminderManagerFactory();
+
+        let timeoutPassed = false;
+
+        const cb = () => {
+            assert.ok(timeoutPassed, 'Callback was called after expected time')
+            reminderManager.stop();
+            assert.equal(reminderManager.running, false, 'reminderManager is stopped');
+            done();
+        };
+
+        reminderManager.remind(cb, 20); // 20ms
+        reminderManager.start();
+        setTimeout(() => timeoutPassed = true, 19);
+    });
+
+    // TODO: remind multiple
+
+    // TODO: forget named
+
+    // TODO: forget all
+
+    QUnit.test('Chaining', assert => {
+        const cb = () => {};
+        const reminderManager = reminderManagerFactory();
+        reminderManager
+            .stop()
+            .start()
+            .remind(cb, 10)
+            .forget(cb)
+            .stop();
+        assert.ok(true, 'No error thrown => reminderManager methods are chainable');
+    });
+});

--- a/test/mediaplayer/utils/timeObserver/test.html
+++ b/test/mediaplayer/utils/timeObserver/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test - Media Player - utils - timeObserver</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/mediaplayer/utils/timeObserver/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+    </body>
+</html>

--- a/test/mediaplayer/utils/timeObserver/test.js
+++ b/test/mediaplayer/utils/timeObserver/test.js
@@ -15,7 +15,7 @@
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
-define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _, timeObserverFactory) {
+define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
     'use strict';
 
     QUnit.module('timeObserver');
@@ -47,16 +47,16 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
 
     QUnit.test('Default values', assert => {
         const timeObserver = timeObserverFactory();
-        assert.equal(timeObserver.position, 0);
-        assert.equal(timeObserver.duration, 0);
+        assert.equal(timeObserver.position, 0, 'position is default value');
+        assert.equal(timeObserver.duration, 0, 'duration is default value');
     });
 
     QUnit.test('Init values', assert => {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        assert.equal(timeObserver.position, 7);
-        assert.equal(timeObserver.duration, 11);
+        assert.equal(timeObserver.position, 7, 'position is init value');
+        assert.equal(timeObserver.duration, 11, 'duration is init value');
     });
 
     QUnit.test('Update position value - seeking forward works', assert => {
@@ -71,8 +71,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
 
         // +1 sec
         timeObserver.update(8);
-        assert.equal(timeObserver.position, 8);
-        assert.equal(timeObserver.duration, 11);
+        assert.equal(timeObserver.position, 8, 'position is updated');
+        assert.equal(timeObserver.duration, 11, 'duration is unchanged');
     });
 
     QUnit.test('Update position value - seeking backward works', assert => {
@@ -87,8 +87,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
 
         // -1 sec
         timeObserver.update(6);
-        assert.equal(timeObserver.position, 6);
-        assert.equal(timeObserver.duration, 11);
+        assert.equal(timeObserver.position, 6, 'position is updated');
+        assert.equal(timeObserver.duration, 11, 'duration is unchanged');
     });
 
     QUnit.test('Update position value - seeking forward & exceeding interval', assert => {
@@ -98,7 +98,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
         timeObserver.init(7, 11);
 
         timeObserver.after('irregularity', function() {
-            assert.equal(timeObserver.position, 9);
+            assert.ok(true, 'fires irregularity');
+            assert.equal(timeObserver.position, 9, 'position is updated');
             done();
         });
 
@@ -114,7 +115,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
         timeObserver.init(7, 11);
 
         timeObserver.after('irregularity', function() {
-            assert.equal(timeObserver.position, 10);
+            assert.ok(true, 'fires irregularity');
+            assert.equal(timeObserver.position, 10, 'position is updated');
             done();
         });
 
@@ -129,10 +131,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
         timeObserver.init(7, 11);
 
         timeObserver.seek(5);
-        assert.equal(timeObserver.position, 5);
+        assert.equal(timeObserver.position, 5, 'position is updated by seek');
 
         timeObserver.after('irregularity', function() {
-            assert.equal(timeObserver.position, 7);
+            assert.ok(true, 'fires irregularity');
+            assert.equal(timeObserver.position, 7, 'position is updated');
             done();
         });
 

--- a/test/mediaplayer/utils/timeObserver/test.js
+++ b/test/mediaplayer/utils/timeObserver/test.js
@@ -1,0 +1,152 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _, timeObserverFactory) {
+    'use strict';
+
+    QUnit.module('timeObserver');
+
+    QUnit.test('module', assert => {
+        assert.equal(typeof timeObserverFactory, 'function', 'The timeObserver module exposes a function');
+        assert.equal(typeof timeObserverFactory(), 'object', 'The timeObserver factory produces an object');
+        assert.notStrictEqual(
+            timeObserverFactory(),
+            timeObserverFactory(),
+            'The timeObserver factory provides a different object on each call'
+        );
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'init' },
+            { title: 'update' },
+            { title: 'seek' }
+        ])
+        .test('API ', (data, assert) => {
+            const instance = timeObserverFactory();
+            assert.equal(
+                typeof instance[data.title],
+                'function',
+                `The timeObserver instance exposes a "${data.title}" function`
+            );
+        });
+
+    QUnit.test('Default values', assert => {
+        const timeObserver = timeObserverFactory();
+        assert.equal(timeObserver.position, 0);
+        assert.equal(timeObserver.duration, 0);
+    });
+
+    QUnit.test('Init values', assert => {
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        assert.equal(timeObserver.position, 7);
+        assert.equal(timeObserver.duration, 11);
+    });
+
+    QUnit.test('Update position value - seeking forward works', assert => {
+        assert.expect(2);
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.on('irregularity', function() {
+            assert.ok(false, 'Should not report time irregularity!');
+        });
+
+        // +1 sec
+        timeObserver.update(8);
+        assert.equal(timeObserver.position, 8);
+        assert.equal(timeObserver.duration, 11);
+    });
+
+    QUnit.test('Update position value - seeking backward works', assert => {
+        assert.expect(2);
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.on('irregularity', function() {
+            assert.ok(false, 'Should not report time irregularity!');
+        });
+
+        // -1 sec
+        timeObserver.update(6);
+        assert.equal(timeObserver.position, 6);
+        assert.equal(timeObserver.duration, 11);
+    });
+
+    QUnit.test('Update position value - seeking forward & exceeding interval', assert => {
+        const done = assert.async();
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.after('irregularity', function() {
+            assert.equal(timeObserver.position, 9);
+            done();
+        });
+
+        // +2 sec
+        timeObserver.update(9);
+    });
+
+    QUnit.test('Update position value - seeking forward & exceeding non-default interval', assert => {
+        const done = assert.async();
+
+        const interval = 2;
+        const timeObserver = timeObserverFactory(interval);
+        timeObserver.init(7, 11);
+
+        timeObserver.after('irregularity', function() {
+            assert.equal(timeObserver.position, 10);
+            done();
+        });
+
+        // +3 sec
+        timeObserver.update(10);
+    });
+
+    QUnit.test('Set seek value & update', assert => {
+        const done = assert.async();
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.seek(5);
+        assert.equal(timeObserver.position, 5);
+
+        timeObserver.after('irregularity', function() {
+            assert.equal(timeObserver.position, 7);
+            done();
+        });
+
+        // +2 sec
+        timeObserver.update(7);
+    });
+
+    QUnit.test('Chaining', assert => {
+        const timeObserver = timeObserverFactory();
+        timeObserver
+            .init(7, 11)
+            .seek(8)
+            .update(9)
+            .seek(10);
+        assert.ok(true, 'No error thrown => timeObserver methods are chainable');
+    });
+});

--- a/test/mediaplayer/utils/timeObserver/test.js
+++ b/test/mediaplayer/utils/timeObserver/test.js
@@ -30,20 +30,14 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         );
     });
 
-    QUnit.cases
-        .init([
-            { title: 'init' },
-            { title: 'update' },
-            { title: 'seek' }
-        ])
-        .test('API ', (data, assert) => {
-            const instance = timeObserverFactory();
-            assert.equal(
-                typeof instance[data.title],
-                'function',
-                `The timeObserver instance exposes a "${data.title}" function`
-            );
-        });
+    QUnit.cases.init([{ title: 'init' }, { title: 'update' }, { title: 'seek' }]).test('API ', (data, assert) => {
+        const instance = timeObserverFactory();
+        assert.equal(
+            typeof instance[data.title],
+            'function',
+            `The timeObserver instance exposes a "${data.title}" function`
+        );
+    });
 
     QUnit.test('Default values', assert => {
         const timeObserver = timeObserverFactory();
@@ -65,7 +59,7 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        timeObserver.on('irregularity', function() {
+        timeObserver.on('irregularity', function () {
             assert.ok(false, 'Should not report time irregularity!');
         });
 
@@ -81,7 +75,7 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        timeObserver.on('irregularity', function() {
+        timeObserver.on('irregularity', function () {
             assert.ok(false, 'Should not report time irregularity!');
         });
 
@@ -97,7 +91,12 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        timeObserver.after('irregularity', function() {
+        timeObserver.on('irregularity', function (lastPosition, newPosition) {
+            assert.equal(lastPosition, 7, 'last position is given');
+            assert.equal(newPosition, 9, 'new position is given');
+        });
+
+        timeObserver.after('irregularity', function () {
             assert.ok(true, 'fires irregularity');
             assert.equal(timeObserver.position, 9, 'position is updated');
             done();
@@ -114,7 +113,12 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory(interval);
         timeObserver.init(7, 11);
 
-        timeObserver.after('irregularity', function() {
+        timeObserver.on('irregularity', function (lastPosition, newPosition) {
+            assert.equal(lastPosition, 7, 'last position is given');
+            assert.equal(newPosition, 10, 'new position is given');
+        });
+
+        timeObserver.after('irregularity', function () {
             assert.ok(true, 'fires irregularity');
             assert.equal(timeObserver.position, 10, 'position is updated');
             done();
@@ -133,7 +137,12 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         timeObserver.seek(5);
         assert.equal(timeObserver.position, 5, 'position is updated by seek');
 
-        timeObserver.after('irregularity', function() {
+        timeObserver.on('irregularity', function (lastPosition, newPosition) {
+            assert.equal(lastPosition, 5, 'last position is given');
+            assert.equal(newPosition, 7, 'new position is given');
+        });
+
+        timeObserver.after('irregularity', function () {
             assert.ok(true, 'fires irregularity');
             assert.equal(timeObserver.position, 7, 'position is updated');
             done();
@@ -145,11 +154,7 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
 
     QUnit.test('Chaining', assert => {
         const timeObserver = timeObserverFactory();
-        timeObserver
-            .init(7, 11)
-            .seek(8)
-            .update(9)
-            .seek(10);
+        timeObserver.init(7, 11).seek(8).update(9).seek(10);
         assert.ok(true, 'No error thrown => timeObserver methods are chainable');
     });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1460

Improve the detection of stalled media in the media player.

The previous way of detecting the stalled media has been removed and totally reworked. Instead of having it both in the mediaplayer and in the html5 implementation, it has been entirely integrated in the html5 implementation since it is deeply linked to it.

The stalled state is detected at various stages:
- when an explicit error occurs
- when the playback is stuck for some time (2s by default)
- when the current position is suddenly moved to the end (browser handling of missing data)

For this purpose, several counter measures have been put in place:
- a timeObserver to detect irregularities in the timeline
- a reminder to detect stuck playback (a callback is registered and is called if the time position didn't get updated for more than N seconds)
- an error observer that focus on recoverable errors and discard those that are not impacting the playback

**How to test:**
- have a video with a size big enough to not be entirely cached when starting the playback (40~60MB video would be enough).
- disconnect the network and play the video
- disconnect the network and reload the player
- play the video, disconnect the network and change the time position
- when the connection is off and the video is playing back, the message "You are encountering a prolonged connectivity loss. Click to reload." Should be displayed and the video should be blurred.

**Note about how to disconnect from the network. It can be done either by:**
- set the browser offline using the dev tools (Chrome, Edge) or by a dedicated menu (Firefox)
- block the request from the dev tools
- shutdown the server
- put an error in the file `tao/getFileFlysystem.php`, like `header("HTTP/1.0 404 Not Found"); die();`

**Note about unit tests:**
- unit tests need to be updated, and they are failing for the time being. It should be fixed before merging the PR