### PR TITLE
Feature/ADF-1220/Move the columns manager link

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -519,8 +519,16 @@ export default function searchModalFactory(config) {
         // Keeping the table container introduces a DOM pollution.
         // It is faster and cleaner to recreate the container than cleaning it explicitly.
         const $tableContainer = $(resultsContainerTpl());
-        const $contentContainer = $('.content-container', $container);
-        $contentContainer.empty().append($tableContainer);
+        const $contentContainer = $('.content-area', $container).empty();
+        const $contentToolbar = $('.content-toolbar', $container).empty();
+
+        if (instance.isAdvancedSearchEnabled()) {
+            const $manageColumnsBtn = $(propertySelectButtonTpl());
+            $contentToolbar.append($manageColumnsBtn);
+            $manageColumnsBtn.on('click', handleManageColumnsBtnClick);
+        }
+
+        $contentContainer.append($tableContainer);
         $tableContainer.on('load.datatable', searchResultsLoaded);
 
         const { sortby, sortorder, page } = data.storedSearchOptions || instance.config;
@@ -576,14 +584,7 @@ export default function searchModalFactory(config) {
      * @param {object} dataset - datatable dataset
      */
     function searchResultsLoaded(e, dataset) {
-        const $actionsHeader = $('th.actions', $container);
         const { sortby, sortorder } = getTableOptions();
-
-        if (instance.isAdvancedSearchEnabled()) {
-            const $manageColumnsBtn = $(propertySelectButtonTpl());
-            $actionsHeader.append($manageColumnsBtn);
-            $manageColumnsBtn.on('click', handleManageColumnsBtnClick);
-        }
 
         if (dataset.records === 0) {
             replaceSearchResultsDatatableWithMessage('no-matches');

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -46,17 +46,6 @@ $classTreeVariables: (
         border: none;
     }
 
-    .toggle-modal-button {
-        user-select: none;
-        .icon-add {
-            font-size: 1.6rem;
-            position: relative;
-            top: 2px;
-            margin-right: 8px;
-        }
-    }
-
-
     .content-panel {
         width: 100%;
         height: 100%;
@@ -136,6 +125,27 @@ $classTreeVariables: (
         border: none;
         @include simple-flex-box();
         overflow: auto;
+    }
+
+    .content-toolbar {
+        height: 2rem;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: stretch;
+        align-content: space-around;
+    }
+    .content-area {}
+
+    .toggle-modal-button {
+        user-select: none;
+        margin: 0 2rem;
+        .icon-add {
+            font-size: 1.6rem;
+            position: relative;
+            top: 2px;
+            margin-right: 8px;
+        }
     }
 
     .content-block {
@@ -249,7 +259,7 @@ $classTreeVariables: (
     // Increasing specificity
     &.search-modal {
         max-height: 100%;
-        min-height: 320px;    
+        min-height: 320px;
         height: 100%;
         padding: 0px;
     }
@@ -341,7 +351,7 @@ $classTreeVariables: (
     }
     .content-container {
         @media screen and (min-width: 840px) {
-            padding: 64px !important;
+            padding: 44px 64px 64px;
         }
         .no-datatable-container {
             display: flex;

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -135,7 +135,6 @@ $classTreeVariables: (
         align-items: stretch;
         align-content: space-around;
     }
-    .content-area {}
 
     .toggle-modal-button {
         user-select: none;

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -132,8 +132,6 @@ $classTreeVariables: (
         display: flex;
         flex-direction: row;
         justify-content: flex-end;
-        align-items: stretch;
-        align-content: space-around;
     }
 
     .toggle-modal-button {

--- a/src/searchModal/tpl/layout.tpl
+++ b/src/searchModal/tpl/layout.tpl
@@ -20,7 +20,9 @@
                 <button class="btn-search btn-info small">{{__ "Search"}}</button>
             </div>
         </div>
-        <div class="content-container" style="padding:40px 20px">
+        <div class="content-container">
+            <div class="content-toolbar"></div>
+            <div class="content-area"></div>
         </div>
     </div>
 </div>

--- a/src/searchModal/tpl/list-checkbox-criterion.tpl
+++ b/src/searchModal/tpl/list-checkbox-criterion.tpl
@@ -4,8 +4,8 @@
     <fieldset class="filter-bool-group">
         <legend>{{criterion.label}}
             {{#if criterion.isDuplicated}}
-            {{#if criterion.alias}}<span class="criteria-alias">({{criterion.alias}})</span>{{/if}}
-            {{#if criterion.class.label}}<span class="class-path">/ {{criterion.class.label}}</span>{{/if}}
+                {{#if criterion.alias}}<span class="criteria-alias">({{criterion.alias}})</span>{{/if}}
+                {{#if criterion.class.label}}<span class="class-path">/ {{criterion.class.label}}</span>{{/if}}
             {{/if}}
         </legend>
         {{#each criterion.values}}

--- a/src/searchModal/tpl/text-criterion.tpl
+++ b/src/searchModal/tpl/text-criterion.tpl
@@ -3,8 +3,8 @@
     <label>
         <span class="filter-label-text">{{criterion.label}}
             {{#if criterion.isDuplicated}}
-            {{#if criterion.alias}}<span class="criteria-alias">({{criterion.alias}})</span>{{/if}}
-            {{#if criterion.class.label}}<span class="class-path">/ {{criterion.class.label}}</span>{{/if}}
+                {{#if criterion.alias}}<span class="criteria-alias">({{criterion.alias}})</span>{{/if}}
+                {{#if criterion.class.label}}<span class="class-path">/ {{criterion.class.label}}</span>{{/if}}
             {{/if}}
         </span>
         <input type="text">

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -249,17 +249,17 @@ define([
                 ])
                 .then(() => searchStore.setItem('results', mocks.mockedResults))
                 .then(() => {
+                    const $container = $('#testable-container');
                     advancedSearchEnabled = true;
                     const instance = searchModalFactory({
                         criterias: { search: 'example' },
                         url: '/test/searchModal/mocks/with-occurrences/search.json',
-                        renderTo: '#testable-container',
+                        renderTo: $container,
                         rootClassUri: 'http://www.tao.lu/Ontologies/TAOItem.rdf#Item'
                     });
 
                     instance.on('ready', function () {
-                        const $container = $('.search-modal');
-                        const $searchInput = $container.find('.generic-search-input');
+                        const $searchInput = $container.find('.search-modal .generic-search-input');
 
                         assert.equal(
                             $('#testable-container')[0],
@@ -271,7 +271,7 @@ define([
                     });
 
                     instance.on('datatable-loaded', function () {
-                        const $datatable = $('table.datatable');
+                        const $datatable = $container.find('table.datatable');
                         assert.equal($datatable.length, 1, 'datatable has been created');
                         assert.equal(
                             $datatable.find('thead th').length,
@@ -325,7 +325,7 @@ define([
                         );
 
                         assert.equal(
-                            $datatable.find('.toggle-modal-button').length,
+                            $container.find('.content-toolbar .toggle-modal-button').length,
                             1,
                             'The columns manager is reachable'
                         );


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1220

### Summary

Move the `manage columns` link outside of the datatable.

### Details

A toolbar has been added to the layout, with accommodation in the CSS to keep the same position as before for the datatable (padding/margin): the toolbar is shown above the table, and the table got a reduced top margin.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)