### PR TITLE
Fix/ADF-1220/Fix search modal

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -437,7 +437,14 @@ export default function searchModalFactory(config) {
      * @returns {string|*}
      */
     const emptyValueTransform = value => {
-        return value === '' || value === null || typeof value === 'undefined' ? '-' : value;
+        let testedValue = value;
+        if (Array.isArray(testedValue)) {
+            testedValue = testedValue[0];
+        }
+        if ('string' === typeof testedValue) {
+            testedValue = testedValue.trim();
+        }
+        return testedValue === '' || testedValue === null || typeof testedValue === 'undefined' ? '-' : value;
     };
 
     /**

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -52,6 +52,8 @@ import shortcutRegistry from 'util/shortcut/registry';
  * @param {string} config.classesUrl - the URL to the classes API (usually '/tao/RestResource/getAll')
  * @param {string} config.classMappingUrl - the URL to the class mapping API (usually '/tao/ClassMetadata/getWithMapping')
  * @param {string} config.statusUrl - the URL to the status API (usually '/tao/AdvancedSearch/status')
+ * @param {string} config.sortby - the default sorted column (usually 'label')
+ * @param {string} config.sortorder - the default sort order (usually 'asc')
  * @returns {searchModal}
  */
 export default function searchModalFactory(config) {
@@ -63,7 +65,9 @@ export default function searchModalFactory(config) {
         renderTo: 'body',
         criterias: {},
         searchOnInit: true,
-        maxListSize: 5
+        maxListSize: 5,
+        sortby: 'label',
+        sortorder: 'asc'
     };
     // Private properties to be easily accessible by instance methods
     let $container = null;
@@ -512,7 +516,7 @@ export default function searchModalFactory(config) {
         $contentContainer.empty().append($tableContainer);
         $tableContainer.on('load.datatable', searchResultsLoaded);
 
-        const { sortby, sortorder, page } = data.storedSearchOptions || {};
+        const { sortby, sortorder, page } = data.storedSearchOptions || instance.config;
 
         //create datatable
         $tableContainer.datatable(

--- a/test/searchModal/mocks/with-occurrences/dataset.json
+++ b/test/searchModal/mocks/with-occurrences/dataset.json
@@ -37,7 +37,8 @@
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e103c32b144a6be0cf4a640e0a4",
-            "http://www.w3.org/2000/01/rdf-schema#label": "example_2_Math"
+            "http://www.w3.org/2000/01/rdf-schema#label": "example_2_Math",
+            "custom_prop": ""
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e10370a44445642b4249664cd56",
@@ -47,7 +48,8 @@
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e1031ff3e4486d4bd1f46de2c04",
             "http://www.w3.org/2000/01/rdf-schema#label": "Example_0_Introduction",
-            "custom_label": "Example 0 Introduction"
+            "custom_label": "Example 0 Introduction",
+            "custom_prop": [" "]
         }
     ],
     "readonly": [],

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -571,7 +571,7 @@ define([
                         const options = resolutions[2];
 
                         assert.equal(criterias.search, 'query to be stored', 'query correctly stored');
-                        assert.equal(options.sortby, 'id', 'sorted column correctly stored');
+                        assert.equal(options.sortby, 'label', 'sorted column correctly stored');
                         assert.equal(options.sortorder, 'asc', 'sort order correctly stored');
                         assert.equal(results.totalCount, 9, 'results correctly stored');
                         assert.equal(

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -119,7 +119,7 @@ define([
     });
     QUnit.test('searchModal component is correctly initialized triggering initial search', function (assert) {
         const ready = assert.async();
-        assert.expect(15);
+        assert.expect(18);
 
         Promise.all([store('search'), store('selectedColumns')]).then(stores => {
             const searchStore = stores[0];
@@ -204,6 +204,21 @@ define([
                             $datatable.find('tbody tr').length,
                             9,
                             'datatable display the correct number of matches'
+                        );
+                        assert.equal(
+                            $datatable.find('tbody tr:eq(5) td.custom_prop').text().trim(),
+                            '-',
+                            'the missing column is filled with a placeholder'
+                        );
+                        assert.equal(
+                            $datatable.find('tbody tr:eq(6) td.custom_prop').text().trim(),
+                            '-',
+                            'the empty column is filled with a placeholder'
+                        );
+                        assert.equal(
+                            $datatable.find('tbody tr:eq(8) td.custom_prop').text().trim(),
+                            '-',
+                            'the column with an empty array is filled with a placeholder'
                         );
 
                         assert.equal(


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1220

### Summary

Fix a few defecs in the searchModal component:
- set the default column to `label`
- replace any empty value with the placeholder

### Details
- The default sort order can now be set by configuration, defaulted to the `label` column
- Some data come as an array, some as a string. While the datatable component can manage each variant indifferently thanks to Handlebars, it was not the case of the transform function applied to the cells. It now checks if it is an array or a string and applies preliminary cleanup to it for better detection.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)