### PR TITLE
Update raphael to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4266,6 +4266,12 @@
             "from": "git+https://github.com/adobe-webplatform/eve.git#eef80ed",
             "dev": true
         },
+        "eve-raphael": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+            "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA=",
+            "dev": true
+        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -7026,19 +7032,12 @@
             "dev": true
         },
         "raphael": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
-            "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
-            },
-            "dependencies": {
-                "eve": {
-                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
-                    "dev": true
-                }
+                "eve-raphael": "0.5.0"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "postcss-scss": "^2.0.0",
         "promise-limit": "^2.7.0",
         "qunit": "^2.17.2",
-        "raphael": "2.2.0",
+        "raphael": "2.3.0",
         "require-css": "^0.1.10",
         "requirejs-plugins": "^1.0.2",
         "rollup": "^1.12.1",


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3287

 - update rahpael to 2.3.0 in order to get rid of the subdependency to `eve` using `git://`