### PR TITLE
fix: date picker validation error set correct style

### DIFF
--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -715,6 +715,10 @@ label {
                 @include simple-border();
             }
         }
+        & ~.form-error{
+            color: $error;
+            text-align: right;
+        }
 
         [dir="rtl"] & {
             padding: 0 0 0 10px;


### PR DESCRIPTION
Related to:
https://oat-sa.atlassian.net/browse/AUT-1894

PR : [tao-core](https://github.com/oat-sa/tao-core/pull/3508)

**PR:**

Fix : Data picker validation error incorrect style

**PREREQUISITES**
To have a test created and published

SETPS to test:
• Checkout to branch: AUT-1894/date-picker-validation-error-message-wrong-style
• Go to delivery and change the dates in the delivery form in such a a way that the start date goes after the end date
•  Press save.

ACTUAL RESULT:
A message pops up aligned to the left and in grey color,

EXPECTED RESULT:
A message pops up, aligned to the right and in the red $error color.

![image](https://user-images.githubusercontent.com/60346520/166444916-bca53dfc-85c9-43c4-bfe7-284ed72d160b.png)
