### PR TITLE
Fix/aut 1667/wrap text img positioned outside a block

### DIFF
--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -17,7 +17,7 @@
     overflow-x: hidden; 
 }
 
-.grid-row, .fixed-grid-row, .colrow, .widget-block {
+.grid-row, .fixed-grid-row, .colrow {
     @extend .clearfix;
     width: widthPerc(852, 840);
     &:before {
@@ -26,8 +26,6 @@
     &:after {
         @extend .clearfix:after;
     }
-    background-color: cornflowerblue;
-    //test
 }
 
 @for $i from 1 through 12 {

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -20,12 +20,6 @@
 .grid-row, .fixed-grid-row, .colrow {
     @extend .clearfix;
     width: widthPerc(852, 840);
-    &:before {
-        @extend .clearfix:before;
-    }
-    &:after {
-        @extend .clearfix:after;
-    }
 }
 
 @for $i from 1 through 12 {

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -26,7 +26,7 @@
     &:after {
         @extend .clearfix:after;
     }
-    background: cornflowerblue;
+    background-color: cornflowerblue;
     //test
 }
 

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -17,9 +17,17 @@
     overflow-x: hidden; 
 }
 
-.grid-row, .fixed-grid-row {
+.grid-row, .fixed-grid-row, .colrow, .widget-block {
     @extend .clearfix;
     width: widthPerc(852, 840);
+    &:before {
+        @extend .clearfix:before;
+    }
+    &:after {
+        @extend .clearfix:after;
+    }
+    background: cornflowerblue;
+    //test
 }
 
 @for $i from 1 through 12 {


### PR DESCRIPTION
**Related to Related to** 
 https://oat-sa.atlassian.net/browse/AUT-1667 
 https://github.com/oat-sa/extension-tao-itemqti/pull/2003
https://github.com/oat-sa/tao-core/pull/3353
https://github.com/oat-sa/tao-deliver-fe/pull/337


**Wrap text around image** - image is positioned **outside of A-block**
Authoring image outside of canva when wrap text around image is enabled.
Delivery (solar and terre) not displaying as authored when  wrap text around image and multi column are enabled.

**Config** and **steps** to follow as explained [here:](https://github.com/oat-sa/extension-tao-itemqti/pull/2003)

**ACTUAL RESULT:**
in item authoring and shared stimulus authoring, image overflows outside the container when text wrap is used.
In New UI and Terre delivery view alignment is not correct.

**EXPECTED RESULT:**
item and shared stimuluss authroing image is within the container.
Items are viewed with alignement as authored in terre and solar delivery