### PR TITLE
[Backport] fix: TR-3292. Restore focusing functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.47.0",
+    "version": "1.47.0-1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.47.0",
+    "version": "1.47.0-1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -410,11 +410,10 @@ label {
             left: -1em;
         }
     }
+
     input[type="radio"],
     input[type="checkbox"] {
-        visibility: hidden;
-        pointer-events: none;
-        position: absolute;
+        @include visuallyHidden;
 
         &:focus ~ [class^="icon-"],
         &:focus ~ [class*=" icon-"],

--- a/scss/inc/_functions.scss
+++ b/scss/inc/_functions.scss
@@ -270,3 +270,14 @@ Usage:
 @mixin disableSelect() {
     @include vendor-prefix(user-select, none, property);
 }
+
+/* based on "visually-hidden" mixin in LDS for accessibility goals */
+@mixin visuallyHidden() {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    margin: 0;
+    padding: 0;
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-3292 (original bug report)
https://oat-sa.atlassian.net/browse/TR-3414 (newer bug report)

Apply the fix from https://github.com/oat-sa/tao-core-ui-fe/pull/407/files on top of tag `1.47.0`
(currently used in [tao-core](https://github.com/oat-sa/tao-core/blob/release-2022-02-lts/views/package.json#L20) used in [taoCommunity](https://github.com/oat-sa/tao-community/blob/release-2022-02-lts/composer.json) `release-2022-02-lts`).
