### PR TITLE
feat: take specialChars default value from config

### DIFF
--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -19,11 +19,13 @@ import $ from 'jquery';
 import _ from 'lodash';
 import dtdHandler from 'ui/ckeditor/dtdHandler';
 import 'ckeditor';
+import module from 'module';
 
 /**
  * Cache original config
  */
 const originalConfig = _.cloneDeep(window.CKEDITOR.config);
+const moduleConfig = module.config();
 
 function getUserLanguage() {
     const documentLang = window.document.documentElement.getAttribute('lang');
@@ -430,6 +432,11 @@ const ckConfigurator = (function () {
         ],
         disableNativeTableHandles: true
     };
+
+    //update default specialChars if config for it exists
+    if(moduleConfig && moduleConfig.specialChars) {
+        ckConfigDefault.specialChars = moduleConfig.specialChars;
+    }
 
     /**
      * Insert positioned plugins at position specified in options.positionedPlugins

--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -433,7 +433,6 @@ const ckConfigurator = (function () {
         disableNativeTableHandles: true
     };
 
-    //update default specialChars if config for it exists
     if(moduleConfig && moduleConfig.specialChars) {
         ckConfigDefault.specialChars = moduleConfig.specialChars;
     }


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/TR-4303

### Description

Customers need to configure their own set of ckeditor specialChars

This PR makes it possible to pass the ckeditor specialChars configuration to config file 

### How to test

##### Kitchen

On kitchen environment https://test-shaveko.playground.kitchen.it.taocloud.org/
CkEditor character set is configured to provided by UDIR

To change character set you can login by ssh to environment and edit the file `./delivery/app/config/tao/client_lib_config_registry.conf.php`

Or you can switch between setups running convenience scripts: 
`./customSpecialChars.sh`
`./defaultSpecialChars.sh`


##### Locally

update config `config/tao/client_lib_config_registry.conf.php` for your installation with the following member of `config` array


```        'ui/ckeditor/ckConfigurator' => array(
            'specialChars' => array("!","&quot;","#","$","%","&amp;","'","(",")","*","+","-",".","/","0","1","2","3","4","5","6","7","8","9",":",";","&lt;","=","&gt;","?","@","A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z","[","]","^","_","`","a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","{","|","}","~","&euro;","&lsquo;","&rsquo;","&ldquo;","&rdquo;","&ndash;","&mdash;","&iexcl;","&cent;","&pound;","&curren;","&yen;","&brvbar;","&sect;","&uml;","&copy;","&ordf;","&laquo;","&not;","&reg;","&macr;","&deg;","&sup2;","&sup3;","&acute;","&micro;","&para;","&middot;","&cedil;","&sup1;","&ordm;","&raquo;","&frac14;","&frac12;","&frac34;","&iquest;","&Agrave;","&Aacute;","&Acirc;","&Atilde;","&Auml;","&Aring;","&AElig;","&Ccedil;","&Egrave;","&Eacute;","&Ecirc;","&Euml;","&Igrave;","&Iacute;","&Icirc;","&Iuml;","&ETH;","&Ntilde;","&Ograve;","&Oacute;","&Ocirc;","&Otilde;","&Ouml;","&times;","&Oslash;","&Ugrave;","&Uacute;","&Ucirc;","&Uuml;","&Yacute;","&THORN;","&szlig;","&agrave;","&aacute;","&acirc;","&atilde;","&auml;","&aring;","&aelig;","&ccedil;","&egrave;","&eacute;","&ecirc;","&euml;","&igrave;","&iacute;","&icirc;","&iuml;","&eth;","&ntilde;","&ograve;","&oacute;","&ocirc;","&otilde;","&ouml;","&divide;","&oslash;","&ugrave;","&uacute;","&ucirc;","&uuml;","&yacute;","&thorn;","&yuml;","&OElig;","&oelig;","&#372;","&#374","&#373","&#375;","&sbquo;","&#8219;","&bdquo;","&hellip;","&trade;","&#9658;","&bull;","&rarr;","&rArr;","&hArr;","&diams;","&asymp;","À","à","Á","á","Â","â","Ã","ã","Ä","ä","Ā","ā","Ă","ă","Ą","ą","Ç","ç","Ć","ć","Ĉ","ĉ","Ċ","ċ","Č","č","Ď","ď","Đ","đ","ð","È","è","É","é","Ê","ê","Ë","ë","Ē","ē","Ĕ","ĕ","Ė","ė","Ę","ę","Ě","ě","Ĝ","ĝ","Ğ","ğ","Ġ","ġ","Ģ","ģ","Ĥ","ĥ","Ì","ì","Í","í","Î","î","Ï","ï","Ĩ","ĩ","Ī","ī","Ĭ","ĭ","İ","ı","Į","į","Ķ","ķ","Ł","ł","Ļ","ļ","Ń","ń","Ň","ň","Ŋ","ŋ","Ñ","ñ","Ņ","ņ","Ò","ò","Ó","ó","Ô","ô","Õ","õ","Ö","ö","Ō","ō","Ŏ","ŏ","Ő","ő","Œ","œ","Ŕ","ŕ","Ř","ř","Ś","ś","Ŝ","ŝ","Ş","ş","Š","š","Ţ","ţ","Ť","ť","Ŧ","ŧ","Ù","ù","Ú","ú","Û","û","Ü","ü","Ũ","ũ","Ū","ū","Ŭ","ŭ","Ű","ű","Ų","ų","Ý","ý","Ÿ","ÿ","Ŷ","ŷ","Ź","ź","Ż","ż","Ž","ž","Þ","þ","ß","¿","¡","Ω"),
        ),
```

Check the spcial characters are updated in authoring UI