### PR TITLE
fix/TR-3280/header-logo-support-rtl

### DIFF
--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -382,6 +382,12 @@ body {
         float: left;
     }
 
+    body[dir="rtl"] {
+        & .content-wrap>header>.lft {
+            float: none;
+        }
+    }
+
     .rgt,
     .wrap-right {
         display: inline;


### PR DESCRIPTION
**Related to:** [TR-3280](https://oat-sa.atlassian.net/browse/TR-3280)

**Description:**
On RTL mode the logo on the Header keeps on the left. There is a CSS class that forces a `float: left`.
I've tracked the CSS class but I don't know the reason to have it. In order to avoid regression, I just disable the floating effect on RTL mode.

**Changes:**

- Add CSS rule to disable `float: left` effect on RTL mode.