### PR TITLE
Feature/ADF-1195/Show column alias in header

### DIFF
--- a/scss/inc/_colors.scss
+++ b/scss/inc/_colors.scss
@@ -21,6 +21,7 @@ $websiteBorder: rgb(141, 148, 158);
 
 $textColor: #222;
 $textHighlight: white;
+$textSecondary: #737373;
 $shadowColor: rgba(0, 0, 0, 0.25);
 
 $modalBorderColor: #dddfe2;

--- a/src/datatable/scss/datatable.scss
+++ b/src/datatable/scss/datatable.scss
@@ -109,6 +109,9 @@ table.datatable {
         .sorted.sorted_desc:after{
             @include icon-up;
         }
+        .alias {
+            color: $textSecondary;
+        }
     }
     tr{
         &.selected {

--- a/src/datatable/tpl/layout.tpl
+++ b/src/datatable/tpl/layout.tpl
@@ -64,7 +64,7 @@
                                 data-sort-by="{{#if sortId}}{{sortId}}{{else}}{{id}}{{/if}}"
                                 {{#if sorttype}}data-sort-type="{{sorttype}}"{{/if}}
                                 tabindex="0"
-                            {{/if}}>{{label}}</div>
+                                {{/if}}>{{label}}{{#if alias}} /<span class="alias">/ {{alias}}</span>{{/if}}</div>
                         {{#if filterable}}
                         <aside data-column="{{id}}" class="filter column
                             {{#if customFilter}} customInput" >

--- a/src/propertySelector/scss/propertySelector.scss
+++ b/src/propertySelector/scss/propertySelector.scss
@@ -33,7 +33,7 @@
             gap: 1rem;
 
             .property-description-alias {
-                color: $grey;
+                color: $textSecondary;
             }
         }
     }

--- a/src/propertySelector/tpl/alias-text.tpl
+++ b/src/propertySelector/tpl/alias-text.tpl
@@ -1,1 +1,1 @@
-<span class="property-description-alias">/{{{text}}}</span>
+<span class="property-description-alias">/ {{{text}}}</span>

--- a/src/propertySelector/tpl/label-text.tpl
+++ b/src/propertySelector/tpl/label-text.tpl
@@ -1,1 +1,1 @@
-<span class="property-description-label">{{{text}}}{{#if alias}}/{{/if}}</span>
+<span class="property-description-label">{{{text}}}{{#if alias}} /{{/if}}</span>

--- a/test/datatable/test.js
+++ b/test/datatable/test.js
@@ -1795,6 +1795,49 @@ define([
             });
     });
 
+    QUnit.test('Columns with alias', function(assert) {
+        var ready = assert.async();
+        var $container = $('#container-1');
+
+        assert.expect(7);
+
+        assert.equal($container.length, 1, 'Test the fixture is available');
+
+        $container.on('create.datatable', function() {
+
+            var $headerCells = $('.datatable thead th', $container);
+
+            assert.equal($headerCells.length, 3, 'The login header exists');
+            assert.equal($headerCells.eq(0).text().trim(), 'Login // username');
+            assert.equal($headerCells.eq(1).text().trim(), 'Name');
+            assert.equal($headerCells.eq(2).text().trim(), 'Email');
+
+            assert.equal($('.datatable thead [data-sort-by="login"] .alias', $container).length, 1, 'The column alias is rendered');
+            assert.equal($('.datatable thead [data-sort-by="email"] .alias', $container).length, 0, 'Column without alias does not show alias');
+
+            ready();
+        })
+            .datatable({
+                url: '/test/datatable/data.json',
+                'model': [{
+                    id: 'login',
+                    label: 'Login',
+                    alias: 'username',
+                    sortable: true,
+                    visible: true
+                }, {
+                    id: 'name',
+                    label: 'Name',
+                    sortable: true,
+                    visible: true
+                }, {
+                    id: 'email',
+                    label: 'Email',
+                    sortable: false
+                }]
+            });
+    });
+
     QUnit.test('pageSizeSelector disabled by default', function(assert){
         var ready = assert.async();
         var $container = $('#container-1');

--- a/test/searchModal/mocks/with-occurrences/search.json
+++ b/test/searchModal/mocks/with-occurrences/search.json
@@ -13,6 +13,17 @@
                     "isDuplicated": false,
                     "default": true,
                     "sortable": true
+                },
+                {
+                    "id": "custom_prop",
+                    "sortId": "custom_prop",
+                    "label": "Custom",
+                    "type": "text",
+                    "alias": "Additional property",
+                    "classLabel": "Custom properties",
+                    "isDuplicated": false,
+                    "default": true,
+                    "sortable": true
                 }
             ]
         },

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -97,7 +97,7 @@ define([
             rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item'
         });
         const ready = assert.async();
-        assert.expect(4);
+        assert.expect(9);
 
         instance.on('ready', function () {
             const $container = $('.search-modal');
@@ -110,6 +110,11 @@ define([
         instance.on('datatable-loaded', function () {
             const $datatable = $('table.datatable');
             assert.equal($datatable.length, 1, 'datatable has been created');
+            assert.equal($datatable.find('thead th').length, 3, 'datatable display the correct number of columns');
+            assert.equal($datatable.find('thead [data-sort-by="label"]').length, 1, 'The default column is displayed');
+            assert.equal($datatable.find('thead [data-sort-by="label"] .alias').length, 0, 'The default column has no alias');
+            assert.equal($datatable.find('thead [data-sort-by="custom_prop"]').length, 1, 'The additional column for the custom property is displayed');
+            assert.equal($datatable.find('thead [data-sort-by="custom_prop"] .alias').length, 1, 'The alias for the custom property is displayed');
             assert.equal($datatable.find('tbody tr').length, 9, 'datatable display the correct number of matches');
 
             instance.destroy();


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1195

### Summary

Display the column alias in the datatable header.

### Details

Take care of the column alias that can be supplied with the data model.

Style the column alias.

Also align the styling of the `propertySelector` with respect to the mockup.

### How to test
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/test.html
    - http://127.0.0.1:5400/test/datatable/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)