### PR TITLE
Fix/aut 2076/notes showing trough test preview npm

### DIFF
--- a/scss/ckeditor/skins/tao/scss/inc/_mainui.scss
+++ b/scss/ckeditor/skins/tao/scss/inc/_mainui.scss
@@ -61,7 +61,8 @@ Special outer level classes used in this file:
 
   padding: 0;
   position: relative;
-  z-index: 0;
+  z-index: 10001;
+
 }
 
 /* Added to the outer boundary of the UI when in inline editing,

--- a/scss/ckeditor/skins/tao/scss/inc/_mainui.scss
+++ b/scss/ckeditor/skins/tao/scss/inc/_mainui.scss
@@ -61,8 +61,7 @@ Special outer level classes used in this file:
 
   padding: 0;
   position: relative;
-  z-index: 10001;
-
+  z-index: 0;
 }
 
 /* Added to the outer boundary of the UI when in inline editing,

--- a/scss/ckeditor/skins/tao/scss/inc/_reset.scss
+++ b/scss/ckeditor/skins/tao/scss/inc/_reset.scss
@@ -37,6 +37,7 @@ http://docs.cksource.com/CKEditor_4.x/Skin_SDK/Reset
   box-sizing: content-box;
   position: static;
   transition: none;
+  z-index: 0 !important;
 }
 
 /* Reset for elements and their children. */


### PR DESCRIPTION
Related to: 
https://oat-sa.atlassian.net/browse/AUT-2017](https://oat-sa.atlassian.net/browse/AUT-2076)
PR: 

Fix : Notes show in Test and item solar preview when item/ Test have property text.

**PREREQUISITES**
Have an instance with solar preview installed.

**SETPS to test:**
• Checkout to branch: fix/AUT-2076/notes-showing-trough-test-preview-npm
• Create a  class with a property  text long - html  for tests and for items
![image](https://user-images.githubusercontent.com/60346520/164485741-798f3a38-085c-4f76-96b8-ad6e598be83d.png)
•  Add test/ items respectively to the class
• Press preview

**ACTUAL RESULT:**
The preview shows with the text box in the front

**EXPECTED RESULT:**
Preview shows clean, withouth text box for both  test and item

![image](https://user-images.githubusercontent.com/60346520/164485348-fe0c8426-0c21-469b-a78a-7219b6f059a9.png)
![image](https://user-images.githubusercontent.com/60346520/164487489-6f21df78-1154-4e28-99fd-1b8f636c746e.png)

**CHANGES:**
Added a reset for Z-index.

