### PR TITLE
Backport/AUT-2273: Fix glitching volume slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.56.1",
+    "version": "1.56.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "1.56.1",
+    "version": "1.56.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -258,7 +258,8 @@ $controlsHeight: 36px;
             height: $playerActionSize;
 
             .action {
-                z-index: 5;
+                position: relative;
+                z-index: 1001;
             }
             .volume {
                 cursor: default;

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -257,42 +257,51 @@ $controlsHeight: 36px;
             width: $playerActionSize;
             height: $playerActionSize;
 
-
+            .action {
+                z-index: 5;
+            }
             .volume {
                 cursor: default;
                 position: absolute;
-                z-index: 3;
+                z-index: 1000;
                 background-color: $playerBackground;
-                padding: 0 10px 0 10px;
+                margin: 1px 2px;
+                padding: 10px 0;
+                width: 100%;
                 height: 0;
                 top: 0;
                 left: -1px;
                 opacity : 0;
+                text-align: center;
                 border: solid 1px $playerBorder;
+                pointer-events: none;
+                overflow: hidden;
                 @include vendor-prefix(transition, 'height 300ms ease-out, top 300ms ease-out, opacity 50ms linear 250ms', property);
 
                 &.up, &.down {
                     height: 120px;
-                    padding: 10px 10px 5px 10px;
                     opacity : 1;
+                    pointer-events: auto;
                     .slider {
+                        display: inline-block;
                         opacity : 1;
                         transition: opacity 50ms linear 200ms;
                         @include vendor-prefix(transition, 'opacity 50ms linear 200ms', property);
                     }
                 }
                 &.up {
-                    top: -125px;
+                    top: -127px;
                      @include vendor-prefix(transition, 'height 300ms ease-out 50ms, top 300ms ease-out 50ms, opacity 50ms linear', property);
                 }
                 &.down {
-                    top: 29px;
+                    top: 30px;
                      @include vendor-prefix(transition, 'height 300ms ease-out 50ms, opacity 50ms linear', property);
                 }
             }
 
             .slider {
                 opacity : 0;
+                display: none;
                 .noUi-handle {
                     cursor: pointer;
                     width: 9px;


### PR DESCRIPTION
Backport of https://github.com/oat-sa/tao-core-ui-fe/pull/486

---

Related to https://oat-sa.atlassian.net/browse/AUT-2273

**Description:**
The slider should be aligned inside the box and shown without impediments, make sure the player is in an "active" state.
Player has internal padding and the control boundaries shown as green.
And volume button boundaries as red.
<img width="1017" alt="Screenshot 2022-08-11 at 11 51 45" src="https://user-images.githubusercontent.com/2067027/184110396-0e745676-dd19-47a0-ae25-c8956d099b73.png">


**Changes:**
* Adjusted styling to be aligned center independently of container width.
* Modified box model

How to check:
* Add Audio to interaction
* Click preview
* Make sure player is not in muted mode (speaker icon shown not a cross)
* Hover mouse on the volume button 
