### PR TITLE
Fix/AUT-345/disable label for disabled input

### DIFF
--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -438,7 +438,8 @@ label {
         }
         &.disabled, &[disabled], &[readonly] {
             & ~[class^="icon-"],
-            & ~[class*=" icon-"]{
+            & ~[class*=" icon-"],
+            & ~label {
                 cursor: not-allowed !important;
                 opacity: .4 !important;
                 color: #555;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-345

Fix label of the radio button has disabled state as input.
<img width="181" alt="image" src="https://user-images.githubusercontent.com/25976342/159285234-99849fd9-1ea0-4924-91ae-36f9f4e6d92c.png">