### PR TITLE
Fix/tr 3390 remove logarithm translation from calculator

### DIFF
--- a/src/maths/calculator/core/labels.js
+++ b/src/maths/calculator/core/labels.js
@@ -98,8 +98,8 @@ export default {
     ASINH: __('sinh') + '<sup>\u207B1</sup>',
     ACOSH: __('cosh') + '<sup>\u207B1</sup>',
     ATANH: __('tanh') + '<sup>\u207B1</sup>',
-    LN: __('ln'),
-    LOG: __('log') + '<sub>10</sub>',
+    LN: 'ln',
+    LOG: 'log <sub>10</sub>',
     ABS: __('abs'),
     RAND: __('random'),
 

--- a/src/maths/calculator/core/labels.js
+++ b/src/maths/calculator/core/labels.js
@@ -99,7 +99,7 @@ export default {
     ACOSH: __('cosh') + '<sup>\u207B1</sup>',
     ATANH: __('tanh') + '<sup>\u207B1</sup>',
     LN: 'ln',
-    LOG: 'log <sub>10</sub>',
+    LOG: 'log<sub>10</sub>',
     ABS: __('abs'),
     RAND: __('random'),
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3390

Remove `ln` and `log` translation of the calculator, because it should not be translated.