### PR TITLE
Feature/tr 3033/login form rtl

### DIFF
--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -571,6 +571,10 @@ label {
         text-align: right;
         margin: 30px 0 0 0;
         @extend %clearfix;
+
+        [dir="rtl"] & {
+            text-align: left;
+        }
     }
 
     .property-title {
@@ -710,6 +714,10 @@ label {
                 max-width: none;
                 @include simple-border();
             }
+        }
+
+        [dir="rtl"] & {
+            padding: 0 0 0 10px;
         }
     }
     input {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3033

I wasn't sure if a style should be added only for login form, or on global level for all forms, but it looked like it's better to do it on global level. I thinks RTL feature is in progress of being implemented, so we shouldn't break anything by this change,

How to test: with https://github.com/oat-sa/tao-core/pull/3255