### PR TITLE
Backport/TR-3442/Safari cannot play media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -78,6 +78,7 @@ const defaults = {
         maxPlays: 0,
         replayTimeout: 0,
         stalledTimeout: 2000,
+        stalledUpdate: 5,
         canPause: true,
         canSeek: true,
         loop: false,
@@ -202,6 +203,7 @@ const isResponsiveSize = sizeProps => {
  * @param {Number} [config.maxPlays] - Sets a few number of plays (default: infinite)
  * @param {Number} [config.replayTimeout] - disable the possibility to replay a media after this timeout, in seconds (default: 0)
  * @param {Number} [config.stalledTimeout] - delay before considering stalled playback (default: 2000)
+ * @param {Number} [config.stalledUpdate] - the number of updates before considering stalled playback once the player declared a stalled event (default: 5)
  * @param {Number} [config.volume] - Sets the sound volume (default: 80)
  * @param {Number} [config.width] - Sets the width of the player (default: depends on media type)
  * @param {Number} [config.height] - Sets the height of the player (default: depends on media type)
@@ -1428,7 +1430,7 @@ function mediaplayerFactory(config) {
          * @private
          */
         _onStalled() {
-            this.stalledTimeUpdateCount = 0;
+            this.stalledUpdateCountdown = this.config.stalledUpdate;
             this.stalledTimer = window.setTimeout(() => {
                 const position = this.getPosition();
                 if (position) {
@@ -1445,11 +1447,11 @@ function mediaplayerFactory(config) {
          */
         _onTimeUpdate() {
             if (this.stalledTimer) {
-                if (this.stalledTimeUpdateCount === 5) {
+                if (this.stalledUpdateCountdown <= 0) {
                     window.clearTimeout(this.stalledTimer);
                     this.stalledTimer = null;
                 } else {
-                    this.stalledTimeUpdateCount++;
+                    this.stalledUpdateCountdown--;
                 }
             }
 

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -1368,10 +1368,11 @@ function mediaplayerFactory(config) {
             this._playingState(false, true);
             this._updatePosition(0);
 
-            // disable GUI when the play limit is reached
+            // disable when the play limit is reached
             if (this._playLimitReached()) {
-                this._disableGUI();
-
+                if (!this.is('disabled')) {
+                    this.disable();
+                }
                 /**
                  * Triggers a play limit reached event
                  * @event mediaplayer#limitreached
@@ -1435,19 +1436,9 @@ function mediaplayerFactory(config) {
             this.timerId = requestAnimationFrame(this._replayTimeout.bind(this));
 
             if (elapsedSeconds >= parseInt(this.config.replayTimeout, 10)) {
-                this._disableGUI();
                 this.disable();
                 cancelAnimationFrame(this.timerId);
             }
-        },
-
-        /**
-         * Disable the player GUI
-         * @private
-         */
-        _disableGUI() {
-            this._setState('ready', false);
-            this._setState('canplay', false);
         },
 
         /**

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -189,9 +189,14 @@ const isResponsiveSize = sizeProps => {
 /**
  * Builds a media player instance
  * @param {Object} config
- * @param {String} config.type - The type of media to play
- * @param {String|Array} config.url - The URL to the media
- * @param {String} [config.mimeType] - The MIME type of the media
+ * @param {String} config.type - The type of media to play, say `audio`, `video`, or `youtube`. The default is `video`.
+ * It might also contain the MIME type of the media as a shorthand.
+ * @param {String|Array} [config.url] - The URL to the media. If several media are proposed as alternatives,
+ * please look at the `sources` option instead.
+ * @param {String} [config.mimeType] - The MIME type of the media. If omitted, the player will try to extract it
+ * from the `type` property, otherwise it will request the server to get the content-type.
+ * @param {Array} [config.sources] - A list of URL if several media can be proposed. Each entry may be either a
+ * string (single URL), or an object containing both the URL and the MIME type ({src: string, type: string}).
  * @param {String|jQuery|HTMLElement} [config.renderTo] - An optional container in which renders the player
  * @param {Boolean} [config.canSeek] - The player allows to reach an arbitrary position within the media using the duration bar
  * @param {Boolean} [config.loop] - The media will be played continuously

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -1607,11 +1607,8 @@ function mediaplayerFactory(config) {
          * @private
          */
         execute(command, ...args) {
-            const ctx = this.player;
-            const method = ctx && ctx[command];
-
-            if (_.isFunction(method)) {
-                return method.apply(ctx, args);
+            if (this.player && 'function' === typeof this.player[command]) {
+                return this.player[command](...args);
             }
         }
     };

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -77,8 +77,6 @@ const defaults = {
         startMuted: false,
         maxPlays: 0,
         replayTimeout: 0,
-        stalledTimeout: 2000,
-        stalledUpdate: 5,
         canPause: true,
         canSeek: true,
         loop: false,
@@ -202,8 +200,6 @@ const isResponsiveSize = sizeProps => {
  * @param {Number} [config.autoStartAt] - The time position at which the player should start
  * @param {Number} [config.maxPlays] - Sets a few number of plays (default: infinite)
  * @param {Number} [config.replayTimeout] - disable the possibility to replay a media after this timeout, in seconds (default: 0)
- * @param {Number} [config.stalledTimeout] - delay before considering stalled playback (default: 2000)
- * @param {Number} [config.stalledUpdate] - the number of updates before considering stalled playback once the player declared a stalled event (default: 5)
  * @param {Number} [config.volume] - Sets the sound volume (default: 80)
  * @param {Number} [config.width] - Sets the width of the player (default: depends on media type)
  * @param {Number} [config.height] - Sets the height of the player (default: depends on media type)
@@ -1430,15 +1426,12 @@ function mediaplayerFactory(config) {
          * @private
          */
         _onStalled() {
-            this.stalledUpdateCountdown = this.config.stalledUpdate;
-            this.stalledTimer = window.setTimeout(() => {
-                const position = this.getPosition();
-                if (position) {
-                    this.positionBeforeStalled = position;
-                }
-                this._setState('stalled', true);
-                this._setState('ready', false);
-            }, this.config.stalledTimeout);
+            const position = this.getPosition();
+            if (position) {
+                this.positionBeforeStalled = position;
+            }
+            this._setState('stalled', true);
+            this._setState('ready', false);
         },
 
         /**
@@ -1446,15 +1439,6 @@ function mediaplayerFactory(config) {
          * @private
          */
         _onTimeUpdate() {
-            if (this.stalledTimer) {
-                if (this.stalledUpdateCountdown <= 0) {
-                    window.clearTimeout(this.stalledTimer);
-                    this.stalledTimer = null;
-                } else {
-                    this.stalledUpdateCountdown--;
-                }
-            }
-
             this._updatePosition(this.player.getPosition());
 
             /**

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -889,7 +889,11 @@ function mediaplayerFactory(config) {
             this._setState('error', error);
             this._setState('nogui', !support.canControl());
             this._setState('preview', this.config.preview);
-            this._setState('loading', true);
+            this._setState('loading', !error);
+            if (error) {
+                this._setState('ready', true);
+                this.trigger('ready');
+            }
         },
 
         /**

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -205,6 +205,7 @@ const isResponsiveSize = sizeProps => {
  * @param {Number} [config.height] - Sets the height of the player (default: depends on media type)
  * @param {Boolean} [config.preview] - Enables the media preview (load media metadata)
  * @param {Boolean} [config.debug] - Enables the debug mode
+ * @param {number} [config.config.stalledDetectionDelay] - The delay before considering a media is stalled
  * @event render - Event triggered when the player is rendering
  * @event error - Event triggered when the player throws an unrecoverable error
  * @event ready - Event triggered when the player is fully ready
@@ -857,7 +858,8 @@ function mediaplayerFactory(config) {
                         type: this.getType(),
                         sources: this.getSources(),
                         preview: this.config.preview,
-                        debug: this.config.debug
+                        debug: this.config.debug,
+                        stalledDetectionDelay: this.config.stalledDetectionDelay
                     };
                     this.player = playerFactory(this.$player, playerConfig)
                         .on('resize', (width, height) => {

--- a/src/mediaplayer.js
+++ b/src/mediaplayer.js
@@ -191,6 +191,7 @@ const isResponsiveSize = sizeProps => {
  * @param {Object} config
  * @param {String} config.type - The type of media to play
  * @param {String|Array} config.url - The URL to the media
+ * @param {String} [config.mimeType] - The MIME type of the media
  * @param {String|jQuery|HTMLElement} [config.renderTo] - An optional container in which renders the player
  * @param {Boolean} [config.canSeek] - The player allows to reach an arbitrary position within the media using the duration bar
  * @param {Boolean} [config.loop] - The media will be played continuously
@@ -232,6 +233,9 @@ function mediaplayerFactory(config) {
             // load the config set, discard null values in order to allow defaults to be set
             this.config = _.omit(config || {}, value => typeof value === 'undefined' || value === null);
             _.defaults(this.config, defaults.options);
+            if (!this.config.mimeType && 'string' === typeof this.config.type && this.config.type.indexOf('/') > 0) {
+                this.config.mimeType = this.config.type;
+            }
             this._setType(this.config.type || defaults.type);
 
             this._reset();
@@ -774,8 +778,12 @@ function mediaplayerFactory(config) {
                 source = _.clone(src);
             }
 
-            if (this.is('youtube') && !source.type) {
-                source.type = defaults.type;
+            if (!source.type) {
+                if (this.is('youtube')) {
+                    source.type = defaults.type;
+                } else if (this.config.mimeType) {
+                    source.type = this.config.mimeType;
+                }
             }
 
             if (!source.type) {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -212,10 +212,7 @@ export default function html5PlayerFactory($container, config = {}) {
                 });
             }
 
-            sources.forEach(source => {
-                const { src, type } = source;
-                this.addMedia(src, type);
-            });
+            sources.forEach(source => this.addMedia(source.src, source.type));
 
             return result;
         },
@@ -353,28 +350,28 @@ export default function html5PlayerFactory($container, config = {}) {
             return mute;
         },
 
-        addMedia(src, type) {
-            debug('api call', 'addMedia', src, type);
+        addMedia(src, srcType) {
+            debug('api call', 'addMedia', src, srcType);
 
             if (media) {
-                if (!support.checkSupport(media, type)) {
+                if (!support.checkSupport(media, srcType)) {
                     return false;
                 }
             }
 
             if (src && $media) {
-                $media.append(sourceTpl({ src, type }));
+                $media.append(sourceTpl({ src, type: srcType }));
                 return true;
             }
             return false;
         },
 
-        setMedia(src, type) {
-            debug('api call', 'setMedia', src, type);
+        setMedia(src, srcType) {
+            debug('api call', 'setMedia', src, srcType);
 
             if ($media) {
                 $media.empty();
-                return this.addMedia(src, type);
+                return this.addMedia(src, srcType);
             }
             return false;
         }

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -272,7 +272,9 @@ export default function html5PlayerFactory($container, config = {}) {
                 });
             }
 
-            sources.forEach(source => this.addMedia(source.src, source.type));
+            result =
+                result &&
+                sources.reduce((supported, source) => this.addMedia(source.src, source.type) || supported, false);
 
             return result;
         },

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -91,6 +91,7 @@ const playerEvents = ['end', 'error', 'pause', 'play', 'playing', 'ready', 'resi
  * @param {string} [config.type] - The type of player (video or audio) (default: video)
  * @param {boolean} [config.preview] - Enables the media preview (load media metadata)
  * @param {boolean} [config.debug] - Enables the debug mode
+ * @param {number} [config.config.stalledDetectionDelay] - The delay before considering a media is stalled
  * @returns {object} player
  */
 export default function html5PlayerFactory($container, config = {}) {
@@ -98,6 +99,8 @@ export default function html5PlayerFactory($container, config = {}) {
     const sources = config.sources || [];
     const updateObserver = reminderManagerFactory();
     const timeObserver = timeObserverFactory();
+
+    config.stalledDetectionDelay = config.stalledDetectionDelay || stalledDetectionDelay;
 
     let $media;
     let media;
@@ -302,10 +305,10 @@ export default function html5PlayerFactory($container, config = {}) {
             state.stallDetection = true;
             updateObserver.remind(() => {
                 // The last time update is a bit old, the media is most probably stalled now
-                if (updateObserver.elapsed >= stalledDetectionDelay) {
+                if (updateObserver.elapsed >= config.stalledDetectionDelay) {
                     this.stalled();
                 }
-            }, stalledDetectionDelay);
+            }, config.stalledDetectionDelay);
 
             updateObserver.start();
         },
@@ -331,7 +334,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     }
                     this.stalled();
                 }
-            }, stalledDetectionDelay);
+            }, config.stalledDetectionDelay);
         },
 
         stalled(position) {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -220,7 +220,8 @@ export default function html5PlayerFactory($container, config = {}) {
                 .on(`error${ns}`, () => {
                     if (
                         media.networkState === HTMLMediaElement.NETWORK_NO_SOURCE ||
-                        (media.error instanceof MediaError && media.error === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED)
+                        (media.error instanceof MediaError &&
+                            media.error.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED)
                     ) {
                         // No source means the player does not support the supplied media.
                         // Or it can be more explicit with the not supported error.
@@ -511,7 +512,7 @@ export default function html5PlayerFactory($container, config = {}) {
         stop() {
             debug('api call', 'stop');
 
-            if (media && state.playback) {
+            if (media && media.duration && state.playback && !state.stalled) {
                 media.currentTime = media.duration;
             }
         },

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -358,6 +358,17 @@ export default function html5PlayerFactory($container, config = {}) {
             state.stalled = false;
             state.stallDetection = false;
             if (media) {
+                // Special processing of video player to prevent visual glitch while reloading
+                if (media.tagName === 'VIDEO') {
+                    // Temporary fix the size of the media to prevent a shrink while reloading it
+                    $media.width($media.width());
+                    $media.height($media.height());
+                    $media.on('loadedmetadata.recover', () => {
+                        $media.off('loadedmetadata.recover');
+                        $media.css({ width: '', height: '' });
+                    });
+                }
+
                 media.load();
                 if (state.stalledAt) {
                     this.seek(state.stalledAt);

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -181,6 +181,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     this.trigger('end');
                 })
                 .on(`timeupdate${ns}`, () => {
+                    state.playing = true;
                     updateObserver.start();
                     timeObserver.update(media.currentTime);
                     this.trigger('timeupdate');
@@ -191,7 +192,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     }
 
                     if (!config.preview && media.networkState === HTMLMediaElement.NETWORK_IDLE) {
-                        this.trigger('ready');
+                        this.ready();
                     }
                 })
                 .on(`waiting${ns}`, () => {
@@ -214,15 +215,17 @@ export default function html5PlayerFactory($container, config = {}) {
                 })
                 .on('loadedmetadata', () => {
                     timeObserver.init(media.currentTime, media.duration);
+                    this.ready();
                 })
                 .on(`canplay${ns}`, () => {
                     if (!state.stalled) {
-                        state.stallDetection = false;
-                        this.trigger('ready');
+                        this.ready();
                     }
                 })
                 .on(`stalled${ns}`, () => {
-                    this.handleError(media.error);
+                    if (state.playing) {
+                        this.handleError(media.error);
+                    }
                 })
                 .on(`playing${ns}`, () => {
                     updateObserver.forget().start();
@@ -259,6 +262,15 @@ export default function html5PlayerFactory($container, config = {}) {
             }, stalledDetectionDelay);
 
             updateObserver.start();
+        },
+
+        ready() {
+            if (!state.ready) {
+                state.ready = true;
+                state.stalled = false;
+                state.stallDetection = false;
+                this.trigger('ready');
+            }
         },
 
         stalled(position) {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -237,7 +237,7 @@ export default function html5PlayerFactory($container, config = {}) {
                 .on(`stalled${ns}`, () => {
                     // The "stalled" event may be triggered once the player is halted after initialisation,
                     // but this does not mean the playback is actually stalled, hence we only take care of the playing state
-                    if (state.playing) {
+                    if (state.playing && !media.paused) {
                         this.handleError(media.error);
                     }
                 })

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -109,7 +109,8 @@ export default function html5PlayerFactory($container, config = {}) {
         return `[html5-${type}(networkState=${networkState},readyState=${readyState}):${action}]`;
     };
     // eslint-disable-next-line
-    const debug = (action, ...args) => config.debug && window.console.log(getDebugContext(action), ...args);
+    const debug = (action, ...args) =>
+        (config.debug === true || config.debug === action) && window.console.log(getDebugContext(action), ...args);
 
     return eventifier({
         init() {

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -502,7 +502,9 @@ export default function html5PlayerFactory($container, config = {}) {
             debug('api call', 'pause');
 
             if (media) {
-                state.pausedViaApi = true;
+                if (!media.paused) {
+                    state.pausedViaApi = true;
+                }
                 media.pause();
             }
         },

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -182,7 +182,7 @@ export default function html5PlayerFactory($container, config = {}) {
                 .on(`seeked${ns}`, () => {
                     // When the user try changing the current playing position while the network is down,
                     // the player will end the playback by moving straight to the end.
-                    if (state.seekedViaApi && state.seekAt !== media.currentTime) {
+                    if (state.seekedViaApi && Math.floor(state.seekAt) !== Math.floor(media.currentTime)) {
                         state.stallDetection = true;
                     }
                     state.seekedViaApi = false;

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -237,7 +237,6 @@ export default function html5PlayerFactory($container, config = {}) {
                 })
                 .on(`canplay${ns}`, () => {
                     if (!state.stalled) {
-                        state.stallDetection = false;
                         this.ready();
                     }
                 })

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -355,9 +355,11 @@ $controlsHeight: 36px;
                 cursor: pointer;
             }
 
-            .player:hover {
-                [data-control="play"] {
-                    display: inline-block;
+            &:not(.audio) {
+                .player:hover {
+                    [data-control="play"] {
+                        display: inline-block;
+                    }
                 }
             }
 
@@ -375,9 +377,11 @@ $controlsHeight: 36px;
                 cursor: pointer;
             }
 
-            .player:hover {
-                [data-control="pause"] {
-                    display: inline-block;
+            &:not(.audio) {
+                .player:hover {
+                    [data-control="pause"] {
+                        display: inline-block;
+                    }
                 }
             }
         }

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -424,6 +424,12 @@ $controlsHeight: 36px;
         }
     }
 
+    &.disabled:not(.stalled):not(.error) {
+        .controls {
+            visibility: visible;
+        }
+    }
+
     &.playing.canpause {
         .controls {
             [data-control="pause"] {

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -360,6 +360,7 @@ $controlsHeight: 36px;
                             width: calc(100% + 2px);
                             font-size: 20px;
                             line-height: 20px;
+                            min-height: 36px;
 
                             .icon {
                                 text-shadow: none;

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -343,6 +343,32 @@ $controlsHeight: 36px;
                 bottom: 0;
             }
         }
+
+        &.stalled {
+            .player {
+                .player-overlay {
+                    [data-control="reload"] {
+                        margin-top: 0;
+
+                        display: flex;
+                        flex-direction: row;
+                        justify-content: center;
+
+                        &.reload {
+                            width: 100%;
+                            font-size: 20px;
+                            line-height: 20px;
+
+                            .message {
+                                font-size: 10px;
+                                line-height: 15px;
+                                margin-top: 2px;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     &.ready {

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -348,21 +348,31 @@ $controlsHeight: 36px;
             .player {
                 .player-overlay {
                     [data-control="reload"] {
-                        margin-top: 0;
-
                         display: flex;
-                        flex-direction: row;
-                        justify-content: center;
-
+                        align-items: center;
+                        background-color: #000;
+                        margin: 0;
+                        flex-wrap: wrap;
+                        padding: 5px 5px 5px 50px;
+                        text-align: left;
+                        line-height: 2.3rem;
                         &.reload {
-                            width: 100%;
+                            width: calc(100% + 2px);
                             font-size: 20px;
                             line-height: 20px;
 
+                            .icon {
+                                text-shadow: none;
+                                position: absolute;
+                                left: 0;
+                                font-size: 2rem;
+                                font-weight: bold;
+                            }
+
                             .message {
-                                font-size: 10px;
-                                line-height: 15px;
-                                margin-top: 2px;
+                                text-shadow: none;
+                                font-size: 1.3rem;
+                                margin-right: 5px;
                             }
                         }
                     }

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -424,12 +424,6 @@ $controlsHeight: 36px;
         }
     }
 
-    &.disabled:not(.stalled):not(.error) {
-        .controls {
-            visibility: visible;
-        }
-    }
-
     &.playing.canpause {
         .controls {
             [data-control="pause"] {

--- a/src/mediaplayer/support.js
+++ b/src/mediaplayer/support.js
@@ -19,12 +19,14 @@
 /**
  * A Regex to detect Apple mobile browsers
  * @type {RegExp}
+ * @private
  */
 const reAppleMobiles = /ip(hone|od)/i;
 
 /**
  * A list of MIME types with codec declaration
  * @type {Object}
+ * @private
  */
 const supportedMimeTypes = {
     // video
@@ -39,6 +41,15 @@ const supportedMimeTypes = {
 };
 
 /**
+ * Checks support for a MIME type.
+ * @param {HTMLMediaElement} media The media element on which check support
+ * @param {String} mimeType A MIME type to check the support for
+ * @returns {string}
+ * @private
+ */
+const findSupport = (media, mimeType) => media.canPlayType(mimeType).replace(/no/, '');
+
+/**
  * Support detection
  * @type {Object}
  */
@@ -51,13 +62,15 @@ export default {
      * @private
      */
     checkSupport(media, mimeType) {
-        const support = !!media.canPlayType;
-
+        const support = media.canPlayType;
         if (support && mimeType) {
-            return !!media.canPlayType(supportedMimeTypes[mimeType] || mimeType).replace(/no/, '');
+            return !!(
+                (supportedMimeTypes[mimeType] && findSupport(media, supportedMimeTypes[mimeType])) ||
+                findSupport(media, mimeType)
+            );
         }
 
-        return support;
+        return !!support;
     },
 
     /**

--- a/src/mediaplayer/tpl/player.tpl
+++ b/src/mediaplayer/tpl/player.tpl
@@ -9,8 +9,7 @@
             </a>
             <a class="action reload" data-control="reload">
                 <div class="icon icon-reload" title="{{__ 'Reload'}}"></div>
-                <div class="message">{{__ 'You are encountering a prolonged connectivity loss.'}}</div>
-                <div class="message">{{__ 'Click to reload.'}}</div>
+                <div class="message">{{__ 'You are encountering a prolonged connectivity loss.'}}<br />{{__ 'Click to reload.'}}</div>
             </a>
         </div>
     </div>

--- a/src/mediaplayer/tpl/player.tpl
+++ b/src/mediaplayer/tpl/player.tpl
@@ -9,7 +9,7 @@
             </a>
             <a class="action reload" data-control="reload">
                 <div class="icon icon-reload" title="{{__ 'Reload'}}"></div>
-                <div class="message">{{__ 'You are encountering a prolonged connectivity loss.'}}<br />{{__ 'Click to reload.'}}</div>
+                <div class="message">{{__ 'You are encountering a prolonged connectivity loss.'}} {{__ 'Click to reload.'}}</div>
             </a>
         </div>
     </div>

--- a/src/mediaplayer/utils/reminder.js
+++ b/src/mediaplayer/utils/reminder.js
@@ -1,0 +1,184 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Creates a reminder manager.
+ *
+ * A reminder manager allows to register callback functions that will be called after a particular amount of time.
+ * The schedule can be created and cancelled at any time.
+ *
+ * @example
+ * // Create a reminder manager
+ * const manager = reminderManagerFactory();
+ *
+ * // Add a reminder that will be called after 2s (delay is given in milliseconds)
+ * manager.remind(() => console.log('Hello!'), 2000);
+ *
+ * // Start the schedule
+ * manager.start();
+ *
+ * // We can know how many time elapsed since the last schedule
+ * const elapsed = manager.elapsed;
+ *
+ * // The schedule can be cancelled
+ * if (needToCancel) {
+ *     manager.stop();
+ * }
+ *
+ * // The schedule should be cancelled
+ * console.log('schedule running:', manager.running)
+ *
+ * @returns {reminderManager}
+ */
+export default function reminderManagerFactory() {
+    // Keep track of the running state
+    let running = false;
+
+    // Timestamp of the last start
+    let last = 0;
+
+    // A list of reminders to callback
+    const reminders = new Map();
+
+    /**
+     * Cancels a schedule for a particular reminder.
+     * @param {object} state - A sate object containing the timeout handler for the reminder.
+     * @private
+     */
+    const stopReminder = state => {
+        if (state && state.timeout) {
+            clearTimeout(state.timeout);
+            state.timeout = null;
+        }
+    };
+
+    /**
+     * Cancel the schedule for all reminders.
+     * @private
+     */
+    const stopAllReminders = () => reminders.forEach(stopReminder);
+
+    /**
+     * Schedule all reminders.
+     * @private
+     */
+    const startAllReminders = () => {
+        reminders.forEach((state, reminder) => {
+            stopReminder(state);
+            state.timeout = setTimeout(reminder, state.delay);
+        });
+    };
+
+    /**
+     * Defines the API of a reminder manager.
+     *
+     * A reminder manager allows to register callback functions that will be called after a particular amount of time.
+     * The schedule can be created and cancelled at any time.
+     *
+     * @namespace reminderManager
+     */
+    return {
+        /**
+         * Tells whether or not the schedule is running.
+         * @type {boolean}
+         * @member running
+         * @memberOf reminderManager
+         */
+        get running() {
+            return running;
+        },
+
+        /**
+         * Gives the amount of time elapsed since the start of the schedule. It is given in milliseconds.
+         * If the schedule is not running, it will always be 0.
+         * @type {number}
+         * @member running
+         * @memberOf reminderManager
+         */
+        get elapsed() {
+            if (!running) {
+                return 0;
+            }
+            return performance.now() - last;
+        },
+
+        /**
+         * Schedules all reminders from now on.
+         *
+         * @returns {reminderManager}
+         * @function start
+         * @memberOf reminderManager
+         */
+        start() {
+            running = true;
+            last = performance.now();
+            startAllReminders();
+            return this;
+        },
+
+        /**
+         * Cancels all scheduled reminders.
+         *
+         * @returns {reminderManager}
+         * @function stop
+         * @memberOf reminderManager
+         */
+        stop() {
+            running = false;
+            stopAllReminders();
+            return this;
+        },
+
+        /**
+         * Adds a callback to be scheduled.
+         * It won't be scheduled until the schedule is restarted.
+         *
+         * @param {Function} cb - A function to call after the delay elapsed.
+         * @param {number} delay - The delay after what call back the reminder. It is given in milliseconds.
+         * @returns {reminderManager}
+         * @function remind
+         * @memberOf reminderManager
+         */
+        remind(cb, delay) {
+            if ('function' === typeof cb && delay) {
+                stopReminder(reminders.get(cb));
+                reminders.set(cb, { delay });
+            }
+            return this;
+        },
+
+        /**
+         * Removes a scheduled callback. If a schedule was running, it will be cancelled first.
+         *
+         * @param {Function} [cb] - The callback function to remove. If omitted, all reminders will be removed.
+         * @returns {reminderManager}
+         * @function forget
+         * @memberOf reminderManager
+         */
+        forget(cb) {
+            if ('undefined' !== typeof cb) {
+                stopReminder(reminders.get(cb));
+                reminders.delete(cb);
+            } else {
+                stopAllReminders();
+                reminders.clear();
+            }
+            return this;
+        }
+    };
+}

--- a/src/mediaplayer/utils/timeObserver.js
+++ b/src/mediaplayer/utils/timeObserver.js
@@ -118,7 +118,7 @@ export default function timeObserverFactory(interval = 1) {
         update(newPosition) {
             if (newPosition > seek && newPosition - position > interval) {
                 /**
-                 * Notifies an irregularity in in the time update
+                 * Notifies an irregularity in the time update
                  * @event irregularity
                  * @param {number} position - last regular position
                  * @param {number} newPosition - new irregular position

--- a/src/mediaplayer/utils/timeObserver.js
+++ b/src/mediaplayer/utils/timeObserver.js
@@ -120,8 +120,10 @@ export default function timeObserverFactory(interval = 1) {
                 /**
                  * Notifies an irregularity in in the time update
                  * @event irregularity
+                 * @param {number} position - last regular position
+                 * @param {number} newPosition - new irregular position
                  */
-                this.trigger('irregularity');
+                this.trigger('irregularity', position, newPosition);
             }
             position = newPosition;
             return this;

--- a/src/mediaplayer/utils/timeObserver.js
+++ b/src/mediaplayer/utils/timeObserver.js
@@ -1,0 +1,141 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import eventifier from 'core/eventifier';
+
+/**
+ * Creates a time observer.
+ *
+ * It observes the updates applied to a timeline, raising a flag when an irregularity occurs.
+ *
+ * It works as follow:
+ * - an initial state is defined (example: current: 0, duration: 100)
+ * - each time a position is forced (say the position is changed outside of the regular time update), the observer needs
+ *   to be notified.
+ * - each time the position is updated (say regular time update), the observer needs to be called.
+ * - if the difference between the last regular update and the last one is too high, an event is triggered
+ *
+ * @example
+ * // Create a time observer with an expected interval of 2 seconds
+ * const observer = timeObserverFactory(2);
+ *
+ * // Init the state
+ * observer.start(player.position, player.duration);
+ *
+ * // Update on a regular basis
+ * player.on('timeupdate', () => observer.update(player.position));
+ *
+ * // Notify any position change outside of the regular update
+ * player.on('seek', () => observer.seek(player.position));
+ *
+ * // Gets informed from any irregularity
+ * observer.on('irregularity', () => console.log('irregular jump in time');
+ *
+ * @param {number} interval - The typical interval expected between two updates. It is given in seconds.
+ * @returns {timeObserver}
+ */
+export default function timeObserverFactory(interval = 1) {
+    // Current time position
+    let position = 0;
+
+    // Total duration expected
+    let duration = 0;
+
+    // Last position forced
+    let seek = 0;
+
+    /**
+     * Defines the API of a time observer.
+     *
+     * It observes the updates applied to a timeline, raising a flag when an irregularity occurs.
+     *
+     * @namespace timeObserver
+     */
+    return eventifier({
+        /**
+         * Gets the current time position reported to the observer.
+         *
+         * @returns {number}
+         * @type {number}
+         * @member position
+         * @memberOf timeObserver
+         */
+        get position() {
+            return position;
+        },
+
+        /**
+         * Gets the total duration reported to the observer.
+         *
+         * @returns {number}
+         * @type {number}
+         * @member duration
+         * @memberOf timeObserver
+         */
+        get duration() {
+            return duration;
+        },
+
+        /**
+         * Initialises the time state.
+         *
+         * @param {number} initPosition - The initial time position
+         * @param {number} initDuration - The total duration expected
+         * @returns {timeObserver}
+         * @function init
+         * @memberOf timeObserver
+         */
+        init(initPosition, initDuration) {
+            position = seek = initPosition;
+            duration = initDuration;
+            return this;
+        },
+
+        /**
+         * Updates the time position. If the difference with the previous update is too high, an `irregularity` event
+         * will be emitted.
+         *
+         * @param {number} newPosition - The new time position
+         * @returns {timeObserver}
+         *
+         * @fires irregularity
+         */
+        update(newPosition) {
+            if (newPosition > seek && newPosition - position > interval) {
+                /**
+                 * Notifies an irregularity in in the time update
+                 * @event irregularity
+                 */
+                this.trigger('irregularity');
+            }
+            position = newPosition;
+            return this;
+        },
+
+        /**
+         * Notifies the observer about a change in the position outside of the regular update.
+         *
+         * @param {number} seekPosition
+         * @returns {timeObserver}
+         */
+        seek(seekPosition) {
+            position = seek = seekPosition;
+            return this;
+        }
+    });
+}

--- a/test/mediaplayer/mocks/playerMock.js
+++ b/test/mediaplayer/mocks/playerMock.js
@@ -118,6 +118,10 @@ define([
                 stalled = false;
             },
 
+            recover() {
+                this.play();
+            },
+
             getMedia() {
                 return media;
             },

--- a/test/mediaplayer/players/html5/test.js
+++ b/test/mediaplayer/players/html5/test.js
@@ -55,7 +55,7 @@ define([
     };
     const parseHTMLMock = parseHTMLMockFactory(parseHTMLFilter);
 
-    QUnit.module('players', {
+    QUnit.module('html5 player', {
         afterEach() {
             support.reset();
             UrlParser.reset();

--- a/test/mediaplayer/players/youtube/test.js
+++ b/test/mediaplayer/players/youtube/test.js
@@ -23,7 +23,7 @@ define([
 ], function ($, playerFactory, youtubeManagerFactory, support) {
     'use strict';
 
-    QUnit.module('players', {
+    QUnit.module('youtube player', {
         afterEach() {
             support.reset();
         }
@@ -144,11 +144,7 @@ define([
                     videoSrc1,
                     'The player has been set with the right video source'
                 );
-                assert.equal(
-                    $media.attr('data-video-id'),
-                    videoId1,
-                    'The player has been set with the right video id'
-                );
+                assert.equal($media.attr('data-video-id'), videoId1, 'The player has been set with the right video id');
                 assert.equal(
                     $media.attr('data-video-list'),
                     `${videoId2},${videoId3}`,
@@ -498,11 +494,7 @@ define([
             .on('ready', () => {
                 const $media = $container.find('.media');
                 assert.equal($media.length, 1, 'The player has been rendered');
-                assert.equal(
-                    $media.attr('data-video-id'),
-                    videoId1,
-                    'The player has been set with the right video id'
-                );
+                assert.equal($media.attr('data-video-id'), videoId1, 'The player has been set with the right video id');
                 assert.equal(
                     $media.attr('data-video-list'),
                     videoId2,
@@ -541,11 +533,7 @@ define([
             .on('ready', () => {
                 const $media = $container.find('.media');
                 assert.equal($media.length, 1, 'The player has been rendered');
-                assert.equal(
-                    $media.attr('data-video-id'),
-                    videoId2,
-                    'The player has been set with the right video id'
-                );
+                assert.equal($media.attr('data-video-id'), videoId2, 'The player has been set with the right video id');
                 assert.equal(
                     $media.attr('data-video-list'),
                     videoId3,

--- a/test/mediaplayer/support/test.js
+++ b/test/mediaplayer/support/test.js
@@ -38,7 +38,7 @@ define(['ui/mediaplayer/support', 'test/ui/mediaplayer/mocks/userAgentMock'], fu
                 return {
                     canPlayType(type) {
                         const supportList = {
-                            'video/webm; codecs="vp8, vorbis"': 'probably',
+                            'video/webm': 'probably',
                             'video/mp4; codecs="avc1.42E01E, mp4a.40.2"': 'maybe',
                             'video/mkv': 'no'
                         };

--- a/test/mediaplayer/test.js
+++ b/test/mediaplayer/test.js
@@ -100,10 +100,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
     QUnit.test('DOM [audio player]', assert => {
         const ready = assert.async();
         const url = 'samples/audio.mp3';
+        const type = 'audio/mp3';
         const $container = $('#qunit-fixture');
         const instance = mediaplayer({
-            url: url,
-            type: 'audio/mp3',
+            url,
+            type,
             renderTo: $container
         });
 
@@ -138,6 +139,7 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
             assert.equal($source.length, 1, 'The rendered content contains an audio source');
             assert.equal($source.attr('data-src'), url, 'Audio source targets the right URL');
+            assert.equal($source.attr('data-type'), type, 'Audio source has the right type');
 
             assert.equal($overlay.length, 1, 'The rendered content contains an overlay element');
             assert.equal(
@@ -216,10 +218,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
     QUnit.test('DOM [video player]', assert => {
         const ready = assert.async();
         const url = 'samples/video.mp4';
+        const type = 'video/mp4';
         const $container = $('#qunit-fixture');
         const instance = mediaplayer({
-            url: url,
-            type: 'video/mp4',
+            url,
+            type,
             renderTo: $container
         });
 
@@ -254,6 +257,7 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
             assert.equal($source.length, 1, 'The rendered content contains a video source');
             assert.equal($source.attr('data-src'), url, 'Video source targets the right URL');
+            assert.equal($source.attr('data-type'), type, 'Video source has the right type');
 
             assert.equal($overlay.length, 1, 'The rendered content contains an overlay element');
             assert.equal(
@@ -333,10 +337,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
         const ready = assert.async();
         const videoId = 'YJWSVUPSQqw';
         const url = `//www.youtube.com/watch?v=${videoId}`;
+        const type = 'video/youtube';
         const $container = $('#qunit-fixture');
         const instance = mediaplayer({
-            url: url,
-            type: 'video/youtube',
+            url,
+            type,
             renderTo: $container
         });
 
@@ -1076,6 +1081,66 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
         instance.destroy();
     });
+
+    QUnit.cases
+        .init([
+            {
+                title: 'request mime type',
+                config: {
+                    type: 'audio',
+                    url: 'samples/audio.mp3'
+                },
+                mime: 'audio/mpeg'
+            },
+            {
+                title: 'use type',
+                config: {
+                    type: 'audio/mp3',
+                    url: 'samples/audio.mp3'
+                },
+                mime: 'audio/mp3'
+            },
+            {
+                title: 'specify type',
+                config: {
+                    type: 'audio/mpeg',
+                    mimeType: 'audio/mp3',
+                    url: 'samples/audio.mp3'
+                },
+                mime: 'audio/mp3'
+            },
+            {
+                title: 'youtube type',
+                config: {
+                    type: 'video/youtube',
+                    mimeType: 'video/webm',
+                    url: 'YJWSVUPSQqw'
+                },
+                mime: 'video/mp4'
+            }
+        ])
+        .test('Type management ', (data, assert) => {
+            const ready = assert.async();
+            const instance = mediaplayer(
+                Object.assign(
+                    {
+                        renderTo: '#qunit-fixture'
+                    },
+                    data.config
+                )
+            )
+                .on('render', () => {
+                    const sources = instance.getSources();
+
+                    assert.equal(sources.length, 1, 'The media player has one media in its list of sources');
+
+                    assert.equal(sources[0].src, data.config.url, 'The source URL is as expected');
+                    assert.equal(sources[0].type, data.mime, 'The source type is as expected');
+
+                    instance.destroy();
+                })
+                .on('destroy', ready);
+        });
 
     QUnit.test('stalled', assert => {
         const ready = assert.async();

--- a/test/mediaplayer/test.js
+++ b/test/mediaplayer/test.js
@@ -1082,12 +1082,12 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
         assert.expect(5);
 
-        const stalledTimeout = 50;
+        const stalledDetectionDelay = 50;
         const instance = mediaplayer({
             url: 'samples/video.mp4',
             type: 'video',
             renderTo: '#qunit-fixture',
-            stalledTimeout
+            stalledDetectionDelay
         })
             .on('render.test', $dom => {
                 instance.off('.test');
@@ -1102,18 +1102,17 @@ define(['jquery', 'lodash', 'ui/mediaplayer', 'core/store'], function ($, _, med
 
                     //simulate user click to reload button
                     instance.reload();
-                }, stalledTimeout);
+                }, stalledDetectionDelay);
             })
             .on('reload', () => {
                 assert.ok(true, 'reload event is fired');
 
-                // add listener for rerender
-                instance.on('render', $dom => {
+                instance.on('play', () => {
                     assert.equal(instance.getTimesPlayed(), 1, 'timesPlayed is kept');
                     assert.equal(instance.is('stalled'), true, 'player still stalled after reload');
 
                     // simulate video start playing
-                    $dom.find('.media').trigger('playing');
+                    instance.$component.find('.media').trigger('playing');
                     assert.equal(instance.is('stalled'), false, 'player is not stalled anymore');
 
                     instance.destroy();

--- a/test/mediaplayer/utils/reminder/test.html
+++ b/test/mediaplayer/utils/reminder/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test - Media Player - utils - reminder</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/mediaplayer/utils/reminder/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+    </body>
+</html>

--- a/test/mediaplayer/utils/reminder/test.js
+++ b/test/mediaplayer/utils/reminder/test.js
@@ -1,0 +1,115 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+define(['ui/mediaplayer/utils/reminder'], function (reminderManagerFactory) {
+    'use strict';
+
+    let performanceNow;
+
+    QUnit.module('reminderManager', {
+        beforeEach: function() {
+            performanceNow = performance.now;
+        },
+        afterEach: function() {
+            performance.now = performanceNow;
+        }
+    });
+
+    QUnit.test('module', assert => {
+        assert.equal(typeof reminderManagerFactory, 'function', 'The reminderManager module exposes a function');
+        assert.equal(typeof reminderManagerFactory(), 'object', 'The reminderManager factory produces an object');
+        assert.notStrictEqual(
+            reminderManagerFactory(),
+            reminderManagerFactory(),
+            'The reminderManager factory provides a different object on each call'
+        );
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'start' },
+            { title: 'stop' },
+            { title: 'remind' },
+            { title: 'forget' }
+        ])
+        .test('API ', (data, assert) => {
+            const instance = reminderManagerFactory();
+            assert.equal(
+                typeof instance[data.title],
+                'function',
+                `The reminderManager instance exposes a "${data.title}" function`
+            );
+        });
+
+    QUnit.test('Default values', assert => {
+        const reminderManager = reminderManagerFactory();
+        performance.now = () => 1234;
+        assert.equal(reminderManager.running, false, 'reminderManager is stopped');
+        assert.equal(reminderManager.elapsed, 0, 'reminderManager reports zero elapsed time');
+    });
+
+    QUnit.test('Start & stop', assert => {
+        const reminderManager = reminderManagerFactory();
+
+        performance.now = () => 1234;
+        reminderManager.start();
+        performance.now = () => 1334;
+        assert.equal(reminderManager.running, true, 'reminderManager is running');
+        assert.equal(reminderManager.elapsed, 100, 'reminderManager calculates correct elapsed time');
+
+        reminderManager.stop();
+        assert.equal(reminderManager.running, false, 'reminderManager is stopped');
+        assert.equal(reminderManager.elapsed, 0, 'reminderManager reports zero elapsed time');
+    });
+
+    QUnit.test('Add 1 reminder', assert => {
+        const done = assert.async();
+
+        const reminderManager = reminderManagerFactory();
+
+        let timeoutPassed = false;
+
+        const cb = () => {
+            assert.ok(timeoutPassed, 'Callback was called after expected time')
+            reminderManager.stop();
+            assert.equal(reminderManager.running, false, 'reminderManager is stopped');
+            done();
+        };
+
+        reminderManager.remind(cb, 20); // 20ms
+        reminderManager.start();
+        setTimeout(() => timeoutPassed = true, 19);
+    });
+
+    // TODO: remind multiple
+
+    // TODO: forget named
+
+    // TODO: forget all
+
+    QUnit.test('Chaining', assert => {
+        const cb = () => {};
+        const reminderManager = reminderManagerFactory();
+        reminderManager
+            .stop()
+            .start()
+            .remind(cb, 10)
+            .forget(cb)
+            .stop();
+        assert.ok(true, 'No error thrown => reminderManager methods are chainable');
+    });
+});

--- a/test/mediaplayer/utils/timeObserver/test.html
+++ b/test/mediaplayer/utils/timeObserver/test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test - Media Player - utils - timeObserver</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/mediaplayer/utils/timeObserver/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+    </body>
+</html>

--- a/test/mediaplayer/utils/timeObserver/test.js
+++ b/test/mediaplayer/utils/timeObserver/test.js
@@ -15,7 +15,7 @@
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
-define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _, timeObserverFactory) {
+define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
     'use strict';
 
     QUnit.module('timeObserver');
@@ -47,16 +47,16 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
 
     QUnit.test('Default values', assert => {
         const timeObserver = timeObserverFactory();
-        assert.equal(timeObserver.position, 0);
-        assert.equal(timeObserver.duration, 0);
+        assert.equal(timeObserver.position, 0, 'position is default value');
+        assert.equal(timeObserver.duration, 0, 'duration is default value');
     });
 
     QUnit.test('Init values', assert => {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        assert.equal(timeObserver.position, 7);
-        assert.equal(timeObserver.duration, 11);
+        assert.equal(timeObserver.position, 7, 'position is init value');
+        assert.equal(timeObserver.duration, 11, 'duration is init value');
     });
 
     QUnit.test('Update position value - seeking forward works', assert => {
@@ -71,8 +71,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
 
         // +1 sec
         timeObserver.update(8);
-        assert.equal(timeObserver.position, 8);
-        assert.equal(timeObserver.duration, 11);
+        assert.equal(timeObserver.position, 8, 'position is updated');
+        assert.equal(timeObserver.duration, 11, 'duration is unchanged');
     });
 
     QUnit.test('Update position value - seeking backward works', assert => {
@@ -87,8 +87,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
 
         // -1 sec
         timeObserver.update(6);
-        assert.equal(timeObserver.position, 6);
-        assert.equal(timeObserver.duration, 11);
+        assert.equal(timeObserver.position, 6, 'position is updated');
+        assert.equal(timeObserver.duration, 11, 'duration is unchanged');
     });
 
     QUnit.test('Update position value - seeking forward & exceeding interval', assert => {
@@ -98,7 +98,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
         timeObserver.init(7, 11);
 
         timeObserver.after('irregularity', function() {
-            assert.equal(timeObserver.position, 9);
+            assert.ok(true, 'fires irregularity');
+            assert.equal(timeObserver.position, 9, 'position is updated');
             done();
         });
 
@@ -114,7 +115,8 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
         timeObserver.init(7, 11);
 
         timeObserver.after('irregularity', function() {
-            assert.equal(timeObserver.position, 10);
+            assert.ok(true, 'fires irregularity');
+            assert.equal(timeObserver.position, 10, 'position is updated');
             done();
         });
 
@@ -129,10 +131,11 @@ define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _
         timeObserver.init(7, 11);
 
         timeObserver.seek(5);
-        assert.equal(timeObserver.position, 5);
+        assert.equal(timeObserver.position, 5, 'position is updated by seek');
 
         timeObserver.after('irregularity', function() {
-            assert.equal(timeObserver.position, 7);
+            assert.ok(true, 'fires irregularity');
+            assert.equal(timeObserver.position, 7, 'position is updated');
             done();
         });
 

--- a/test/mediaplayer/utils/timeObserver/test.js
+++ b/test/mediaplayer/utils/timeObserver/test.js
@@ -1,0 +1,152 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+define(['jquery', 'lodash', 'ui/mediaplayer/utils/timeObserver'], function ($, _, timeObserverFactory) {
+    'use strict';
+
+    QUnit.module('timeObserver');
+
+    QUnit.test('module', assert => {
+        assert.equal(typeof timeObserverFactory, 'function', 'The timeObserver module exposes a function');
+        assert.equal(typeof timeObserverFactory(), 'object', 'The timeObserver factory produces an object');
+        assert.notStrictEqual(
+            timeObserverFactory(),
+            timeObserverFactory(),
+            'The timeObserver factory provides a different object on each call'
+        );
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'init' },
+            { title: 'update' },
+            { title: 'seek' }
+        ])
+        .test('API ', (data, assert) => {
+            const instance = timeObserverFactory();
+            assert.equal(
+                typeof instance[data.title],
+                'function',
+                `The timeObserver instance exposes a "${data.title}" function`
+            );
+        });
+
+    QUnit.test('Default values', assert => {
+        const timeObserver = timeObserverFactory();
+        assert.equal(timeObserver.position, 0);
+        assert.equal(timeObserver.duration, 0);
+    });
+
+    QUnit.test('Init values', assert => {
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        assert.equal(timeObserver.position, 7);
+        assert.equal(timeObserver.duration, 11);
+    });
+
+    QUnit.test('Update position value - seeking forward works', assert => {
+        assert.expect(2);
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.on('irregularity', function() {
+            assert.ok(false, 'Should not report time irregularity!');
+        });
+
+        // +1 sec
+        timeObserver.update(8);
+        assert.equal(timeObserver.position, 8);
+        assert.equal(timeObserver.duration, 11);
+    });
+
+    QUnit.test('Update position value - seeking backward works', assert => {
+        assert.expect(2);
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.on('irregularity', function() {
+            assert.ok(false, 'Should not report time irregularity!');
+        });
+
+        // -1 sec
+        timeObserver.update(6);
+        assert.equal(timeObserver.position, 6);
+        assert.equal(timeObserver.duration, 11);
+    });
+
+    QUnit.test('Update position value - seeking forward & exceeding interval', assert => {
+        const done = assert.async();
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.after('irregularity', function() {
+            assert.equal(timeObserver.position, 9);
+            done();
+        });
+
+        // +2 sec
+        timeObserver.update(9);
+    });
+
+    QUnit.test('Update position value - seeking forward & exceeding non-default interval', assert => {
+        const done = assert.async();
+
+        const interval = 2;
+        const timeObserver = timeObserverFactory(interval);
+        timeObserver.init(7, 11);
+
+        timeObserver.after('irregularity', function() {
+            assert.equal(timeObserver.position, 10);
+            done();
+        });
+
+        // +3 sec
+        timeObserver.update(10);
+    });
+
+    QUnit.test('Set seek value & update', assert => {
+        const done = assert.async();
+
+        const timeObserver = timeObserverFactory();
+        timeObserver.init(7, 11);
+
+        timeObserver.seek(5);
+        assert.equal(timeObserver.position, 5);
+
+        timeObserver.after('irregularity', function() {
+            assert.equal(timeObserver.position, 7);
+            done();
+        });
+
+        // +2 sec
+        timeObserver.update(7);
+    });
+
+    QUnit.test('Chaining', assert => {
+        const timeObserver = timeObserverFactory();
+        timeObserver
+            .init(7, 11)
+            .seek(8)
+            .update(9)
+            .seek(10);
+        assert.ok(true, 'No error thrown => timeObserver methods are chainable');
+    });
+});

--- a/test/mediaplayer/utils/timeObserver/test.js
+++ b/test/mediaplayer/utils/timeObserver/test.js
@@ -30,20 +30,14 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         );
     });
 
-    QUnit.cases
-        .init([
-            { title: 'init' },
-            { title: 'update' },
-            { title: 'seek' }
-        ])
-        .test('API ', (data, assert) => {
-            const instance = timeObserverFactory();
-            assert.equal(
-                typeof instance[data.title],
-                'function',
-                `The timeObserver instance exposes a "${data.title}" function`
-            );
-        });
+    QUnit.cases.init([{ title: 'init' }, { title: 'update' }, { title: 'seek' }]).test('API ', (data, assert) => {
+        const instance = timeObserverFactory();
+        assert.equal(
+            typeof instance[data.title],
+            'function',
+            `The timeObserver instance exposes a "${data.title}" function`
+        );
+    });
 
     QUnit.test('Default values', assert => {
         const timeObserver = timeObserverFactory();
@@ -65,7 +59,7 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        timeObserver.on('irregularity', function() {
+        timeObserver.on('irregularity', function () {
             assert.ok(false, 'Should not report time irregularity!');
         });
 
@@ -81,7 +75,7 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        timeObserver.on('irregularity', function() {
+        timeObserver.on('irregularity', function () {
             assert.ok(false, 'Should not report time irregularity!');
         });
 
@@ -97,7 +91,12 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory();
         timeObserver.init(7, 11);
 
-        timeObserver.after('irregularity', function() {
+        timeObserver.on('irregularity', function (lastPosition, newPosition) {
+            assert.equal(lastPosition, 7, 'last position is given');
+            assert.equal(newPosition, 9, 'new position is given');
+        });
+
+        timeObserver.after('irregularity', function () {
             assert.ok(true, 'fires irregularity');
             assert.equal(timeObserver.position, 9, 'position is updated');
             done();
@@ -114,7 +113,12 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         const timeObserver = timeObserverFactory(interval);
         timeObserver.init(7, 11);
 
-        timeObserver.after('irregularity', function() {
+        timeObserver.on('irregularity', function (lastPosition, newPosition) {
+            assert.equal(lastPosition, 7, 'last position is given');
+            assert.equal(newPosition, 10, 'new position is given');
+        });
+
+        timeObserver.after('irregularity', function () {
             assert.ok(true, 'fires irregularity');
             assert.equal(timeObserver.position, 10, 'position is updated');
             done();
@@ -133,7 +137,12 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
         timeObserver.seek(5);
         assert.equal(timeObserver.position, 5, 'position is updated by seek');
 
-        timeObserver.after('irregularity', function() {
+        timeObserver.on('irregularity', function (lastPosition, newPosition) {
+            assert.equal(lastPosition, 5, 'last position is given');
+            assert.equal(newPosition, 7, 'new position is given');
+        });
+
+        timeObserver.after('irregularity', function () {
             assert.ok(true, 'fires irregularity');
             assert.equal(timeObserver.position, 7, 'position is updated');
             done();
@@ -145,11 +154,7 @@ define(['ui/mediaplayer/utils/timeObserver'], function (timeObserverFactory) {
 
     QUnit.test('Chaining', assert => {
         const timeObserver = timeObserverFactory();
-        timeObserver
-            .init(7, 11)
-            .seek(8)
-            .update(9)
-            .seek(10);
+        timeObserver.init(7, 11).seek(8).update(9).seek(10);
         assert.ok(true, 'No error thrown => timeObserver methods are chainable');
     });
 });


### PR DESCRIPTION
Related to: [TR-3442](https://oat-sa.atlassian.net/browse/TR-3442)

Backport the fixes made with the tickets:
- [TR-1460](https://oat-sa.atlassian.net/browse/TR-1460) - Message on connectivity loss isn't shown when connection to server is interrupted by network request blocking. It contains a small refactoring of the media player, with fixes for stalled media detection.
- [TR-2846](https://oat-sa.atlassian.net/browse/TR-2846) - Message on connectivity loss is occasionally shown on video player despite connection to server is established. It contains fixes for the detection of stalled media, and also for the media type detection.
- [TR-3028](https://oat-sa.atlassian.net/browse/TR-3028) - Redesign the Reload button in Audio interaction.
- [TR-2827](https://oat-sa.atlassian.net/browse/TR-2827) - Media Interaction audio player with max plays restriction is displayed differently right upon finishing last playback attempt vs. after revisiting item later