### PR TITLE
fix: collapsing lines when whole text is <sub> or <sup>

### DIFF
--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -211,7 +211,6 @@ body {
     sub,
     sup {
         font-size: .75em;
-        line-height: 0;
         position: relative;
         vertical-align: baseline;
     }


### PR DESCRIPTION
# Pull request summary

Related to [OATSD-1881](https://oat-sa.atlassian.net/browse/OATSD-1881).

Removed `line-height: 0;`, so when `<sub>` or `<sup>` elements take more than one line text wouldn't collapse to a single one.

# How to test

This fix needs to be tested within Item Result Preview.

1. Setup new dockerized TAO instance as described in [docker-stack-cli](https://github.com/oat-sa/docker-stack-cli)
2. Publish `@oat-sa/tao-core-ui` package to your local [Verdaccio](https://verdaccio.org/) instance or to a file and update dependency within your package-tao (`tao/views`) or update it directly from this branch (`npm i github:oat-sa/tao-core-ui-fe#fix/OATSD-1881/sub-line-height`) and rebuild css by running `npx run taosass` from `tao/views/build`
3. Create and take the test with ExtendedTextInteraction (it's important to select whole text and make it `sub` or `sup` by clicking corresponding button)
4. Login as admin, open developer tools with Network tab, go to results screen and look for `/getResults` request, then go to response preview tab and look for `data[0].id` value - you'll have to encode this value via `encodeURIComponent` in console and use as `resultId` in the Launch URL
5. Use the following tool http://ltiapps.net/test/tc.php to open Item Result Previewer. Your Launch URL should look something like `https://<your-tao-instance>.docker.localhost/ltiOutcomeUi/ItemResultPreviewer/launch?itemRef=<itemRef>&resultId=<resultId>` (I'm not sure how to find itemRef, so I ended up using default name for my item and itemRef for it was `item-1`)
6. Then fill Consumer key and Shared secret values, click save data and Launch TP in new window - `<sub>` or `<sup>` lines shouldn't be collapsed