### PR TITLE
fix: revert .colrow class width

### DIFF
--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -23,7 +23,6 @@
 }
 .colrow {
     @extend .clearfix;
-    width: revert;
 }
 @for $i from 1 through 12 {
     .col-#{$i} {

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -14,14 +14,17 @@
 }
 
 .grid-container {
-    overflow-x: hidden; 
+    overflow-x: hidden;
 }
 
-.grid-row, .fixed-grid-row, .colrow {
+.grid-row, .fixed-grid-row {
     @extend .clearfix;
     width: widthPerc(852, 840);
 }
-
+.colrow {
+    @extend .clearfix;
+    width: revert;
+}
 @for $i from 1 through 12 {
     .col-#{$i} {
         @include grid-unit($i, 12, 12);


### PR DESCRIPTION
**Related to:** TR-4635[https://oat-sa.atlassian.net/browse/TR-4635](url)

**STEPS TO TEST:**
1º Import items in above ticket
2º Create a test, add both items and enable ruler tool in test-taker tools in test authoring
3º Publish and assign to test taker
4º Take test as test taker.

ACTUAL RESULT:
.colrow class width larger than original size in second image hence ruler measurement changes (should be 12cm)

EXPECTED RESULT:
Width doesn't change for any images and measurement is 12cm for this item example

<img width="947" alt="image" src="https://user-images.githubusercontent.com/60346520/189636018-7be2ee2a-5b41-410b-ac0f-33425815e834.png">

PROPOSED SOLUTION:
Revert width to original for the issue class `.colrow`
