### PR TITLE
Feature/adf 1197/refactor search modal requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "UI libraries of TAO",
     "scripts": {
         "test": "npx qunit-testrunner",
-        "test:keepAlive": "npx qunit-testrunner --keepalive",
+        "test:keepAlive": "npx qunit-testrunner --keepalive --port 5400",
         "test:cov": "npm run build:cov && npx qunit-testrunner --cov",
         "test:dev": "run-p test:keepAlive build:watch",
         "coverage": "nyc report",

--- a/src/datatable/tpl/layout.tpl
+++ b/src/datatable/tpl/layout.tpl
@@ -61,7 +61,7 @@
                         <div
                             {{#if sortable}}
                                 class="sortable"
-                                data-sort-by="{{id}}"
+                                data-sort-by="{{#if sortId}}{{sortId}}{{else}}{{id}}{{/if}}"
                                 {{#if sorttype}}data-sort-type="{{sorttype}}"{{/if}}
                                 tabindex="0"
                             {{/if}}>{{label}}</div>
@@ -88,7 +88,7 @@
                         {{#if ../options.selectable}}
                         <td class="checkboxes"><input type="checkbox" name="cb[{{id}}]" value="1" /></td>
                         {{/if}}
-{{! IMPORTANT:START IF YOU'RE GOING TO MAKE CHANGES TO THIS SECTION, 
+{{! IMPORTANT:START IF YOU'RE GOING TO MAKE CHANGES TO THIS SECTION,
     PLEASE UPDATE shallowUpdate METHOD ACCORDINGLY}}
                         {{#each ../options.model}}
                             {{#if type}}
@@ -120,7 +120,7 @@
                             {{/if}}
 
                         {{/each}}
-{{! IMPORTANT:END IF YOU'RE GOING TO MAKE CHANGES TO THIS SECTION, 
+{{! IMPORTANT:END IF YOU'RE GOING TO MAKE CHANGES TO THIS SECTION,
     PLEASE UPDATE shallowUpdate METHOD ACCORDINGLY}}
                         {{#with ../options.actions}}
                         <td class="actions">

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -318,7 +318,6 @@ export default function searchModalFactory(config) {
      * @returns {Promise}
      */
     const searchQuery = (query, classFilterUri, params = {}) => {
-        running = true;
         return new Promise((resolve, reject) => {
             $.ajax({
                 url: instance.config.url,
@@ -327,25 +326,26 @@ export default function searchModalFactory(config) {
                 dataType: 'json'
             })
                 .done(resolve)
-                .fail(reject)
-                .always(() => (running = false));
+                .fail(reject);
         });
     };
 
     /**
-     * Performs the search query, throttling and controlling to prevent sending too many requests
+     * Performs the search query, preventing to send too many requests
      * @param query - The searched terms
      * @param classFilterUri - The URI of the node class
      * @param [params] - Additional parameters
      */
-    const searchHandler = _.throttle((query, classFilterUri, params={}) => {
+    const searchHandler = (query, classFilterUri, params={}) => {
         if (running === false) {
+            running = true;
             searchQuery(query, classFilterUri, params)
                 .then(data => appendDefaultDatasetToDatatable(data.data))
                 .then(data => buildSearchResultsDatatable(data))
-                .catch(e => instance.trigger('error', e));
+                .catch(e => instance.trigger('error', e))
+                .then(() => (running = false));
         }
-    }, 100);
+    };
 
     /**
      * Request search results and manages its results

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -45,10 +45,17 @@ import shortcutRegistry from 'util/shortcut/registry';
  * @param {string} config.rootClassUri - Uri for the root class of current context, required to init the class filter
  * @param {bool} config.hideResourceSelector - if resourceSelector must be hidden
  * @param {string} config.placeholder - placeholder for input in template
+ * @param {string} config.classesUrl - the URL to the classes API (usually '/tao/RestResource/getAll')
+ * @param {string} config.classMappingUrl - the URL to the class mapping API (usually '/tao/ClassMetadata/getWithMapping')
+ * @param {string} config.statusUrl - the URL to the status API (usually '/tao/AdvancedSearch/status')
  * @returns {searchModal}
  */
 export default function searchModalFactory(config) {
+    // @TODO: The consumer must be responsible for supplying the routes. The component must not hardcode endpoints.
     const defaults = {
+        classesUrl: urlUtil.route('getAll', 'RestResource', 'tao'),
+        classMappingUrl: urlUtil.route('getWithMapping', 'ClassMetadata', 'tao'),
+        statusUrl: urlUtil.route('status', 'AdvancedSearch', 'tao'),
         renderTo: 'body',
         criterias: {},
         searchOnInit: true,
@@ -82,6 +89,7 @@ export default function searchModalFactory(config) {
         advancedSearch = advancedSearchFactory({
             renderTo: $('.filters-container', $container),
             advancedCriteria: instance.config.criterias.advancedCriteria,
+            statusUrl: instance.config.statusUrl,
             rootClassUri: rootClassUri
         });
         promises.push(initClassFilter());
@@ -149,7 +157,7 @@ export default function searchModalFactory(config) {
             // when a class query is triggered, update selector options with received resources
             resourceSelector.on('query', params => {
                 const classOnlyParams = { ...params, classOnly: true };
-                const route = urlUtil.route('getAll', 'RestResource', 'tao');
+                const route = instance.config.classesUrl;
                 request(route, classOnlyParams)
                     .then(response => {
                         if (
@@ -189,7 +197,7 @@ export default function searchModalFactory(config) {
                 const classUri = _.map(selectedValue, 'classUri')[0];
                 const label = _.map(selectedValue, 'label')[0];
                 const uri = _.map(selectedValue, 'uri')[0];
-                const route = urlUtil.route('getWithMapping', 'ClassMetadata', 'tao', {
+                const route = urlUtil.build(instance.config.classMappingUrl, {
                     classUri,
                     maxListSize: instance.config.maxListSize
                 });

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -28,7 +28,6 @@ import component from 'ui/component';
 import 'ui/modal';
 import 'ui/datatable';
 import 'select2';
-import urlUtil from 'util/url';
 import request from 'core/dataProvider/request';
 
 /**
@@ -38,6 +37,7 @@ import request from 'core/dataProvider/request';
  * @param {object} config.renderTo - DOM element where component will be rendered to
  * @param {string} config.advancedCriteria - advanced criteria to be set on component creation
  * @param {string} config.rootClassUri - rootClassUri to check for whitelist sections
+ * @param {string} config.statusUrl - the URL to the status API (usually '/tao/AdvancedSearch/status')
  * @returns {advancedSearch}
  */
 export default function advancedSearchFactory(config) {
@@ -168,8 +168,7 @@ export default function advancedSearchFactory(config) {
      * Inits select2 on criteria select and its UX logic
      */
     function initAddCriteriaSelector() {
-        const route = urlUtil.route('status', 'AdvancedSearch', 'tao');
-        return request(route)
+        return request(instance.config.statusUrl)
             .then(function (response) {
                 if (!response.enabled || (response.whitelist && response.whitelist.includes(config.rootClassUri))) {
                     isAdvancedSearchStatusEnabled = false;

--- a/test/datatable/test.js
+++ b/test/datatable/test.js
@@ -1615,6 +1615,22 @@ define([
                 sortType: 'asc'
             },
             message: 'First time sort by "name"'
+        },
+        {
+            initSortOptions: {
+                sortorder: 'desc',
+            },
+            updateSortOptions: {
+                sortBy: 'username',
+                asc: undefined,
+                sortType: 'asc'
+            },
+            expectedOptions: {
+                sortBy: 'username',
+                sortOrder: 'asc',
+                sortType: 'asc'
+            },
+            message: 'Sort login using the sort identifier "username"'
         }
     ]).test('Sort options', (cases, assert) => {
         const done = assert.async();
@@ -1631,7 +1647,13 @@ define([
         })
         .datatable(Object.assign({
             url: '/test/datatable/data.json',
-            'model': [ {
+            'model': [{
+                id: 'login',
+                sortId: 'username',
+                label: 'Login',
+                sortable: true,
+                sorttype: 'string'
+            }, {
                 id: 'name',
                 label: 'Name',
                 sortable: true
@@ -1639,7 +1661,45 @@ define([
         }, cases.initSortOptions));
     });
 
-    QUnit.test('Sortable headers', function(assert) {
+    QUnit.cases.init([
+        {
+            title: "regular sort options",
+            sortBy: 'login',
+            model: [{
+                id: 'login',
+                label: 'Login',
+                sortable: true,
+                sorttype: 'string'
+            }, {
+                id: 'name',
+                label: 'Name',
+                sortable: true
+            }, {
+                id: 'email',
+                label: 'Email',
+                sortable: false
+            }]
+        },
+        {
+            title: "using a different sort identifier",
+            sortBy: 'username',
+            model: [{
+                id: 'login',
+                sortId: 'username',
+                label: 'Login',
+                sortable: true,
+                sorttype: 'string'
+            }, {
+                id: 'name',
+                label: 'Name',
+                sortable: true
+            }, {
+                id: 'email',
+                label: 'Email',
+                sortable: false
+            }]
+        }
+    ]).test('Sortable headers', function(data, assert) {
         var ready = assert.async();
         var $container = $('#container-1');
 
@@ -1657,7 +1717,7 @@ define([
             assert.equal($loginHead.length, 1, 'The login head exists');
             assert.equal($loginHead.text().trim(), 'Login', 'The login head contains the right text');
             assert.ok($loginHead.hasClass('sortable'), 'The login column is sortable');
-            assert.equal($loginHead.data('sort-by'), 'login', 'The sort by data is correct');
+            assert.equal($loginHead.data('sort-by'), data.sortBy, 'The sort by data is correct');
             assert.equal($loginHead.data('sort-type'), 'string', 'The sort type is correct');
 
             assert.equal($emailHead.length, 1, 'The email head exists');
@@ -1669,7 +1729,7 @@ define([
         })
         .on('sort.datatable', function(e, sortby, sortorder, sorttype) {
 
-            assert.equal(sortby, 'login', 'The sort by data passed via event');
+            assert.equal(sortby, data.sortBy, 'The sort by data passed via event');
             assert.notEqual(sortorder, undefined, 'The sort order passed via event');
             assert.equal(sorttype, 'string', 'The sort type passed via event');
 
@@ -1678,20 +1738,7 @@ define([
         .datatable({
             url: '/test/datatable/data.json',
             sortby: false,
-            'model': [{
-                id: 'login',
-                label: 'Login',
-                sortable: true,
-                sorttype: 'string'
-            }, {
-                id: 'name',
-                label: 'Name',
-                sortable: true
-            }, {
-                id: 'email',
-                label: 'Email',
-                sortable: false
-            }]
+            model: data.model
         });
     });
 

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -214,7 +214,8 @@
     });
     QUnit.test('bind between view and model is correctly set', function (assert) {
         const instance = advancedSearchFactory({
-            renderTo: '#testable-container'
+            renderTo: '#testable-container',
+            statusUrl: 'undefined/tao/AdvancedSearch/status'
         });
         const ready = assert.async();
         assert.expect(8);

--- a/test/searchModal/mocks/with-occurrences/search.json
+++ b/test/searchModal/mocks/with-occurrences/search.json
@@ -1,6 +1,21 @@
 {
     "data": {
         "url": "/test/searchModal/mocks/with-occurrences/dataset.json",
+        "settings": {
+            "availableColumns": [
+                {
+                    "id": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "sortId": "label",
+                    "label": "Label",
+                    "type": "text",
+                    "alias": null,
+                    "classLabel": null,
+                    "isDuplicated": false,
+                    "default": true,
+                    "sortable": true
+                }
+            ]
+        },
         "model": {
             "http://www.w3.org/2000/01/rdf-schema#label": {
                 "id": "http://www.w3.org/2000/01/rdf-schema#label",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1197

### Summary

A few changes:
- Preliminary changes to make the search query more agnostic.
- Support for sorting the columns with respect to the new columns configuration.
- Preliminary support for the columns selection (in the state, all available columns are displayed).

Note: as a small improvement, this PR also fixes the port number for the unit tests runner. It is now 5400 instead a random port.

### Details

Move the hardcoded routes to the config. There are still changes needed on the consumer side, the config now relies on default values.

Modularise the search preparation, using promise chains.
Wrong concurrency management was also fixed (useless throttle of nested function).

The [data model ](https://github.com/oat-sa/tao-core-ui-fe/pull/494/files#diff-931d32bcbcc0445525c09cb03af3e8d008e666548a6a8b32d94e9938d07a8730R420)for the datatable is now coming from the new API (the `settings` section of the `searchParams` response). Support is still present for the old `model` property, but it could be removed in the end.

Support for a sort identifier different from the column identifier is also added.

What is remaining: wire the column selection to the data model. For the time being, all available columns are used.

### How to test
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at (replace PORT_NUMBER):
    - `http://127.0.0.1:PORT_NUMBER/test/searchModal/advancedSearch/test.html`
    - `http://127.0.0.1:PORT_NUMBER/test/searchModal/test.html`
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)
