### PR TITLE
Fix/ADF-1191/Behavior of the  columns selector

### DIFF
--- a/src/propertySelector/propertySelector.js
+++ b/src/propertySelector/propertySelector.js
@@ -32,6 +32,21 @@ import $ from 'jquery';
 const searchableFields = ['label', 'alias', 'classLabel'];
 
 /**
+ * Sort an array by a particular property.
+ * @param {Array} iter - The array to sort.
+ * @param {string} prop - The name of the sorting property.
+ * @returns {Array} - Returns a sorted copy of the array.
+ * @private
+ */
+function sortBy(iter, prop) {
+    return Array.from(iter).sort((a, b) => {
+        const textA = (a && a[prop]) || '';
+        const textB = (b && b[prop]) || '';
+        return textA.localeCompare(textB);
+    });
+}
+
+/**
  * Creates a property selector with respect to given options.
  * @param {object} [config]
  * @returns {*}
@@ -94,7 +109,7 @@ export default function propertySelectorFactory(config) {
          */
         setData(data) {
             if (data.available) {
-                availableProperties = data.available;
+                availableProperties = sortBy(data.available, 'label');
             }
             selectedProperties = new Set(data.selected);
             this.redrawList();

--- a/src/propertySelector/propertySelector.js
+++ b/src/propertySelector/propertySelector.js
@@ -31,7 +31,11 @@ import $ from 'jquery';
  */
 const searchableFields = ['label', 'alias', 'classLabel'];
 
-
+/**
+ * Creates a property selector with respect to given options.
+ * @param {object} [config]
+ * @returns {*}
+ */
 export default function propertySelectorFactory(config) {
     //element references
     let $container;
@@ -100,12 +104,12 @@ export default function propertySelectorFactory(config) {
                 this.hide();
             } else {
                 this.show();
+                this.redrawList();
             }
         }
     })
         .setTemplate(propertySelectorTpl)
         .on('render', function () {
-            this.shown = true;
             //component parts reference assignments
             $container = instance.getElement();
             $propertyListContainer = $('.property-list-container', $container);
@@ -136,14 +140,48 @@ export default function propertySelectorFactory(config) {
                 searchRedrawTimeoutId = setTimeout(instance.redrawList, searchRedrawTimeout);
             });
 
+            this.show();
             this.trigger('ready');
         })
+        .on('destroy', unregisterPageClick)
         .on('hide', function () {
             this.shown = false;
+            unregisterPageClick();
         })
         .on('show', function () {
+            registerPageClick();
             this.shown = true;
+        })
+        .on('cancel select', function () {
+            this.hide();
+            $searchInput.val('');
+            search = '';
         });
+
+    /**
+     * Close the component when clicking outside.
+     * @param event
+     */
+    function pageClick(event) {
+        if ($(event.target).closest('.property-selector-container').length) {
+            return;
+        }
+        instance.trigger('cancel');
+    }
+
+    /**
+     * Listens to the clicks outside the component
+     */
+    function registerPageClick() {
+        setTimeout(() => document.addEventListener('click', pageClick), 0);
+    }
+
+    /**
+     * Stops listening to the clicks outside the component
+     */
+    function unregisterPageClick() {
+        setTimeout(() => document.removeEventListener('click', pageClick), 0);
+    }
 
     /**
      * Checks if a searchable field contains the searched term.
@@ -196,24 +234,13 @@ export default function propertySelectorFactory(config) {
             label: 'Cancel',
             type: 'info',
             cls: 'btn-secondary'
-        }).on('click', () => {
-            //clear search
-            $searchInput.val('');
-            search = '';
-            instance.redrawList();
-
-            instance.trigger('cancel');
-            instance.hide();
-        });
+        }).on('click', () => instance.trigger('cancel'));
 
         const saveButton = buttonFactory({
             id: 'save',
             label: 'Save',
             type: 'info'
-        }).on('click', () => {
-            instance.trigger('select', [...selectedProperties]);
-            instance.hide();
-        });
+        }).on('click', () => instance.trigger('select', [...selectedProperties]));
 
         cancelButton.render($targetContainer);
         saveButton.render($targetContainer);

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -123,15 +123,18 @@ export default function searchModalFactory(config) {
     }
 
     // Creates new component
-    const instance = component({
-        /**
-         * Tells if the advanced search is enabled.
-         * @returns {boolean}
-         */
-        isAdvancedSearchEnabled() {
-            return advancedSearch && advancedSearch.isEnabled();
-        }
-    }, defaults)
+    const instance = component(
+        {
+            /**
+             * Tells if the advanced search is enabled.
+             * @returns {boolean}
+             */
+            isAdvancedSearchEnabled() {
+                return advancedSearch && advancedSearch.isEnabled();
+            }
+        },
+        defaults
+    )
         .setTemplate(layoutTpl)
         .on('selected-store-updated', recreateDatatable)
         .on('render', renderModal)
@@ -576,7 +579,6 @@ export default function searchModalFactory(config) {
      * @param {Event} e
      */
     function handleManageColumnsBtnClick(e) {
-
         const selected = selectedColumns;
         const available = columnsToModel(availableColumns);
 
@@ -586,7 +588,7 @@ export default function searchModalFactory(config) {
             const position = {
                 top: btnBottom - containerTop,
                 right: containerRight - btnRight
-            }
+            };
             propertySelectorInstance = propertySelectorFactory({
                 renderTo: $container,
                 data: {

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -31,6 +31,21 @@ import 'select2';
 import request from 'core/dataProvider/request';
 
 /**
+ * Sort an array by a particular property.
+ * @param {Array} iter - The array to sort.
+ * @param {string} prop - The name of the sorting property.
+ * @returns {Array} - Returns a sorted copy of the array.
+ * @private
+ */
+function sortBy(iter, prop) {
+    return Array.from(iter).sort((a, b) => {
+        const textA = (a && a[prop]) || '';
+        const textB = (b && b[prop]) || '';
+        return textA.localeCompare(textB);
+    });
+}
+
+/**
  * Creates advanced search component
  *
  * @param {object} config
@@ -179,7 +194,11 @@ export default function advancedSearchFactory(config) {
     function initAddCriteriaSelector() {
         return request(instance.config.statusUrl)
             .then(function (response) {
-                if (config.hideCriteria || !response.enabled || (response.whitelist && response.whitelist.includes(config.rootClassUri))) {
+                if (
+                    config.hideCriteria ||
+                    !response.enabled ||
+                    (response.whitelist && response.whitelist.includes(config.rootClassUri))
+                ) {
                     isAdvancedSearchStatusEnabled = false;
                     return;
                 }
@@ -188,7 +207,7 @@ export default function advancedSearchFactory(config) {
                 $criteriaSelect.select2({
                     containerCssClass: 'criteria-select2',
                     dropdownCssClass: 'criteria-dropdown-select2',
-                    sortResults: results => _.sortBy(results, ['text']),
+                    sortResults: results => sortBy(results, 'text'),
                     escapeMarkup: function (markup) {
                         return markup;
                     },
@@ -200,7 +219,9 @@ export default function advancedSearchFactory(config) {
 
                         // Add sublabel
                         if (sublabel && sublabel.length) {
-                            template = template + `<span class="class-path"> / ${highlightCharacter(sublabel, query.term, match)}</span>`;
+                            template =
+                                template +
+                                `<span class="class-path"> / ${highlightCharacter(sublabel, query.term, match)}</span>`;
                         }
 
                         return template;
@@ -331,7 +352,7 @@ export default function advancedSearchFactory(config) {
                             subject: term
                         };
                     },
-                    results: (response) => ({
+                    results: response => ({
                         results: response.data.map(option => ({
                             id: valueMapping === 'uri' ? option.uri : option.label,
                             text: option.label
@@ -366,7 +387,7 @@ export default function advancedSearchFactory(config) {
         return $.ajax({
             type: 'GET',
             url: criterion.uri,
-            dataType: 'json',
+            dataType: 'json'
         }).then(({ data }) => {
             if (Array.isArray(criterion.value)) {
                 return criterion.value.map(v => ({
@@ -374,10 +395,10 @@ export default function advancedSearchFactory(config) {
                     text: (data.find(d => d.uri === v) || {}).label
                 }));
             }
-            let c = (data.find(d => d.uri === criterion.value) || {});
+            let c = data.find(d => d.uri === criterion.value) || {};
             return {
                 text: c.label,
-                id: criterion.value,
+                id: criterion.value
             };
         });
     }
@@ -578,12 +599,7 @@ export default function advancedSearchFactory(config) {
             optionText = `${label} (${criterion.alias}) /`;
         }
 
-        option = new Option(
-            label,
-            getCriterionStateId(criterion),
-            false,
-            false
-        );
+        option = new Option(label, getCriterionStateId(criterion), false, false);
 
         option.setAttribute('label', optionText);
         option.setAttribute('sublabel', sublabel);

--- a/test/propertySelector/test.html
+++ b/test/propertySelector/test.html
@@ -20,7 +20,7 @@
                 margin: 10px;
                 padding: 10px;
             }
-            #testable-container {
+            .testable-container {
                 height: 40rem;
                 position: relative;
             }
@@ -35,7 +35,8 @@
         <div id="qunit"></div>
         <div id="qunit-fixture"></div>
         <div id="visual-test">
-            <div id="testable-container"></div>
+            <button class="small btn-info" name="toggle" type="button">toggle</button>
+            <div class="testable-container"></div>
         </div>
     </body>
 </html>

--- a/test/propertySelector/test.js
+++ b/test/propertySelector/test.js
@@ -16,12 +16,12 @@
  * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
 
-define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/propertySelector/mocks/mocks.json', 'lodash'], function (
-    $,
-    propertySelectorFactory,
-    mockData,
-    _
-) {
+define([
+    'jquery',
+    'ui/propertySelector/propertySelector',
+    'json!test/ui/propertySelector/mocks/mocks.json',
+    'lodash'
+], function ($, propertySelectorFactory, mockData, _) {
     QUnit.module('propertySelector');
     QUnit.test('module', function (assert) {
         assert.expect(1);
@@ -34,7 +34,7 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
         assert.expect(7);
 
         const instance = propertySelectorFactory({
-            renderTo: '#testable-container',
+            renderTo: '#qunit-fixture',
             data: mockData
         });
 
@@ -43,11 +43,7 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
             const $searchInput = $container.find('input.search-property');
             const $listContainer = $container.find('.property-list-container');
             const $buttonContainer = $container.find('.control-buttons-container');
-            assert.equal(
-                $('#testable-container')[0],
-                instance.getContainer()[0],
-                'propertySelector component is created'
-            );
+            assert.equal($('#qunit-fixture')[0], instance.getContainer()[0], 'propertySelector component is created');
             assert.equal(
                 $container.css('top'),
                 `${mockData.position.top}px`,
@@ -79,28 +75,27 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
     QUnit.module('api');
     QUnit.test('propertySelector component as setData and redrawList api', function (assert) {
         const instance = propertySelectorFactory({
-            renderTo: '#testable-container',
+            renderTo: '#qunit-fixture',
             data: mockData
         });
 
         const ready = assert.async();
         assert.expect(2);
 
-
         instance.on('ready', () => {
-            assert.ok(typeof instance.setData === 'function', 'The component api has setData a function')
-            assert.ok(typeof instance.redrawList === 'function', 'The component api has redrawList a function')
+            assert.ok(typeof instance.setData === 'function', 'The component api has setData a function');
+            assert.ok(typeof instance.redrawList === 'function', 'The component api has redrawList a function');
             instance.destroy();
             ready();
-        })
-    })
+        });
+    });
 
     QUnit.test('propertySelector component can be managed by setting data from outside', function (assert) {
         const ready = assert.async();
         assert.expect(2);
 
         const instance = propertySelectorFactory({
-            renderTo: '#testable-container',
+            renderTo: '#qunit-fixture',
             data: mockData
         });
 
@@ -112,23 +107,22 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
             mockDataCopy.selected = [];
             mockDataCopy.available = [
                 {
-                    "id":"label",
-                    "label":"Label",
-                    "alias":null,
-                 }
+                    id: 'label',
+                    label: 'Label',
+                    alias: null
+                }
             ];
 
             instance.on('redraw', () => {
-                assert.equal($listContainer.find('input:checked').size(), 0, 'Selected props are updated')
-                assert.equal($listContainer.find('li').size(), 1, 'List items are updated')
+                assert.equal($listContainer.find('input:checked').size(), 0, 'Selected props are updated');
+                assert.equal($listContainer.find('li').size(), 1, 'List items are updated');
 
                 instance.destroy();
                 ready();
-            })
+            });
 
             instance.setData(mockDataCopy);
-
-        })
+        });
     });
 
     QUnit.module('search operation');
@@ -137,7 +131,7 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
         assert.expect(2);
 
         const instance = propertySelectorFactory({
-            renderTo: '#testable-container',
+            renderTo: '#qunit-fixture',
             data: mockData
         });
         instance.on('ready', () => {
@@ -151,18 +145,13 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
                     4,
                     'list of properties is filtered by search input value'
                 );
-                assert.equal(
-                    $listContainer.find('b').size(),
-                    6,
-                    'the found properties highlight the searched terms'
-                );
+                assert.equal($listContainer.find('b').size(), 6, 'the found properties highlight the searched terms');
                 instance.destroy();
                 ready();
             });
 
             $searchInput.val('prop');
             $searchInput.trigger('input');
-
         });
     });
 
@@ -172,7 +161,7 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
         assert.expect(2);
 
         const instance = propertySelectorFactory({
-            renderTo: '#testable-container',
+            renderTo: '#qunit-fixture',
             data: mockData
         });
 
@@ -184,8 +173,12 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
             const $saveButton = $buttons[1];
 
             const selectPromise = new Promise(selectHandled => {
-                instance.on('select', e => {
-                    assert.equal(e.length, mockData.selected.length, 'Select event fired with correct selected');
+                instance.on('select', selection => {
+                    assert.equal(
+                        selection.length,
+                        mockData.selected.length,
+                        'Select event fired with correct selected'
+                    );
                     selectHandled();
                 });
                 $saveButton.click();
@@ -205,14 +198,37 @@ define(['jquery', 'ui/propertySelector/propertySelector', 'json!test/ui/property
         });
     });
 
+    QUnit.test('a click outside propertySelector triggers cancel', function (assert) {
+        const ready = assert.async();
+        assert.expect(1);
+
+        const instance = propertySelectorFactory({
+            renderTo: '#qunit-fixture',
+            data: mockData
+        });
+
+        instance
+            .on('ready', () => {
+                setTimeout(() => document.dispatchEvent(new Event('click')), 0);
+            })
+            .on('cancel', () => {
+                assert.ok(true, 'Cancel event fired');
+                instance.destroy();
+            })
+            .on('destroy', ready);
+    });
+
     QUnit.module('visual');
     QUnit.test('Visual test', function (assert) {
+        const $container = $('#visual-test');
         const instance = propertySelectorFactory({
-            renderTo: '#testable-container',
+            renderTo: $('.testable-container', $container),
             data: mockData
         });
         const ready = assert.async();
         assert.expect(1);
+
+        $('[name=toggle]', $container).on('click', () => instance.toggle());
 
         instance.on('ready', function () {
             assert.ok(true, 'Visual test initialized');


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1191

### Summary

Fix a few defects of the columns selector:
- a click outside of the selector panel will close it, as if the cancel button was clicked
- the list of columns is sorted the same way as for the criteria

### Details

Add an event listener to the page when the columns selector is open. It is removed either when the panel is closed, or when the component is removed.

The listener is added and removed in defer to avoid a concurrency issue with clicks on the toggler link.

The list of properties is sorted when it is set to the component. The sort takes care of locales and is not case sensitive. It has been unified with the list of criteria. However, I had to duplicate the small helper. It would have been better to share it in some way, but it would have added complexity with several packages to update and release.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/propertySelector/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)