### PR TITLE
Feature/ADF-1191/Keep pagination when selecting columns

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -123,15 +123,18 @@ export default function searchModalFactory(config) {
     }
 
     // Creates new component
-    const instance = component({
-        /**
-         * Tells if the advanced search is enabled.
-         * @returns {boolean}
-         */
-        isAdvancedSearchEnabled() {
-            return advancedSearch && advancedSearch.isEnabled();
-        }
-    }, defaults)
+    const instance = component(
+        {
+            /**
+             * Tells if the advanced search is enabled.
+             * @returns {boolean}
+             */
+            isAdvancedSearchEnabled() {
+                return advancedSearch && advancedSearch.isEnabled();
+            }
+        },
+        defaults
+    )
         .setTemplate(layoutTpl)
         .on('selected-store-updated', recreateDatatable)
         .on('render', renderModal)
@@ -500,10 +503,8 @@ export default function searchModalFactory(config) {
      */
     function buildSearchResultsDatatable(data) {
         //update the section container
-        const $tableContainer = $('<div class="flex-container-full"></div>');
-        const section = $('.content-container', $container);
-        section.empty();
-        section.append($tableContainer);
+        const $tableContainer = $('.content-container .flex-container-full', $container);
+        $tableContainer.empty();
         $tableContainer.on('load.datatable', searchResultsLoaded);
         //create datatable
         $tableContainer.datatable(
@@ -576,7 +577,6 @@ export default function searchModalFactory(config) {
      * @param {Event} e
      */
     function handleManageColumnsBtnClick(e) {
-
         const selected = selectedColumns;
         const available = columnsToModel(availableColumns);
 
@@ -586,7 +586,7 @@ export default function searchModalFactory(config) {
             const position = {
                 top: btnBottom - containerTop,
                 right: containerRight - btnRight
-            }
+            };
             propertySelectorInstance = propertySelectorFactory({
                 renderTo: $container,
                 data: {

--- a/src/searchModal/tpl/layout.tpl
+++ b/src/searchModal/tpl/layout.tpl
@@ -21,6 +21,7 @@
             </div>
         </div>
         <div class="content-container" style="padding:40px 20px">
+            <div class="flex-container-full"></div>
         </div>
     </div>
 </div>

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -105,7 +105,11 @@ define([
                             'datatable displays all selected props + actions column'
                         );
 
-                        assert.equal($datatable.find('.toggle-modal-button').length, 0, 'The columns manager is not added');
+                        assert.equal(
+                            $datatable.find('.toggle-modal-button').length,
+                            0,
+                            'The columns manager is not added'
+                        );
 
                         instance.destroy();
                         ready();
@@ -139,7 +143,11 @@ define([
                         const $container = $('.search-modal');
                         const $searchInput = $container.find('.generic-search-input');
 
-                        assert.equal($('#testable-container')[0], instance.getContainer()[0], 'searchModal component is created');
+                        assert.equal(
+                            $('#testable-container')[0],
+                            instance.getContainer()[0],
+                            'searchModal component is created'
+                        );
                         assert.equal($searchInput.val(), 'example', 'search input value is correctly initialized');
                         assert.ok(!instance.isAdvancedSearchEnabled(), 'the advanced search is disabled');
                     });
@@ -147,18 +155,62 @@ define([
                     instance.on('datatable-loaded', function () {
                         const $datatable = $('table.datatable');
                         assert.equal($datatable.length, 1, 'datatable has been created');
-                        assert.equal($datatable.find('thead th').length, 4, 'datatable display the correct number of columns');
-                        assert.equal($datatable.find('thead [data-sort-by="label"]').length, 1, 'The default column is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="label"] .alias').length, 0, 'The default column has no alias');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_prop"]').length, 1, 'The additional column for the custom property is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_prop"] .alias').length, 0, 'The alias for the custom property is not displayed because it is not duplicated');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_prop"] .comment').length, 0, 'The class name for the custom property is not displayed because it is not duplicated');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_label"]').length, 1, 'The additional column for the custom label is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_label"] .alias').length, 1, 'The alias for the custom label is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_label"] .comment').length, 1, 'The class name for the custom label is displayed');
-                        assert.equal($datatable.find('tbody tr').length, 9, 'datatable display the correct number of matches');
+                        assert.equal(
+                            $datatable.find('thead th').length,
+                            4,
+                            'datatable display the correct number of columns'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="label"]').length,
+                            1,
+                            'The default column is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="label"] .alias').length,
+                            0,
+                            'The default column has no alias'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_prop"]').length,
+                            1,
+                            'The additional column for the custom property is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_prop"] .alias').length,
+                            0,
+                            'The alias for the custom property is not displayed because it is not duplicated'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_prop"] .comment').length,
+                            0,
+                            'The class name for the custom property is not displayed because it is not duplicated'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_label"]').length,
+                            1,
+                            'The additional column for the custom label is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_label"] .alias').length,
+                            1,
+                            'The alias for the custom label is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_label"] .comment').length,
+                            1,
+                            'The class name for the custom label is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('tbody tr').length,
+                            9,
+                            'datatable display the correct number of matches'
+                        );
 
-                        assert.equal($datatable.find('.toggle-modal-button').length, 0, 'The columns manager is not added');
+                        assert.equal(
+                            $datatable.find('.toggle-modal-button').length,
+                            0,
+                            'The columns manager is not added'
+                        );
 
                         instance.destroy();
                         ready();
@@ -194,7 +246,11 @@ define([
                         const $container = $('.search-modal');
                         const $searchInput = $container.find('.generic-search-input');
 
-                        assert.equal($('#testable-container')[0], instance.getContainer()[0], 'searchModal component is created');
+                        assert.equal(
+                            $('#testable-container')[0],
+                            instance.getContainer()[0],
+                            'searchModal component is created'
+                        );
                         assert.equal($searchInput.val(), 'example', 'search input value is correctly initialized');
                         assert.ok(instance.isAdvancedSearchEnabled(), 'the advanced search is enabled');
                     });
@@ -202,18 +258,62 @@ define([
                     instance.on('datatable-loaded', function () {
                         const $datatable = $('table.datatable');
                         assert.equal($datatable.length, 1, 'datatable has been created');
-                        assert.equal($datatable.find('thead th').length, 4, 'datatable display the correct number of columns');
-                        assert.equal($datatable.find('thead [data-sort-by="label"]').length, 1, 'The default column is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="label"] .alias').length, 0, 'The default column has no alias');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_prop"]').length, 1, 'The additional column for the custom property is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_prop"] .alias').length, 0, 'The alias for the custom property is not displayed because it is not duplicated');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_prop"] .comment').length, 0, 'The class name for the custom property is not displayed because it is not duplicated');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_label"]').length, 1, 'The additional column for the custom label is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_label"] .alias').length, 1, 'The alias for the custom label is displayed');
-                        assert.equal($datatable.find('thead [data-sort-by="custom_label"] .comment').length, 1, 'The class name for the custom label is displayed');
-                        assert.equal($datatable.find('tbody tr').length, 9, 'datatable display the correct number of matches');
+                        assert.equal(
+                            $datatable.find('thead th').length,
+                            4,
+                            'datatable display the correct number of columns'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="label"]').length,
+                            1,
+                            'The default column is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="label"] .alias').length,
+                            0,
+                            'The default column has no alias'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_prop"]').length,
+                            1,
+                            'The additional column for the custom property is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_prop"] .alias').length,
+                            0,
+                            'The alias for the custom property is not displayed because it is not duplicated'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_prop"] .comment').length,
+                            0,
+                            'The class name for the custom property is not displayed because it is not duplicated'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_label"]').length,
+                            1,
+                            'The additional column for the custom label is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_label"] .alias').length,
+                            1,
+                            'The alias for the custom label is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('thead [data-sort-by="custom_label"] .comment').length,
+                            1,
+                            'The class name for the custom label is displayed'
+                        );
+                        assert.equal(
+                            $datatable.find('tbody tr').length,
+                            9,
+                            'datatable display the correct number of matches'
+                        );
 
-                        assert.equal($datatable.find('.toggle-modal-button').length, 1, 'The columns manager is reachable');
+                        assert.equal(
+                            $datatable.find('.toggle-modal-button').length,
+                            1,
+                            'The columns manager is reachable'
+                        );
 
                         instance.destroy();
                         ready();
@@ -452,7 +552,7 @@ define([
             rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item'
         });
         const ready = assert.async();
-        assert.expect(6);
+        assert.expect(8);
 
         instance.on('ready', function () {
             assert.ok(!instance.isAdvancedSearchEnabled(), 'the advanced search is disabled');
@@ -464,11 +564,15 @@ define([
                     const promises = [];
                     promises.push(searchStore.getItem('criterias'));
                     promises.push(searchStore.getItem('results'));
+                    promises.push(searchStore.getItem('options'));
                     Promise.all(promises).then(function (resolutions) {
                         const criterias = resolutions[0];
                         const results = resolutions[1];
+                        const options = resolutions[2];
 
                         assert.equal(criterias.search, 'query to be stored', 'query correctly stored');
+                        assert.equal(options.sortby, 'id', 'sorted column correctly stored');
+                        assert.equal(options.sortorder, 'asc', 'sort order correctly stored');
                         assert.equal(results.totalCount, 9, 'results correctly stored');
                         assert.equal(
                             criterias.class,


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1191

### Summary

Keep both the pagination and the sorted column when changing the column selection.

### Details

This pull request is built on top of [the one that persists the sorting options](https://github.com/oat-sa/tao-core-ui-fe/pull/501). The actual change for the PR can be found in this commit: https://github.com/oat-sa/tao-core-ui-fe/commit/40d94ba9da6eced16c38c3c757ecbe52fac46662

Each time the selection of columns changes, the data table is reset to its initial options (first page, default order).
From the code change, the options are kept so that the current page as well as the sorted column remains.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)