### PR TITLE
Feature/tr 3180/review panel item button list component

### DIFF
--- a/src/itemButtonList.js
+++ b/src/itemButtonList.js
@@ -44,15 +44,20 @@ const cssSelectors = {
 
 /**
  * @typedef {Object} ItemButton
- * @property {String} id - recommended to use item id
- * @property {Number} position - recommended to use 0-based list index
+ * @property {String} id - item id
+ * @property {Number} position - 0-based list index
  * @property {String} label - displayed text
+ * @property {String} numericLabel - displayed number (alternative to label)
  * @property {String} ariaLabel
- * @property {String} icon - 'info' or null - replaces label if set
- * @property {String} type - 'answered'/'viewed'/'unseen'
+ * @property {Number} score - the item's current score
+ * @property {Number} maxScore - the item's max possible score
+ * @property {Boolean} informational
+ * @property {Boolean} skipped
+ * @property {String} type - 'correct'/'incorrect'/'info'/'skipped'/'default'
+ * @property {String} status - 'answered'/'viewed'/'unseen'
  * @property {String} scoreType - 'correct'/'incorrect'/null
+ * @property {String} icon - 'info' or null
  */
-
 /**
  * Item Button List
  * Ordered list of buttons representing items from a testMap section

--- a/src/itemButtonList.js
+++ b/src/itemButtonList.js
@@ -15,6 +15,7 @@
  *
  * Copyright (c) 2022 Open Assessment Technologies SA ;
  */
+import $ from 'jquery';
 import autoscroll from 'ui/autoscroll';
 import componentFactory from 'ui/component';
 import itemButtonListTpl from 'ui/itemButtonList/tpl/itemButtonList';
@@ -26,7 +27,7 @@ import 'ui/itemButtonList/css/item-button-list.css';
  */
 const cssClasses = {
     active: 'buttonlist-item-active',
-    //keyfocused: 'buttonlist-item-focus'
+    keyfocused: 'buttonlist-item-focus'
 };
 
 /**
@@ -35,7 +36,7 @@ const cssClasses = {
  */
 const cssSelectors = {
     active: `.${cssClasses.active}`,
-    //keyfocused: `.${cssClasses.keyfocused}`,
+    keyfocused: `.${cssClasses.keyfocused}`,
     navigable: '.buttonlist-btn',
     itemById: (id) => `.buttonlist-item[data-id="${id}"]`,
     navigableById: (id) => `.buttonlist-btn[data-id="${id}"]`
@@ -93,19 +94,19 @@ function itemButtonListFactory(config = {}) {
         }
     };
 
-    // /**
-    //  * Demo example of 'tabfocus' styling
-    //  * @param {jQuery|null}  $target
-    //  */
-    // const setFocusStyle = $target => {
-    //     component.getElement()
-    //         .find(cssSelectors.keyfocused)
-    //         .removeClass(cssClasses.keyfocused);
+    /**
+     * 'tabfocus' styling, for Safari until :focus-visible supported
+     * @param {jQuery|null}  $target
+     */
+    const setFocusStyle = $target => {
+        component.getElement()
+            .find(cssSelectors.keyfocused)
+            .removeClass(cssClasses.keyfocused);
 
-    //     if ($target && $target.length) {
-    //         $target.addClass(cssClasses.keyfocused);
-    //     }
-    // };
+        if ($target && $target.length) {
+            $target.addClass(cssClasses.keyfocused);
+        }
+    };
 
     /**
      * Apply a callback on each navigable element
@@ -172,17 +173,17 @@ function itemButtonListFactory(config = {}) {
         .setTemplate(itemButtonListTpl)
         // renders the component
         .on('render', function onItemButtonListRender() {
-            //Demo example of 'tabfocus' detection
-            // this.getElement().on('keydown', cssSelectors.navigable, e => {
-            //     if (e.key === 'Tab') {
-            //         setFocusStyle(null);
-            //     }
-            // });
-            // this.getElement().on('keyup', cssSelectors.navigable, e => {
-            //     if (e.key === 'Tab') {
-            //         setFocusStyle($(e.target));
-            //     }
-            // });
+            // 'tabfocus' detection, for Safari until :focus-visible supported
+            this.getElement().on('keydown', cssSelectors.navigable, e => {
+                if (e.key === 'Tab') {
+                    setFocusStyle(null);
+                }
+            });
+            this.getElement().on('keyup', cssSelectors.navigable, e => {
+                if (e.key === 'Tab') {
+                    setFocusStyle($(e.target));
+                }
+            });
 
             component.getElement().on('click', cssSelectors.navigable, e => {
                 if (!this.is('disabled')) {

--- a/src/itemButtonList.js
+++ b/src/itemButtonList.js
@@ -27,7 +27,7 @@ import 'ui/itemButtonList/css/item-button-list.css';
  */
 const cssClasses = {
     active: 'buttonlist-item-active',
-    keyfocused: 'buttonlist-item-focus'
+    keyfocused: 'buttonlist-btn-focus'
 };
 
 /**
@@ -130,6 +130,7 @@ function itemButtonListFactory(config = {}) {
      */
     const disableKeyboard = () => {
         eachNavigable((index, el) => el.setAttribute('tabindex', -1));
+        setFocusStyle(null);
     };
 
     /**

--- a/src/itemButtonList.js
+++ b/src/itemButtonList.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 Open Assessment Technologies SA ;
+ * Copyright (c) 2022 Open Assessment Technologies SA ;
  */
 import autoscroll from 'ui/autoscroll';
 import componentFactory from 'ui/component';

--- a/src/itemButtonList.js
+++ b/src/itemButtonList.js
@@ -1,0 +1,219 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA ;
+ */
+import autoscroll from 'ui/autoscroll';
+import componentFactory from 'ui/component';
+import itemButtonListTpl from 'ui/itemButtonList/tpl/itemButtonList';
+import 'ui/itemButtonList/css/item-button-list.css';
+
+/**
+ * CSS classes involved in the component
+ * @type {Object}
+ */
+const cssClasses = {
+    active: 'buttonlist-item-active',
+    //keyfocused: 'buttonlist-item-focus'
+};
+
+/**
+ * CSS selectors that match some particular elements
+ * @type {Object}
+ */
+const cssSelectors = {
+    active: `.${cssClasses.active}`,
+    //keyfocused: `.${cssClasses.keyfocused}`,
+    navigable: '.buttonlist-btn',
+    itemById: (id) => `.buttonlist-item[data-id="${id}"]`,
+    navigableById: (id) => `.buttonlist-btn[data-id="${id}"]`
+};
+
+/**
+ * @typedef {Object} ItemButton
+ * @property {String} id - recommended to use item id
+ * @property {Number} position - recommended to use 0-based list index
+ * @property {String} label - displayed text
+ * @property {String} ariaLabel
+ * @property {String} icon - 'info' or null - replaces label if set
+ * @property {String} type - 'answered'/'viewed'/'unseen'
+ * @property {String} scoreType - 'correct'/'incorrect'/null
+ */
+
+/**
+ * Item Button List
+ * Ordered list of buttons representing items from a testMap section
+ * Mostly presentational component
+ *
+ * @param {Object} config
+ * @param {ItemButton[]} [config.items] - The list of entries to display
+ * @returns {component}
+ * @fires ready - When the component is ready to work
+ * @fires click When an item is selected by the user
+ */
+function itemButtonListFactory(config = {}) {
+    let component;
+    let activeItemId = null;
+
+    /**
+     * Selects the active item
+     * @param {String|null} itemId
+     */
+    const selectItem = itemId => {
+        // first deactivate already active elements
+        component.getElement().find(cssSelectors.active)
+            .removeClass(cssClasses.active);
+        component.getElement().find(cssSelectors.navigable)
+            .removeAttr('aria-current');
+
+        // activate element
+        if (itemId) {
+            const $target = component.getElement().find(cssSelectors.itemById(itemId));
+            if ($target.length) {
+                $target.addClass(cssClasses.active);
+                // finally make sure the item is visible
+                autoscroll($target, component.getElement());
+            }
+            const $ariaTarget = component.getElement().find(cssSelectors.navigableById(itemId));
+            if ($ariaTarget.length) {
+                $ariaTarget.attr('aria-current', 'location');
+            }
+        }
+    };
+
+    // /**
+    //  * Demo example of 'tabfocus' styling
+    //  * @param {jQuery|null}  $target
+    //  */
+    // const setFocusStyle = $target => {
+    //     component.getElement()
+    //         .find(cssSelectors.keyfocused)
+    //         .removeClass(cssClasses.keyfocused);
+
+    //     if ($target && $target.length) {
+    //         $target.addClass(cssClasses.keyfocused);
+    //     }
+    // };
+
+    /**
+     * Apply a callback on each navigable element
+     * @param {*} callback
+     */
+    const eachNavigable = callback => {
+        component.getElement()
+            .find(cssSelectors.navigable)
+            .each(callback);
+    };
+
+    /**
+     * Enables the keyboard navigation using 'tab' keys
+     */
+    const enableKeyboard = () => {
+        eachNavigable((index, el) => el.removeAttribute('tabindex'));
+    };
+
+    /**
+     * Disables the keyboard navigation using 'tab' keys
+     */
+    const disableKeyboard = () => {
+        eachNavigable((index, el) => el.setAttribute('tabindex', -1));
+    };
+
+    /**
+     * Emits the click event detailing the clicked item
+     * The active item change should be handled by the consumer through the API, in case it is conditional or asynchronous
+     * @param {String} itemId
+     */
+    const onClick = (itemId) => {
+        /**
+         * @event click
+         * @param {String} itemId
+         * @param {Number} position
+         */
+        component.trigger('click', { id: itemId });
+    };
+
+    /**
+     * Defines the buttonList API
+     * @type {buttonList}
+     */
+    const api = {
+        /**
+         * Sets the active item
+         * @param {String} itemId
+         * @returns {buttonList}
+         */
+        setActiveItem(itemId) {
+            activeItemId = itemId;
+            if (this.is('rendered')) {
+                selectItem(itemId);
+            }
+            return this;
+        }
+    };
+
+    /**
+     * @typedef {component} buttonList
+     */
+    component = componentFactory(api, {})
+        // set the component's layout
+        .setTemplate(itemButtonListTpl)
+        // renders the component
+        .on('render', function onItemButtonListRender() {
+            //Demo example of 'tabfocus' detection
+            // this.getElement().on('keydown', cssSelectors.navigable, e => {
+            //     if (e.key === 'Tab') {
+            //         setFocusStyle(null);
+            //     }
+            // });
+            // this.getElement().on('keyup', cssSelectors.navigable, e => {
+            //     if (e.key === 'Tab') {
+            //         setFocusStyle($(e.target));
+            //     }
+            // });
+
+            component.getElement().on('click', cssSelectors.navigable, e => {
+                if (!this.is('disabled')) {
+                    onClick(e.currentTarget.dataset.id);
+                }
+            });
+
+            selectItem(activeItemId);
+
+            if (!this.is('disabled')) {
+                enableKeyboard();
+            } else {
+                disableKeyboard();
+            }
+
+            /**
+             * @event ready
+             */
+            this.setState('ready', true)
+                .trigger('ready');
+        })
+
+        // reflect enable/disabled state
+        .on('enable', () => enableKeyboard)
+        .on('disable', () => disableKeyboard);
+
+    // initialize the component with the provided config:
+    // config also contains data passed to template when rendering
+    component.init(config);
+
+    return component;
+}
+
+export default itemButtonListFactory;

--- a/src/itemButtonList.js
+++ b/src/itemButtonList.js
@@ -46,14 +46,8 @@ const cssSelectors = {
  * @typedef {Object} ItemButton
  * @property {String} id - item id
  * @property {Number} position - 0-based list index
- * @property {String} label - displayed text
- * @property {String} numericLabel - displayed number (alternative to label)
+ * @property {String} numericLabel - displayed number
  * @property {String} ariaLabel
- * @property {Number} score - the item's current score
- * @property {Number} maxScore - the item's max possible score
- * @property {Boolean} informational
- * @property {Boolean} skipped
- * @property {String} type - 'correct'/'incorrect'/'info'/'skipped'/'default'
  * @property {String} status - 'answered'/'viewed'/'unseen'
  * @property {String} scoreType - 'correct'/'incorrect'/null
  * @property {String} icon - 'info' or null

--- a/src/itemButtonList/scss/item-button-list.scss
+++ b/src/itemButtonList/scss/item-button-list.scss
@@ -193,9 +193,14 @@ $borderMedium: 0.25rem;
     }
 
     /****** keyboard focus styles *******/
+    /*
+     * .key-navigation-highlight and .buttonlist-item-focus:focus styles
+     * could be removed as soon as Safari properly supports :focus-visible
+     */
     .buttonlist-item {
         &.key-navigation-highlight .buttonlist-btn::before,
-        .buttonlist-btn.buttonlist-item-focus:focus::before {
+        .buttonlist-btn.buttonlist-item-focus:focus::before,
+        .buttonlist-btn:focus-visible::before {
             content: '';
             display: block;
             position: absolute;
@@ -211,19 +216,22 @@ $borderMedium: 0.25rem;
         }
 
         &.key-navigation-highlight.buttonlist-item-active .buttonlist-btn .indicator,
-        &.buttonlist-item-active .buttonlist-btn.buttonlist-item-focus:focus .indicator {
+        &.buttonlist-item-active .buttonlist-btn.buttonlist-item-focus:focus .indicator,
+        &.buttonlist-item-active .buttonlist-btn:focus-visible .indicator {
             color: $uiReviewPanelPrimaryHighlight;
         }
 
         &.key-navigation-highlight.viewed .buttonlist-btn,
-        &.viewed .buttonlist-btn.buttonlist-item-focus:focus {
+        &.viewed .buttonlist-btn.buttonlist-item-focus:focus,
+        &.viewed .buttonlist-btn:focus-visible {
             background-color: $uiReviewPanelBgDefault;
             color: $uiReviewPanelPrimaryHighlight;
             border-color: $uiReviewPanelPrimaryHighlight;
         }
 
         &.key-navigation-highlight.answered .buttonlist-btn,
-        &.answered .buttonlist-btn.buttonlist-item-focus:focus {
+        &.answered .buttonlist-btn.buttonlist-item-focus:focus,
+        &.answered .buttonlist-btn:focus-visible {
             background-color: $uiReviewPanelPrimaryHighlight;
             color: $uiReviewPanelTextInverted;
             border-color: $uiReviewPanelPrimaryHighlight;

--- a/src/itemButtonList/scss/item-button-list.scss
+++ b/src/itemButtonList/scss/item-button-list.scss
@@ -1,0 +1,232 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA ;
+ */
+@import "inc/bootstrap";
+
+$correctColor: $success;
+$incorrectColor: $error;
+$hoverBgColor: hsl(208, 100%, 95%);
+
+$radiusCircular: 50%;
+$sizeDefault: 4rem;
+$hitboxSize: 6.25rem;
+$borderThin: 0.125rem;
+$borderMedium: 0.25rem;
+
+.buttonlist-items {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: start;
+    padding: 0;
+
+    /****** base styles *******/
+    .buttonlist-item {
+        height: $hitboxSize;
+        width: $hitboxSize;
+        display: flex;
+        justify-content: center; /* aligning left - cut focusing board for keyboard interacting */
+        align-items: center;
+        /* reset parent styles */
+        padding: 0 !important; /* instead of rewriting 6-classes selector on focusing */
+        border: none !important; /* instead of rewriting 6-classes selector on focusing */
+    }
+
+    .buttonlist-btn {
+        position: relative;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: $sizeDefault;
+        width: $sizeDefault;
+        border-style: solid;
+        border-radius: $radiusCircular;
+        border-width: $borderThin;
+        border-color: $uiReviewPanelTextDisabled;
+        margin: 1.3rem 0.75rem 1rem 0.75rem;
+        padding: 0; /*Fixes firefox button jumps*/
+        font-weight: bold;
+        font-size: 1.6rem;
+        background-color: $uiReviewPanelBgDefault;
+        color: $uiReviewPanelTextDisabled;
+        text-shadow: none;
+        cursor: pointer;
+    }
+
+    .buttonlist-label {
+        font-family: 'Nunito Sans', 'Source Sans Pro', Arial, sans-serif;
+        max-width: 3.75rem;
+        overflow: hidden;
+        white-space: nowrap;
+        line-height: initial;
+    }
+
+    .buttonlist-icon {
+        padding: 0;
+        top: 0;
+        left: 0;
+    }
+
+    .indicator {
+        display: none;
+    }
+
+    .buttonlist-score-badge {
+        position: absolute;
+        top: -0.9rem;
+        right: -0.9rem;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 100%;
+        color: $uiReviewPanelTextInverted;
+        border: 0.1rem solid $uiReviewPanelTextInverted;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .buttonlist-score-icon {
+        font-size: 1.2rem;
+        padding: 0;
+        top: 0;
+        left: 0;
+    }
+
+    .icon-info::before {
+        @include icon-info-bare;
+    }
+    .icon-flagged::before {
+        @include icon-bookmark;
+    }
+    .icon-correct::before {
+        @include icon-result-ok;
+    }
+    .icon-incorrect::before {
+        @include icon-result-nok;
+    }
+
+
+    /****** step state styles *******/
+    .buttonlist-item {
+        &.viewed {
+            .buttonlist-btn {
+                border-width: $borderMedium;
+                color: $uiReviewPanelTextDefault;
+                border-color: $uiReviewPanelTextDefault;
+            }
+        }
+
+        &.answered {
+            .buttonlist-btn {
+                border-width: $borderMedium;
+                background-color: $uiReviewPanelBgInverted;
+                color: $uiReviewPanelTextInverted;
+                border-color: $uiReviewPanelBgInverted;
+            }
+        }
+
+        &.buttonlist-item-active {
+            .indicator {
+                position: absolute;
+                display: block;
+                z-index: 1;
+                color: $uiReviewPanelTextDefault;
+                height: 1.4rem;
+                min-width: 1.6rem;
+                // background-color: $uiReviewPanelBg;
+                top: unset;
+                bottom: -1.7rem;
+                padding: 0;
+                /* centering horizontally */
+                left: 50%;
+                transform: translateX(-50%);
+            }
+        }
+
+        &.correct {
+            .buttonlist-score-badge {
+                background-color: $correctColor;
+            }
+        }
+
+        &.incorrect {
+            .buttonlist-score-badge {
+                background-color: $incorrectColor;
+            }
+        }
+
+    }
+
+    /* disabling is applied at the buttonlist-items level */
+    &:not(.disabled) {
+        .buttonlist-btn:hover {
+            background-color: $hoverBgColor;
+            color: $uiReviewPanelPrimaryHighlight;
+            border-color: $uiReviewPanelPrimaryHighlight;
+        }
+    }
+    &.disabled {
+         /* reset global styles */
+        background-color: unset !important;
+        opacity: 1 !important;
+        text-shadow: none !important;
+
+        .buttonlist-btn {
+            cursor: not-allowed;
+            /* reset global styles */
+            opacity: 0.5;
+            text-shadow: none;
+        }
+    }
+
+    /****** keyboard focus styles *******/
+    .buttonlist-item {
+        &.key-navigation-highlight .buttonlist-btn::before,
+        .buttonlist-btn.buttonlist-item-focus:focus::before {
+            content: '';
+            display: block;
+            position: absolute;
+            width: 5.2rem;
+            height: 5.2rem;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            border-width: $borderMedium;
+            border-color: $uiReviewPanelPrimaryHighlight;
+            border-style: dotted;
+            border-radius: $radiusCircular;
+        }
+
+        &.key-navigation-highlight.buttonlist-item-active .buttonlist-btn .indicator,
+        &.buttonlist-item-active .buttonlist-btn.buttonlist-item-focus:focus .indicator {
+            color: $uiReviewPanelPrimaryHighlight;
+        }
+
+        &.key-navigation-highlight.viewed .buttonlist-btn,
+        &.viewed .buttonlist-btn.buttonlist-item-focus:focus {
+            background-color: $uiReviewPanelBgDefault;
+            color: $uiReviewPanelPrimaryHighlight;
+            border-color: $uiReviewPanelPrimaryHighlight;
+        }
+
+        &.key-navigation-highlight.answered .buttonlist-btn,
+        &.answered .buttonlist-btn.buttonlist-item-focus:focus {
+            background-color: $uiReviewPanelPrimaryHighlight;
+            color: $uiReviewPanelTextInverted;
+            border-color: $uiReviewPanelPrimaryHighlight;
+        }
+    }
+}

--- a/src/itemButtonList/scss/item-button-list.scss
+++ b/src/itemButtonList/scss/item-button-list.scss
@@ -121,6 +121,8 @@ $borderMedium: 0.25rem;
 
     /****** step state styles *******/
     .buttonlist-item {
+        @include disableSelect();
+
         &.viewed {
             .buttonlist-btn {
                 border-width: $borderMedium;
@@ -128,7 +130,6 @@ $borderMedium: 0.25rem;
                 border-color: $uiReviewPanelTextDefault;
             }
         }
-
         &.answered {
             .buttonlist-btn {
                 border-width: $borderMedium;
@@ -137,7 +138,6 @@ $borderMedium: 0.25rem;
                 border-color: $uiReviewPanelBgInverted;
             }
         }
-
         &.buttonlist-item-active {
             .indicator {
                 position: absolute;
@@ -146,7 +146,6 @@ $borderMedium: 0.25rem;
                 color: $uiReviewPanelTextDefault;
                 height: 1.4rem;
                 min-width: 1.6rem;
-                // background-color: $uiReviewPanelBg;
                 top: unset;
                 bottom: -1.7rem;
                 padding: 0;
@@ -193,14 +192,9 @@ $borderMedium: 0.25rem;
     }
 
     /****** keyboard focus styles *******/
-    /*
-     * .key-navigation-highlight and .buttonlist-item-focus:focus styles
-     * could be removed as soon as Safari properly supports :focus-visible
-     */
     .buttonlist-item {
         &.key-navigation-highlight .buttonlist-btn::before,
-        .buttonlist-btn.buttonlist-item-focus:focus::before,
-        .buttonlist-btn:focus-visible::before {
+        .buttonlist-btn.buttonlist-btn-focus:focus::before {
             content: '';
             display: block;
             position: absolute;
@@ -216,22 +210,20 @@ $borderMedium: 0.25rem;
         }
 
         &.key-navigation-highlight.buttonlist-item-active .buttonlist-btn .indicator,
-        &.buttonlist-item-active .buttonlist-btn.buttonlist-item-focus:focus .indicator,
+        &.buttonlist-item-active .buttonlist-btn.buttonlist-btn-focus:focus .indicator,
         &.buttonlist-item-active .buttonlist-btn:focus-visible .indicator {
             color: $uiReviewPanelPrimaryHighlight;
         }
 
         &.key-navigation-highlight.viewed .buttonlist-btn,
-        &.viewed .buttonlist-btn.buttonlist-item-focus:focus,
-        &.viewed .buttonlist-btn:focus-visible {
+        &.viewed .buttonlist-btn.buttonlist-btn-focus:focus {
             background-color: $uiReviewPanelBgDefault;
             color: $uiReviewPanelPrimaryHighlight;
             border-color: $uiReviewPanelPrimaryHighlight;
         }
 
         &.key-navigation-highlight.answered .buttonlist-btn,
-        &.answered .buttonlist-btn.buttonlist-item-focus:focus,
-        &.answered .buttonlist-btn:focus-visible {
+        &.answered .buttonlist-btn.buttonlist-btn-focus:focus {
             background-color: $uiReviewPanelPrimaryHighlight;
             color: $uiReviewPanelTextInverted;
             border-color: $uiReviewPanelPrimaryHighlight;

--- a/src/itemButtonList/scss/item-button-list.scss
+++ b/src/itemButtonList/scss/item-button-list.scss
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 Open Assessment Technologies SA ;
+ * Copyright (c) 2022 Open Assessment Technologies SA ;
  */
 @import "inc/bootstrap";
 

--- a/src/itemButtonList/scss/item-button-list.scss
+++ b/src/itemButtonList/scss/item-button-list.scss
@@ -41,8 +41,8 @@ $borderMedium: 0.25rem;
         justify-content: center; /* aligning left - cut focusing board for keyboard interacting */
         align-items: center;
         /* reset parent styles */
-        padding: 0 !important; /* instead of rewriting 6-classes selector on focusing */
-        border: none !important; /* instead of rewriting 6-classes selector on focusing */
+        padding: 0;
+        border: none;
     }
 
     .buttonlist-btn {

--- a/src/itemButtonList/tpl/itemButtonList.tpl
+++ b/src/itemButtonList/tpl/itemButtonList.tpl
@@ -1,0 +1,23 @@
+<ol class="buttonlist-items">
+    {{#each items}}
+    <li class="buttonlist-item {{type}} {{#if scoreType}}{{scoreType}}{{/if}} {{#if ../disabled}}disabled{{/if}}" data-id="{{id}}">
+        <button class="buttonlist-btn"
+                role="link"
+                aria-label="{{ariaLabel}}"
+                {{#if ../disabled}}aria-disabled="true"{{/if}}
+                data-id="{{id}}">
+            <span class="icon-indicator indicator" aria-hidden="true"></span>
+            {{#if scoreType}}
+                <span class="buttonlist-score-badge">
+                    <span class="buttonlist-score-icon icon-{{scoreType}}" aria-hidden="true"></span>
+                </span>
+            {{/if}}
+            {{#if icon}}
+                <span class="buttonlist-icon icon-{{icon}}" aria-hidden="true"></span>
+            {{else}}
+                <span class="buttonlist-label" aria-hidden="true">{{label}}</span>
+            {{/if}}
+        </button>
+    </li>
+    {{/each}}
+</ol>

--- a/src/itemButtonList/tpl/itemButtonList.tpl
+++ b/src/itemButtonList/tpl/itemButtonList.tpl
@@ -1,6 +1,6 @@
 <ol class="buttonlist-items">
     {{#each items}}
-    <li class="buttonlist-item {{type}} {{#if scoreType}}{{scoreType}}{{/if}} {{#if ../disabled}}disabled{{/if}}" data-id="{{id}}">
+    <li class="buttonlist-item {{status}} {{#if scoreType}}{{scoreType}}{{/if}} {{#if ../disabled}}disabled{{/if}}" data-id="{{id}}">
         <button class="buttonlist-btn"
                 role="link"
                 aria-label="{{ariaLabel}}"
@@ -15,7 +15,7 @@
             {{#if icon}}
                 <span class="buttonlist-icon icon-{{icon}}" aria-hidden="true"></span>
             {{else}}
-                <span class="buttonlist-label" aria-hidden="true">{{label}}</span>
+                <span class="buttonlist-label" aria-hidden="true">{{numericLabel}}</span>
             {{/if}}
         </button>
     </li>

--- a/test/itemButtonList/click.tpl
+++ b/test/itemButtonList/click.tpl
@@ -1,0 +1,4 @@
+<div class="click">
+    <span class="text">Button <strong>{{id}}</strong> clicked!</span>
+    <span class="number">#{{occurrence}}</span>
+</div>

--- a/test/itemButtonList/click.tpl
+++ b/test/itemButtonList/click.tpl
@@ -1,4 +1,0 @@
-<div class="click">
-    <span class="text">Button <strong>{{id}}</strong> clicked!</span>
-    <span class="number">#{{occurrence}}</span>
-</div>

--- a/test/itemButtonList/test.html
+++ b/test/itemButtonList/test.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Ui Test - ItemButtonList Component</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/itemButtonList/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+        <style>
+            #qunit {
+                position: relative !important;
+            }
+            #visual-test {
+                background: #EEE;
+                margin: 10px;
+                padding: 10px;
+            }
+            .test {
+                border: 1px solid rgba(0,0,0,0.3);
+                width: 300px;
+                overflow: hidden;
+                resize: both;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="visual-test">
+            <h2>Visual test</h2>
+            <div class="test"></div>
+        </div>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="fixture-render"></div>
+        </div>
+    </body>
+</html>

--- a/test/itemButtonList/test.js
+++ b/test/itemButtonList/test.js
@@ -77,36 +77,36 @@ define([
     const basicItems = [
         {
             "id": "item-1",
-            "label": 1,
+            "numericLabel": "1",
             "position": 0,
-            "type": "answered",
+            "status": "answered",
             "icon": null,
             "ariaLabel": "Question 1",
             "scoreType": "correct"
         },
         {
             "id": "item-2",
-            "label": 2,
+            "numericLabel": "2",
             "position": 1,
-            "type": "answered",
+            "status": "answered",
             "icon": null,
             "ariaLabel": "Question 2",
             "scoreType": "incorrect"
         },
         {
             "id": "item-4",
-            "label": 4,
+            "numericLabel": "4",
             "position": 3,
-            "type": "viewed",
+            "status": "viewed",
             "icon": "info",
             "ariaLabel": "Question 4",
             "scoreType": null
         },
         {
             "id": "item-5",
-            "label": 5,
+            "numericLabel": "5",
             "position": 4,
-            "type": "unseen",
+            "status": "unseen",
             "icon": null,
             "ariaLabel": "Question 5",
             "scoreType": null
@@ -169,7 +169,7 @@ define([
         // Check label
         assert.equal(
             instance.getElement().find('button')[0].innerText,
-            basicItems[0].label,
+            basicItems[0].numericLabel,
             'The itemButtonList instance has rendered the button with the correct label'
         );
         // Check ariaLabel
@@ -295,56 +295,58 @@ define([
         const items = [
             {
                 "id": "item-1",
-                "label": 1,
+                "numericLabel": "1",
                 "position": 0,
-                "type": "answered",
+                "status": "answered",
                 "icon": null,
                 "ariaLabel": "Question 1",
                 "scoreType": "correct"
             },
             {
                 "id": "item-2",
-                "label": 2,
+                "numericLabel": "2",
                 "position": 1,
-                "type": "viewed",
+                "status": "viewed",
                 "icon": null,
                 "ariaLabel": "Question 2",
                 "scoreType": null
             },
             {
                 "id": "item-3",
-                "label": 3,
+                "numericLabel": "3",
                 "position": 2,
-                "type": "answered",
+                "status": "answered",
                 "icon": null,
                 "ariaLabel": "Question 3",
                 "scoreType": "incorrect"
             },
             {
                 "id": "item-4",
-                "label": 4,
+                "numericLabel": "",
                 "position": 3,
-                "type": "viewed",
+                "status": "viewed",
+                "informational": true,
                 "icon": "info",
-                "ariaLabel": "Question 4",
+                "ariaLabel": "Informational item",
                 "scoreType": null
             },
             {
                 "id": "item-5",
-                "label": 5,
+                "numericLabel": "4",
                 "position": 4,
-                "type": "unseen",
+                "status": "unseen",
                 "icon": null,
-                "ariaLabel": "Question 5",
+                "ariaLabel": "Question 4",
                 "scoreType": null
             },
             {
                 "id": "item-6",
-                "label": 6,
+                "numericLabel": "",
                 "position": 5,
-                "type": "unseen",
+                "status": "unseen",
+                "informational": true,
                 "icon": "info",
-                "ariaLabel": "Question 6",
+                "ariaLabel": "Informational item",
                 "scoreType": null
             }
         ];

--- a/test/itemButtonList/test.js
+++ b/test/itemButtonList/test.js
@@ -368,6 +368,7 @@ define([
             .on('click', function(event) {
                 /* eslint-disable-next-line no-alert */
                 alert(`clicked ${JSON.stringify(event)}`);
+                this.setActiveItem(event.id);
             })
             .render($container);
     });

--- a/test/itemButtonList/test.js
+++ b/test/itemButtonList/test.js
@@ -1,0 +1,374 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+define([
+    'jquery',
+    'lodash',
+    'ui/itemButtonList'
+], function($, _, itemButtonList) {
+    'use strict';
+
+    QUnit.module('ItemButtonList Factory');
+
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
+
+        assert.equal(typeof itemButtonList, 'function', 'The itemButtonList module exposes a function');
+        assert.equal(typeof itemButtonList(), 'object', 'The itemButtonList factory produces an object');
+        assert.notStrictEqual(itemButtonList(), itemButtonList(), 'The itemButtonList factory provides a different object on each call');
+    });
+
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'setSize'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'},
+        {title: 'getConfig'}
+    ]).test('inherited API ', function (data, assert) {
+        const instance = itemButtonList();
+        assert.expect(1);
+        assert.equal(
+            typeof instance[data.title],
+            'function',
+            `The itemButtonList instance exposes a "${data.title}" function`
+        );
+    });
+
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'spread'}
+    ]).test('event API ', function (data, assert) {
+        const instance = itemButtonList();
+        assert.expect(1);
+        assert.equal(
+            typeof instance[data.title],
+            'function',
+            `The itemButtonList instance exposes a "${data.title}" function`
+        );
+    });
+
+    const basicItems = [
+        {
+            "id": "item-1",
+            "label": 1,
+            "position": 0,
+            "type": "answered",
+            "icon": null,
+            "ariaLabel": "Question 1",
+            "scoreType": "correct"
+        },
+        {
+            "id": "item-2",
+            "label": 2,
+            "position": 1,
+            "type": "answered",
+            "icon": null,
+            "ariaLabel": "Question 2",
+            "scoreType": "incorrect"
+        },
+        {
+            "id": "item-4",
+            "label": 4,
+            "position": 3,
+            "type": "viewed",
+            "icon": "info",
+            "ariaLabel": "Question 4",
+            "scoreType": null
+        },
+        {
+            "id": "item-5",
+            "label": 5,
+            "position": 4,
+            "type": "unseen",
+            "icon": null,
+            "ariaLabel": "Question 5",
+            "scoreType": null
+        }
+    ];
+
+    QUnit.module('ItemButtonList Lifecycle');
+
+    QUnit.test('render', function(assert) {
+        const $container = $('#fixture-render');
+        const config = {
+            renderTo: $container,
+            replace: true,
+            items: basicItems
+        };
+        let instance;
+
+        assert.expect(16);
+
+        // Create an instance with autorendering
+        instance = itemButtonList(config);
+
+        // Check the rendered header
+        assert.equal(instance.is('rendered'), true, 'The itemButtonList instance must be rendered');
+        assert.equal(
+            typeof instance.getElement(),
+            'object',
+            'The itemButtonList instance returns the rendered content as an object'
+        );
+        assert.equal(instance.getElement().length, 1, 'The itemButtonList instance returns the rendered content');
+
+        assert.ok(instance.getElement().is('ol'), 'The itemButtonList instance has rendered the list');
+
+        // Check lis
+        assert.equal(instance.getElement().find('li').length, basicItems.length, 'The itemButtonList instance has rendered the list items');
+        // Check li answered/viewed/unseen
+        assert.ok(
+            instance.getElement().find('li').eq(0).hasClass('answered'),
+            'The itemButtonList instance has rendered the button with the correct label'
+        );
+        assert.ok(
+            instance.getElement().find('li').eq(2).hasClass('viewed'),
+            'The itemButtonList instance has rendered the button with the correct label'
+        );
+        assert.ok(
+            instance.getElement().find('li').eq(3).hasClass('unseen'),
+            'The itemButtonList instance has rendered the button with the correct label'
+        );
+        // Check li correct/incorrect
+        assert.ok(
+            instance.getElement().find('li').eq(0).hasClass('correct'),
+            'The itemButtonList instance has rendered the button with the correct label'
+        );
+        assert.ok(
+            instance.getElement().find('li').eq(1).hasClass('incorrect'),
+            'The itemButtonList instance has rendered the button with the correct label'
+        );
+
+        // Check buttons
+        // Check label
+        assert.equal(
+            instance.getElement().find('button')[0].innerText,
+            basicItems[0].label,
+            'The itemButtonList instance has rendered the button with the correct label'
+        );
+        // Check ariaLabel
+        assert.equal(
+            instance.getElement().find('button')[0].ariaLabel,
+            basicItems[0].ariaLabel,
+            'The itemButtonList instance has rendered the button with the correct ariaLabel'
+        );
+        // Check data-id
+        assert.equal(
+            instance.getElement().find('button')[0].dataset.id,
+            basicItems[0].id,
+            'The itemButtonList instance has rendered the button with the correct data-id'
+        );
+        // Check informational icon
+        assert.equal(
+            instance.getElement().find('button .buttonlist-icon.icon-info').length,
+            basicItems.filter(item => item.icon === 'info').length,
+            'The itemButtonList instance has rendered the correct number of informational icon buttons'
+        );
+
+        instance.destroy();
+
+        assert.equal($container.children().length, 0, 'The container is now empty');
+        assert.equal(instance.getElement(), null, 'The itemButtonList instance has removed its rendered content');
+    });
+
+    QUnit.test('enable/disable', function(assert) {
+        const instance = itemButtonList({
+            items: [basicItems[0]]
+        }).render();
+        const $component = instance.getElement();
+
+        assert.expect(8);
+
+        assert.equal(instance.is('rendered'), true, 'The itemButtonList instance must be rendered');
+        assert.equal($component.length, 1, 'The itemButtonList instance returns the rendered content');
+
+        assert.equal(instance.is('disabled'), false, 'The itemButtonList instance is enabled');
+        assert.notOk(
+            $component.hasClass('disabled'),
+            'The itemButtonList instance does not have the disabled class'
+        );
+
+        instance.disable();
+
+        assert.equal(instance.is('disabled'), true, 'The itemButtonList instance is disabled');
+        assert.equal($component.hasClass('disabled'), true, 'The itemButtonList instance has the disabled class');
+
+        instance.enable();
+
+        assert.equal(instance.is('disabled'), false, 'The itemButtonList instance is enabled');
+        assert.notOk(
+            $component.hasClass('disabled'),
+            'The itemButtonList instance does not have the disabled class'
+        );
+
+        instance.destroy();
+    });
+
+    QUnit.test('events', function(assert) {
+        const ready = assert.async();
+        const config = {
+            items: basicItems
+        };
+        const instance = itemButtonList(config);
+
+        assert.expect(4);
+
+        Promise.resolve()
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('ready', function() {
+                            assert.ok(true, 'The itemButtonList instance triggers event when it is ready');
+                            resolve();
+                        })
+                        .render();
+                });
+            })
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('click', function({ id }) {
+                            assert.ok(true, 'The itemButtonList instance call the right action when the button is clicked');
+                            assert.equal(
+                                id,
+                                'item-1',
+                                'The itemButtonList instance provides the button identifier when the button is clicked'
+                            );
+                            resolve();
+                        })
+                        .getElement().find('[data-id="item-1"]').click();
+                });
+            })
+            .then(function() {
+                return new Promise(function(resolve) {
+                    instance
+                        .on('destroy', function() {
+                            assert.ok(true, 'The itemButtonList instance triggers event when it is destroyed');
+                            resolve();
+                        })
+                        .destroy();
+                });
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The operation should not fail!');
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(function() {
+                ready();
+            });
+    });
+
+    QUnit.module('ItemButtonList Visual Test');
+
+    QUnit.test('various buttons', function(assert) {
+        assert.expect(1);
+
+        const items = [
+            {
+                "id": "item-1",
+                "label": 1,
+                "position": 0,
+                "type": "answered",
+                "icon": null,
+                "ariaLabel": "Question 1",
+                "scoreType": "correct"
+            },
+            {
+                "id": "item-2",
+                "label": 2,
+                "position": 1,
+                "type": "viewed",
+                "icon": null,
+                "ariaLabel": "Question 2",
+                "scoreType": null
+            },
+            {
+                "id": "item-3",
+                "label": 3,
+                "position": 2,
+                "type": "answered",
+                "icon": null,
+                "ariaLabel": "Question 3",
+                "scoreType": "incorrect"
+            },
+            {
+                "id": "item-4",
+                "label": 4,
+                "position": 3,
+                "type": "viewed",
+                "icon": "info",
+                "ariaLabel": "Question 4",
+                "scoreType": null
+            },
+            {
+                "id": "item-5",
+                "label": 5,
+                "position": 4,
+                "type": "unseen",
+                "icon": null,
+                "ariaLabel": "Question 5",
+                "scoreType": null
+            },
+            {
+                "id": "item-6",
+                "label": 6,
+                "position": 5,
+                "type": "unseen",
+                "icon": "info",
+                "ariaLabel": "Question 6",
+                "scoreType": null
+            }
+        ];
+
+        const $container = $('#visual-test .test');
+        $container.prepend(`<ol>
+            <li>Answered Correct</li>
+            <li>Viewed</li>
+            <li>Answered Incorrect</li>
+            <li>Viewed Informational (current)</li>
+            <li>Unseen</li>
+            <li>Unseen Informational</li>
+        </ol>`);
+
+        itemButtonList({ items })
+            .on('render', function() {
+                assert.ok(true, 'ItemButtonList is rendered');
+
+                this.setActiveItem(items[3].id);
+            })
+            .on('click', function(event) {
+                /* eslint-disable-next-line no-alert */
+                alert(`clicked ${JSON.stringify(event)}`);
+            })
+            .render($container);
+    });
+});

--- a/test/itemButtonList/test.js
+++ b/test/itemButtonList/test.js
@@ -174,7 +174,7 @@ define([
         );
         // Check ariaLabel
         assert.equal(
-            instance.getElement().find('button')[0].ariaLabel,
+            instance.getElement().find('button')[0].getAttribute('aria-label'),
             basicItems[0].ariaLabel,
             'The itemButtonList instance has rendered the button with the correct ariaLabel'
         );


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-3180

Part of:

A component has been extracted from the new LTI Review Panel, so it can be re-used later in the Test Review Panel.
It's called `itemButtonList` and represents the ordered list of items in a test section - analogous to the `StepProgress` NG component.

![Screenshot 2022-01-07 at 15 20 31](https://user-images.githubusercontent.com/43652944/148557856-b1906f6d-6023-4dd0-a0cc-42cb4dec49ab.png)

Its only API is transmitting button clicks and allowing its `activeItem` to be set.

TODO:
- [x] investigate & enable commented tabfocus / focus styles implementation

To test:
- `npm run test`
- in the context of linked PR