### PR TITLE
feature/TR-2758/set-media-interaction-ltr-direction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,8 +2589,8 @@
             "dev": true
         },
         "eve": {
-            "version": "git+ssh://git@github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "eve@git+https://github.com/adobe-webplatform/eve.git#eef80ed",
+            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
         "extend": {
@@ -4875,12 +4875,12 @@
             "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
             "dev": true,
             "requires": {
-                "eve": "eve@git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
             },
             "dependencies": {
                 "eve": {
-                    "version": "git+ssh://git@github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-                    "from": "eve@git://github.com/adobe-webplatform/eve.git#eef80ed",
+                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "decimal.js": "10.1.1",
         "devbridge-autocomplete": "^1.2.20",
         "dompurify": "^1.0.10",
-        "eve": "git+https://github.com/adobe-webplatform/eve.git#eef80ed",
+        "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed",
         "flatpickr": "4.5.7",
         "fs-extra": "^8.0.1",
         "gamp": "^0.2.1",

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -22,6 +22,7 @@ $controlsHeight: 36px;
     max-width: 100%;
     min-height: $controlsHeight;
     min-width: 200px;
+    direction: ltr;
 
     &.youtube {
         .player {

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -329,7 +329,7 @@ $controlsHeight: 36px;
     &.video, &.youtube {
         .sound {
             .volume {
-                width: $playerActionSize;
+                width: 2.8rem;
                 bottom: $playerActionSize;
                 right: 0;
             }


### PR DESCRIPTION
**Related to:** [TR-2758](https://oat-sa.atlassian.net/browse/TR-2758)

**Description:**

Media Interaction RTL needs to be reverted in Terre, should keep LTR always.

**Changes:**

- Add direction on CSS to fix the direction.
- Update `package.json` and `package-lock.json` to be compatible with NPM 6