### PR TITLE
Fix/aut 2654/issue with player icons

### DIFF
--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -98,11 +98,11 @@ $controlsHeight: 36px;
                 padding: 6px 12px;
                 background-color: $playerBackground;
                 opacity: 0.2;
-                font-family: 'tao' !Important;
+                font-family: 'tao' !important;
 
                 &:hover {
                     opacity: 0.6;
-                    font-family: 'tao' !Important;
+                   font-family: 'tao' !important;
                 }
             }
 
@@ -114,7 +114,7 @@ $controlsHeight: 36px;
                 &:hover {
                     .icon {
                         opacity: 1;
-                        font-family: 'tao' !Important;
+                        font-family: 'tao' !important;
                     }
                 }
 

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -23,7 +23,6 @@ $controlsHeight: 36px;
     min-height: $controlsHeight;
     min-width: 200px;
     direction: ltr;
-    font-family: 'tao' !important;
 
     &.youtube {
         .player {
@@ -98,11 +97,9 @@ $controlsHeight: 36px;
                 padding: 6px 12px;
                 background-color: $playerBackground;
                 opacity: 0.2;
-                font-family: 'tao' !important;
 
                 &:hover {
                     opacity: 0.6;
-                   font-family: 'tao' !important;
                 }
             }
 

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -23,6 +23,7 @@ $controlsHeight: 36px;
     min-height: $controlsHeight;
     min-width: 200px;
     direction: ltr;
+    font-family: 'tao' !important;
 
     &.youtube {
         .player {
@@ -72,6 +73,11 @@ $controlsHeight: 36px;
             right: 0;
             opacity: 1;
             background: transparent none;
+            a.action {
+                 span.icon {
+                    font-family: 'tao' !important;
+                }
+            }
         }
 
         .action {
@@ -92,9 +98,11 @@ $controlsHeight: 36px;
                 padding: 6px 12px;
                 background-color: $playerBackground;
                 opacity: 0.2;
+                font-family: 'tao' !Important;
 
                 &:hover {
                     opacity: 0.6;
+                    font-family: 'tao' !Important;
                 }
             }
 
@@ -106,12 +114,14 @@ $controlsHeight: 36px;
                 &:hover {
                     .icon {
                         opacity: 1;
+                        font-family: 'tao' !Important;
                     }
                 }
 
                 .icon {
                     opacity: 0.6;
                     background: none;
+                    font-family: 'tao' !important;
                 }
                 .message {
                     font-size: 20px;
@@ -160,6 +170,7 @@ $controlsHeight: 36px;
 
                 .icon {
                     line-height: $playerActionSize;
+                    font-family: 'tao' !important;
                 }
             }
 
@@ -401,6 +412,12 @@ $controlsHeight: 36px;
         &.paused.canplay {
             .player-overlay {
                 cursor: pointer;
+                font-family: 'tao' !important;
+                a.action {
+                    span.icon {
+                        font-family: 'tao' !important;
+                    }
+                }
             }
 
             &:not(.audio) {
@@ -423,6 +440,11 @@ $controlsHeight: 36px;
         &.playing.canpause {
             .player-overlay {
                 cursor: pointer;
+                .action {
+                    .icon {
+                        font-family: 'tao' !important;
+                    }
+                }
             }
 
             &:not(.audio) {
@@ -436,6 +458,11 @@ $controlsHeight: 36px;
     }
 
     &.playing.canpause {
+        .action {
+            .icon {
+                font-family: 'tao' !important;
+            }
+        }
         .controls {
             [data-control="pause"] {
                 display: inline-block;
@@ -444,6 +471,11 @@ $controlsHeight: 36px;
     }
 
     &.paused.canplay {
+        .action {
+            .icon {
+                font-family: 'tao' !important;
+            }
+        }
         .controls {
             [data-control="play"] {
                 display: inline-block;
@@ -529,6 +561,16 @@ $controlsHeight: 36px;
             }
         }
     }
+    &.video(.preview) {
+    .player-overlay {
+        .action {
+            .icon {
+              font-family: 'tao' !important;
+             }
+          }
+        }
+
+}
 
     &.video:not(.preview):not(.error) {
         .player-overlay {

--- a/src/mediaplayer/scss/player.scss
+++ b/src/mediaplayer/scss/player.scss
@@ -561,16 +561,6 @@ $controlsHeight: 36px;
             }
         }
     }
-    &.video(.preview) {
-    .player-overlay {
-        .action {
-            .icon {
-              font-family: 'tao' !important;
-             }
-          }
-        }
-
-}
 
     &.video:not(.preview):not(.error) {
         .player-overlay {


### PR DESCRIPTION
Related to shtylesheet Manager tickets. AUT-2654 

After fixing issue in AUT-2637 [https://oat-sa.atlassian.net/browse/AUT-2637](https://github.com/oat-sa/extension-tao-itemqti/pull/url) it was discovered by QA that mediaplayer icons were not displaying.

**STEPS TO TEST:**

Create Passage add an A block and a media item

**CURRENT RESULT:**
icons for play/pause and volume did not diplay appeared as squares 

**EXPECTED RESULT:**
icons show expected
![image](https://user-images.githubusercontent.com/60346520/193532839-83c3162d-08f5-4b74-a086-87d9c65b02ef.png)

