### PR TITLE
Fix/Build SCSS

### DIFF
--- a/build/scss.js
+++ b/build/scss.js
@@ -81,7 +81,7 @@ const writeOutResult = async result => {
 
     // write out map if exist
     if (result.map) {
-        await writeFile(`${outputFile}.map`, result.map, { flag: 'w' });
+        await writeFile(`${outputFile}.map`, result.map.toString(), { flag: 'w' });
     }
 };
 


### PR DESCRIPTION
### Summary
When installing or developping with the library using Node >= 14, the commnd `npm run buildScss` is issuing a log of warnings related to the source map generation.

This is due to a wrong data format supplied to the writer. This PR aims at fixing this by supplying the expected format.

### How to test
- Install Node 14.*
- run the command `npm run buildScss` => it should trigger several errors/warnings :(
- check out the branch
- run the command `npm run buildScss` => it should process without errors/warning :)
- also check the generated source maps for the CSS files

### Technical details
The source map is given as a complex object, of the type `SourceMapGenerator`. The `writeFile` expects a string or a data object it can process.

As per the [documentation](https://postcss.org/api/#result), it can be converted to a better suitable format.