### PR TITLE
Fix/ADF-245: Advanced search section whitelist

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -73,6 +73,7 @@ export default function searchModalFactory(config) {
 
     /**
      * Creates search modal, inits template selectors, inits search store, and once is created triggers initial search
+     * rootClassUri is sent to advancedSearch factory for disabling in whitelisted sections
      */
     function renderModal() {
         const promises = [];
@@ -80,7 +81,8 @@ export default function searchModalFactory(config) {
         initUiSelectors();
         advancedSearch = advancedSearchFactory({
             renderTo: $('.filters-container', $container),
-            advancedCriteria: instance.config.criterias.advancedCriteria
+            advancedCriteria: instance.config.criterias.advancedCriteria,
+            rootClassUri: rootClassUri
         });
         promises.push(initClassFilter());
         promises.push(initSearchStore());

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -161,7 +161,7 @@ export default function advancedSearchFactory(config) {
         const route = urlUtil.route('status', 'AdvancedSearch', 'tao');
         return request(route)
             .then(function (response) {
-                if (!response.enabled || context.shownStructure === 'results') {
+                if (!response.enabled || response.whitelist.includes(context.shownStructure)) {
                     isAdvancedSearchStatusEnabled = false;
                     return;
                 }

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -19,7 +19,6 @@
 import $ from 'jquery';
 import _ from 'lodash';
 import __ from 'i18n';
-import context from 'context';
 import advancedSearchTpl from 'ui/searchModal/tpl/advanced-search';
 import textCriterionTpl from 'ui/searchModal/tpl/text-criterion';
 import invalidCriteriaWarningTpl from 'ui/searchModal/tpl/invalid-criteria-warning';
@@ -39,6 +38,7 @@ import request from 'core/dataProvider/request';
  * @param {object} config
  * @param {object} config.renderTo - DOM element where component will be rendered to
  * @param {string} config.advancedCriteria - advanced criteria to be set on component creation
+ * @param {string} config.rootClassUri - rootClassUri to check for whitelist sections
  * @returns {advancedSearch}
  */
 export default function advancedSearchFactory(config) {
@@ -161,7 +161,7 @@ export default function advancedSearchFactory(config) {
         const route = urlUtil.route('status', 'AdvancedSearch', 'tao');
         return request(route)
             .then(function (response) {
-                if (!response.enabled || response.whitelist.includes(context.shownStructure)) {
+                if (!response.enabled || response.whitelist.includes(config.rootClassUri)) {
                     isAdvancedSearchStatusEnabled = false;
                     return;
                 }


### PR DESCRIPTION
**Associated Jira issue:** [ADF-245](https://oat-sa.atlassian.net/browse/ADF-245)

## Backend changes
We'll be providing to FE a list of sections that should not use Advanced Search but Generis search instead.

`results` is always included in the section _whitelist_, and  `taoBooklet_main` is included in case the extension is enabled; additional sections can be provided via an environment variable.

## Frontend changes
isAdvancedSearchStatusEnabled will be set to false whenever current section is present in new whitelist sent by BE so it can use Generis instead