### PR TITLE
Fix/aut 2268/prevent drag resize math input

### DIFF
--- a/src/component/draggable.js
+++ b/src/component/draggable.js
@@ -33,6 +33,7 @@ import makePlaceable from 'ui/component/placeable';
  * @param {Component} component - an instance of ui/component
  * @param {Object} config
  * @param {jQuery|Element} config.dragRestriction - interact restriction property. See {@link http://interactjs.io/docs/restriction/#restriction}
+ * @param {String} config.ignoreFrom - selectors of elements to ignore pointer events from (interactjs)
  */
 export default function makeDraggable(component, config) {
     if (!makePlaceable.isPlaceable(component)) {
@@ -55,6 +56,9 @@ export default function makeDraggable(component, config) {
             if (!this.config.dragRestriction) {
                 this.config.dragRestriction = this.getContainer()[0];
             }
+            if (!this.config.ignoreFrom) {
+                this.config.ignoreFrom = '.no-drag'; // goal: to preserve text selectability in these form elements
+            }
 
             interact(element)
                 .draggable({
@@ -63,6 +67,7 @@ export default function makeDraggable(component, config) {
                         restriction: this.config.dragRestriction,
                         elementRect: { left: 0, right: 1, top: 0, bottom: 1 }
                     },
+                    ignoreFrom: this.config.ignoreFrom,
                     onmove: function onMove(event) {
                         var xOffset = Math.round(event.dx),
                             yOffset = Math.round(event.dy);

--- a/src/component/resizable.js
+++ b/src/component/resizable.js
@@ -140,6 +140,7 @@ var resizableComponent = {
  * @param {Number} config.maxWidth
  * @param {Number} config.maxHeight
  * @param {jQuery|Element} config.resizeRestriction - interact restriction property. See {@link http://interactjs.io/docs/restriction/#restriction}
+ * @param {String} config.ignoreFrom - selectors of elements to ignore pointer events from (interactjs)
  * @param {Object} config.edges
  * @param {Object} config.edges.top - is resizing from the top allowed
  * @param {Object} config.edges.right - is resizing from the right allowed
@@ -166,6 +167,9 @@ export default function makeResizable(component, config) {
             if (!this.config.resizeRestriction) {
                 this.config.resizeRestriction = this.getContainer()[0];
             }
+            if (!this.config.ignoreFrom) {
+                this.config.ignoreFrom = '.no-resize'; // goal: to preserve text selectability in these form elements
+            }
 
             interact(element)
                 .resizable({
@@ -173,6 +177,7 @@ export default function makeResizable(component, config) {
                     restrict: {
                         restriction: this.config.resizeRestriction
                     },
+                    ignoreFrom: this.config.ignoreFrom,
                     edges: this.config.edges
                 })
                 .on('resizemove', function(event) {

--- a/test/component/draggable/test.html
+++ b/test/component/draggable/test.html
@@ -17,14 +17,18 @@
             #outside {
                 position: relative;
                 border: solid 1px grey;
+                background: rgba(255,255,255,0.9);
                 width: 80%;
                 margin: 10px auto;
                 padding: 10px;
             }
-            .component {
+            #outside .component {
                 outline: dashed 2px black;
-                background-color: lightblue;
-                opacity: 0.5;
+                background-color: rgba(173, 216, 230, 0.5);
+                padding: 4px;
+            }
+            #outside .component textarea {
+                width: 100%;
             }
         </style>
     </head>

--- a/test/component/draggable/test.js
+++ b/test/component/draggable/test.js
@@ -45,7 +45,13 @@ define(['jquery', 'ui/component', 'ui/component/placeable', 'ui/component/dragga
     QUnit.test('Display and play', function(assert) {
         var ready = assert.async();
         var component = componentFactory({}, { width: 200, height: 300 }),
-            $container = $('#outside');
+            $container = $('#outside'),
+            template = `<div class="component">
+                <h2>Draggable box</h2>
+                <div class="no-drag no-resize">
+                    <textarea>Drag events don't bother me</textarea>
+                </div>
+            </div>`;
 
         assert.expect(1);
 
@@ -57,6 +63,7 @@ define(['jquery', 'ui/component', 'ui/component/placeable', 'ui/component/dragga
                 ready();
             })
             .init()
+            .setTemplate(template)
             .render($container)
             .center();
     });

--- a/test/component/resizable/test.html
+++ b/test/component/resizable/test.html
@@ -17,14 +17,18 @@
             #outside {
                 position: relative;
                 border: solid 1px grey;
+                background: rgba(255,255,255,0.9);
                 width: 80%;
                 margin: 10px auto;
                 padding: 10px;
             }
-            .component {
+            #outside .component {
                 outline: dashed 2px black;
-                background-color: lightblue;
-                opacity: 0.5;
+                background-color: rgba(173, 216, 230, 0.5);
+                padding: 4px;
+            }
+            #outside .component textarea {
+                width: 100%;
             }
         </style>
     </head>

--- a/test/component/resizable/test.js
+++ b/test/component/resizable/test.js
@@ -357,7 +357,13 @@ define([
     QUnit.test('display and play', function(assert) {
         var ready = assert.async();
         var component = componentFactory(),
-            $container = $('#outside');
+            $container = $('#outside'),
+            template = `<div class="component">
+                <h2>Resizable box</h2>
+                <div class="no-drag no-resize">
+                    <textarea>Resize events don't bother me</textarea>
+                </div>
+            </div>`;
 
         assert.expect(1);
 
@@ -375,6 +381,7 @@ define([
                 minHeight: 150,
                 maxHeight: 450
             })
+            .setTemplate(template)
             .render($container)
             .setSize(500, 300)
             .center();


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2268

The math dragging/resizing bug could be fixed using [interactjs configurations](https://interactjs.io/docs/action-options/#ignorefrom).

- draggable: add interactjs property `ignoreFrom: '.no-drag'`
- resizable: add interactjs property `ignoreFrom: '.no-resize'`
- both have a new configuration option as an escape hatch, but we won't use it anywhere for now