### PR TITLE
Feature/ADF-1197/Hide criteria on demand

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -44,6 +44,7 @@ import shortcutRegistry from 'util/shortcut/registry';
  * @param {string} config.url - search endpoint to be set on datatable
  * @param {string} config.rootClassUri - Uri for the root class of current context, required to init the class filter
  * @param {bool} config.hideResourceSelector - if resourceSelector must be hidden
+ * @param {bool} config.hideCriteria - if the criteria must be hidden
  * @param {string} config.placeholder - placeholder for input in template
  * @param {string} config.classesUrl - the URL to the classes API (usually '/tao/RestResource/getAll')
  * @param {string} config.classMappingUrl - the URL to the class mapping API (usually '/tao/ClassMetadata/getWithMapping')
@@ -89,6 +90,7 @@ export default function searchModalFactory(config) {
         advancedSearch = advancedSearchFactory({
             renderTo: $('.filters-container', $container),
             advancedCriteria: instance.config.criterias.advancedCriteria,
+            hideCriteria: instance.config.hideCriteria,
             statusUrl: instance.config.statusUrl,
             rootClassUri: rootClassUri
         });

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -36,6 +36,7 @@ import request from 'core/dataProvider/request';
  * @param {object} config
  * @param {object} config.renderTo - DOM element where component will be rendered to
  * @param {string} config.advancedCriteria - advanced criteria to be set on component creation
+ * @param {bool} config.hideCriteria - if the criteria must be hidden
  * @param {string} config.rootClassUri - rootClassUri to check for whitelist sections
  * @param {string} config.statusUrl - the URL to the status API (usually '/tao/AdvancedSearch/status')
  * @returns {advancedSearch}
@@ -170,7 +171,7 @@ export default function advancedSearchFactory(config) {
     function initAddCriteriaSelector() {
         return request(instance.config.statusUrl)
             .then(function (response) {
-                if (!response.enabled || (response.whitelist && response.whitelist.includes(config.rootClassUri))) {
+                if (config.hideCriteria || !response.enabled || (response.whitelist && response.whitelist.includes(config.rootClassUri))) {
                     isAdvancedSearchStatusEnabled = false;
                     return;
                 }

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -117,6 +117,28 @@
         });
     });
 
+     QUnit.test('advancedSearch component is correctly initialized with criteria disabled', function (assert) {
+         const instance = searchModalFactory({
+             criterias: { search: 'example' },
+             url: '/test/searchModal/mocks/with-occurrences/search.json',
+             renderTo: '#testable-container',
+             rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',
+             hideCriteria: true
+         });
+         const ready = assert.async();
+         assert.expect(2);
+
+         instance.on('ready', function () {
+             const $container = $('.advanced-search-container');
+             const $criteriaContainer = $container.find('.add-criteria-container');
+
+             assert.equal($criteriaContainer.length, 1, 'container for criteria is rendered');
+             assert.ok($criteriaContainer.hasClass('disabled'), 'container for criteria is disabled');
+             instance.destroy();
+             ready();
+         });
+     });
+
     QUnit.module('advanced search logic');
     QUnit.cases.init([
         {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1197

### Summary

Disable the criteria on demand from the advanced search.

### Details

Add an option to hide the criteria from the advanced search modal.

The option can be supplied to the search modal.

The search modal forwards the option to the advanced search component.

### How to test
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`,
- checkout the integration branches in the other repositories
- checkout the companion PR too
- check the search in each module. With the Results module, the criteria must not show up.