### PR TITLE
[Fix] ADF-829: Advanced search: filtering rework for alias & class

### DIFF
--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -562,10 +562,6 @@ export default function advancedSearchFactory(config) {
         let option;
         let optionText = label;
 
-        if(criterion.isDuplicated) {
-            sublabel = criterion.class.label;
-            optionText = `${label} / ${sublabel}`;
-        }
         if (criterion.isDuplicated) {
             sublabel = criterion.class.label;
             optionText = `${label} (${criterion.alias}) /`;

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -566,15 +566,19 @@ export default function advancedSearchFactory(config) {
             sublabel = criterion.class.label;
             optionText = `${label} / ${sublabel}`;
         }
+        if (criterion.isDuplicated) {
+            sublabel = criterion.class.label;
+            optionText = `${label} (${criterion.alias}) /`;
+        }
 
         option = new Option(
-            optionText,
+            label,
             getCriterionStateId(criterion),
             false,
             false
         );
 
-        option.setAttribute('label', label);
+        option.setAttribute('label', optionText);
         option.setAttribute('sublabel', sublabel);
 
         return option;
@@ -593,10 +597,6 @@ export default function advancedSearchFactory(config) {
      * @returns String
      */
     function getCriterionLabel(criterion) {
-        if (criterion.isDuplicated) {
-            return criterion.alias ? `${criterion.label} (${criterion.alias})` : criterion.label;
-        }
-
         return criterion.label;
     }
 


### PR DESCRIPTION
**Related ticket** https://oat-sa.atlassian.net/browse/ADF-829

**Related PR** https://github.com/oat-sa/tao-core/pull/3399

**Steps to reproduce:**

1. Go to Items tab (for example)
2. Click 'Search' icon to open Modal View.
3. Click 'add criteria'.
4. Type part of the alias / class  in the search field.

**Actual result:** Autofill shows results when parts of the alias or class are typed. 
**Expected result:** Alias and Class name MUST be ignored in the criteria autocomplete.