### PR TITLE
Fix/TR-2846/Improve stalled detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,8 +2589,8 @@
             "dev": true
         },
         "eve": {
-            "version": "git+ssh://git@github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "eve@git+https://github.com/adobe-webplatform/eve.git#eef80ed",
+            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
         "extend": {
@@ -4875,12 +4875,12 @@
             "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
             "dev": true,
             "requires": {
-                "eve": "eve@git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
             },
             "dependencies": {
                 "eve": {
-                    "version": "git+ssh://git@github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-                    "from": "eve@git://github.com/adobe-webplatform/eve.git#eef80ed",
+                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
                     "dev": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,8 +2589,8 @@
             "dev": true
         },
         "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
+            "version": "git+https://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+            "from": "git+https://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
         "extend": {

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -189,9 +189,14 @@ const isResponsiveSize = sizeProps => {
 /**
  * Builds a media player instance
  * @param {Object} config
- * @param {String} config.type - The type of media to play
- * @param {String|Array} config.url - The URL to the media
- * @param {String} [config.mimeType] - The MIME type of the media
+ * @param {String} config.type - The type of media to play, say `audio`, `video`, or `youtube`. The default is `video`.
+ * It might also contain the MIME type of the media as a shorthand.
+ * @param {String|Array} [config.url] - The URL to the media. If several media are proposed as alternatives,
+ * please look at the `sources` option instead.
+ * @param {String} [config.mimeType] - The MIME type of the media. If omitted, the player will try to extract it
+ * from the `type` property, otherwise it will request the server to get the content-type.
+ * @param {Array} [config.sources] - A list of URL if several media can be proposed. Each entry may be either a
+ * string (single URL), or an object containing both the URL and the MIME type ({src: string, type: string}).
  * @param {String|jQuery|HTMLElement} [config.renderTo] - An optional container in which renders the player
  * @param {Boolean} [config.canSeek] - The player allows to reach an arbitrary position within the media using the duration bar
  * @param {Boolean} [config.loop] - The media will be played continuously

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -191,6 +191,7 @@ const isResponsiveSize = sizeProps => {
  * @param {Object} config
  * @param {String} config.type - The type of media to play
  * @param {String|Array} config.url - The URL to the media
+ * @param {String} [config.mimeType] - The MIME type of the media
  * @param {String|jQuery|HTMLElement} [config.renderTo] - An optional container in which renders the player
  * @param {Boolean} [config.canSeek] - The player allows to reach an arbitrary position within the media using the duration bar
  * @param {Boolean} [config.loop] - The media will be played continuously
@@ -232,6 +233,9 @@ function mediaplayerFactory(config) {
             // load the config set, discard null values in order to allow defaults to be set
             this.config = _.omit(config || {}, value => typeof value === 'undefined' || value === null);
             _.defaults(this.config, defaults.options);
+            if (!this.config.mimeType && 'string' === typeof this.config.type && this.config.type.indexOf('/') > 0) {
+                this.config.mimeType = this.config.type;
+            }
             this._setType(this.config.type || defaults.type);
 
             this._reset();
@@ -774,8 +778,12 @@ function mediaplayerFactory(config) {
                 source = _.clone(src);
             }
 
-            if (this.is('youtube') && !source.type) {
-                source.type = defaults.type;
+            if (!source.type) {
+                if (this.is('youtube')) {
+                    source.type = defaults.type;
+                } else if (this.config.mimeType) {
+                    source.type = this.config.mimeType;
+                }
             }
 
             if (!source.type) {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -220,7 +220,8 @@ export default function html5PlayerFactory($container, config = {}) {
                 .on(`error${ns}`, () => {
                     if (
                         media.networkState === HTMLMediaElement.NETWORK_NO_SOURCE ||
-                        (media.error instanceof MediaError && media.error === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED)
+                        (media.error instanceof MediaError &&
+                            media.error.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED)
                     ) {
                         // No source means the player does not support the supplied media.
                         // Or it can be more explicit with the not supported error.
@@ -511,7 +512,7 @@ export default function html5PlayerFactory($container, config = {}) {
         stop() {
             debug('api call', 'stop');
 
-            if (media && state.playback) {
+            if (media && media.duration && state.playback && !state.stalled) {
                 media.currentTime = media.duration;
             }
         },

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -355,9 +355,11 @@ $controlsHeight: 36px;
                 cursor: pointer;
             }
 
-            .player:hover {
-                [data-control="play"] {
-                    display: inline-block;
+            &:not(.audio) {
+                .player:hover {
+                    [data-control="play"] {
+                        display: inline-block;
+                    }
                 }
             }
 
@@ -375,9 +377,11 @@ $controlsHeight: 36px;
                 cursor: pointer;
             }
 
-            .player:hover {
-                [data-control="pause"] {
-                    display: inline-block;
+            &:not(.audio) {
+                .player:hover {
+                    [data-control="pause"] {
+                        display: inline-block;
+                    }
                 }
             }
         }

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -343,6 +343,32 @@ $controlsHeight: 36px;
                 bottom: 0;
             }
         }
+
+        &.stalled {
+            .player {
+                .player-overlay {
+                    [data-control="reload"] {
+                        margin-top: 0;
+
+                        display: flex;
+                        flex-direction: row;
+                        justify-content: center;
+
+                        &.reload {
+                            width: 100%;
+                            font-size: 20px;
+                            line-height: 20px;
+
+                            .message {
+                                font-size: 10px;
+                                line-height: 15px;
+                                margin-top: 2px;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     &.ready {

--- a/src/mediaplayer/support.js
+++ b/src/mediaplayer/support.js
@@ -19,12 +19,14 @@
 /**
  * A Regex to detect Apple mobile browsers
  * @type {RegExp}
+ * @private
  */
 const reAppleMobiles = /ip(hone|od)/i;
 
 /**
  * A list of MIME types with codec declaration
  * @type {Object}
+ * @private
  */
 const supportedMimeTypes = {
     // video
@@ -39,6 +41,15 @@ const supportedMimeTypes = {
 };
 
 /**
+ * Checks support for a MIME type.
+ * @param {HTMLMediaElement} media The media element on which check support
+ * @param {String} mimeType A MIME type to check the support for
+ * @returns {string}
+ * @private
+ */
+const findSupport = (media, mimeType) => media.canPlayType(mimeType).replace(/no/, '');
+
+/**
  * Support detection
  * @type {Object}
  */
@@ -51,13 +62,15 @@ export default {
      * @private
      */
     checkSupport(media, mimeType) {
-        const support = !!media.canPlayType;
-
+        const support = media.canPlayType;
         if (support && mimeType) {
-            return !!media.canPlayType(supportedMimeTypes[mimeType] || mimeType).replace(/no/, '');
+            return !!(
+                (supportedMimeTypes[mimeType] && findSupport(media, supportedMimeTypes[mimeType])) ||
+                findSupport(media, mimeType)
+            );
         }
 
-        return support;
+        return !!support;
     },
 
     /**

--- a/src/mediaplayer/tpl/player.tpl
+++ b/src/mediaplayer/tpl/player.tpl
@@ -9,8 +9,7 @@
             </a>
             <a class="action reload" data-control="reload">
                 <div class="icon icon-reload" title="{{__ 'Reload'}}"></div>
-                <div class="message">{{__ 'You are encountering a prolonged connectivity loss.'}}</div>
-                <div class="message">{{__ 'Click to reload.'}}</div>
+                <div class="message">{{__ 'You are encountering a prolonged connectivity loss.'}}<br />{{__ 'Click to reload.'}}</div>
             </a>
         </div>
     </div>

--- a/test/mediaplayer/support/test.js
+++ b/test/mediaplayer/support/test.js
@@ -38,7 +38,7 @@ define(['ui/mediaplayer/support', 'test/ui/mediaplayer/mocks/userAgentMock'], fu
                 return {
                     canPlayType(type) {
                         const supportList = {
-                            'video/webm; codecs="vp8, vorbis"': 'probably',
+                            'video/webm': 'probably',
                             'video/mp4; codecs="avc1.42E01E, mp4a.40.2"': 'maybe',
                             'video/mkv': 'no'
                         };

--- a/test/mediaplayer/test.js
+++ b/test/mediaplayer/test.js
@@ -100,10 +100,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
     QUnit.test('DOM [audio player]', assert => {
         const ready = assert.async();
         const url = 'samples/audio.mp3';
+        const type = 'audio/mp3';
         const $container = $('#qunit-fixture');
         const instance = mediaplayer({
-            url: url,
-            type: 'audio/mp3',
+            url,
+            type,
             renderTo: $container
         });
 
@@ -138,6 +139,7 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
             assert.equal($source.length, 1, 'The rendered content contains an audio source');
             assert.equal($source.attr('data-src'), url, 'Audio source targets the right URL');
+            assert.equal($source.attr('data-type'), type, 'Audio source has the right type');
 
             assert.equal($overlay.length, 1, 'The rendered content contains an overlay element');
             assert.equal(
@@ -216,10 +218,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
     QUnit.test('DOM [video player]', assert => {
         const ready = assert.async();
         const url = 'samples/video.mp4';
+        const type = 'video/mp4';
         const $container = $('#qunit-fixture');
         const instance = mediaplayer({
-            url: url,
-            type: 'video/mp4',
+            url,
+            type,
             renderTo: $container
         });
 
@@ -254,6 +257,7 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
             assert.equal($source.length, 1, 'The rendered content contains a video source');
             assert.equal($source.attr('data-src'), url, 'Video source targets the right URL');
+            assert.equal($source.attr('data-type'), type, 'Video source has the right type');
 
             assert.equal($overlay.length, 1, 'The rendered content contains an overlay element');
             assert.equal(
@@ -333,10 +337,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
         const ready = assert.async();
         const videoId = 'YJWSVUPSQqw';
         const url = `//www.youtube.com/watch?v=${videoId}`;
+        const type = 'video/youtube';
         const $container = $('#qunit-fixture');
         const instance = mediaplayer({
-            url: url,
-            type: 'video/youtube',
+            url,
+            type,
             renderTo: $container
         });
 
@@ -1076,6 +1081,66 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
         instance.destroy();
     });
+
+    QUnit.cases
+        .init([
+            {
+                title: 'request mime type',
+                config: {
+                    type: 'audio',
+                    url: 'samples/audio.mp3'
+                },
+                mime: 'audio/mpeg'
+            },
+            {
+                title: 'use type',
+                config: {
+                    type: 'audio/mp3',
+                    url: 'samples/audio.mp3'
+                },
+                mime: 'audio/mp3'
+            },
+            {
+                title: 'specify type',
+                config: {
+                    type: 'audio/mpeg',
+                    mimeType: 'audio/mp3',
+                    url: 'samples/audio.mp3'
+                },
+                mime: 'audio/mp3'
+            },
+            {
+                title: 'youtube type',
+                config: {
+                    type: 'video/youtube',
+                    mimeType: 'video/webm',
+                    url: 'YJWSVUPSQqw'
+                },
+                mime: 'video/mp4'
+            }
+        ])
+        .test('Type management ', (data, assert) => {
+            const ready = assert.async();
+            const instance = mediaplayer(
+                Object.assign(
+                    {
+                        renderTo: '#qunit-fixture'
+                    },
+                    data.config
+                )
+            )
+                .on('render', () => {
+                    const sources = instance.getSources();
+
+                    assert.equal(sources.length, 1, 'The media player has one media in its list of sources');
+
+                    assert.equal(sources[0].src, data.config.url, 'The source URL is as expected');
+                    assert.equal(sources[0].type, data.mime, 'The source type is as expected');
+
+                    instance.destroy();
+                })
+                .on('destroy', ready);
+        });
 
     QUnit.test('stalled', assert => {
         const ready = assert.async();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-2846

In the context of the pre-caching features, the media player is not always able to properly detect a stalled media. It may happen that the state is set even if the media is not actually stalled.

This is especially true with Safari since the MIME type detection was inaccurate with cached audio (the pre-caching loader is caching the data in a blob). The MIME type detection was reworked to first rely on the supplied MIME type if any, and then only fallback to server side detection if missing.

Some additional fixes have been made as well:
- the look and feel for the "reload" state for audio player
- the support detection for WebM media in Safari