### PR TITLE
Fix/ADF-1220/default sorted column

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -486,11 +486,18 @@ export default function searchModalFactory(config) {
             sortorder = 'asc';
         }
 
+        const sortIdentifiers = [];
         data.model.forEach(column => {
+            sortIdentifiers.push(column.sortId || column.id);
             if (column.sortId && column.id === sortby) {
                 sortby = column.sortId;
             }
         });
+        if (!sortIdentifiers.includes(sortby)) {
+            // unknown sort identifier is rejected for safety
+            sortby = void 0;
+            sortorder = void 0;
+        }
 
         data.pageConfig = { sortby, sortorder, page };
 

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -478,6 +478,22 @@ export default function searchModalFactory(config) {
         //save availableColumns to memory
         availableColumns = data.settings.availableColumns;
         data.model = columnsToModel(availableColumns);
+
+        // adjust the default sorting and pagination
+        let { sortby, sortorder, page } = instance.config;
+
+        if (!sortorder || !['asc', 'desc'].includes(sortorder)) {
+            sortorder = 'asc';
+        }
+
+        data.model.forEach(column => {
+            if (column.sortId && column.id === sortby) {
+                sortby = column.sortId;
+            }
+        });
+
+        data.pageConfig = { sortby, sortorder, page };
+
         dataCache = _.cloneDeep(data);
         return data;
     }
@@ -523,7 +539,7 @@ export default function searchModalFactory(config) {
         $contentContainer.empty().append($tableContainer);
         $tableContainer.on('load.datatable', searchResultsLoaded);
 
-        const { sortby, sortorder, page } = data.storedSearchOptions || instance.config;
+        const { sortby, sortorder, page } = data.storedSearchOptions || data.pageConfig;
 
         //create datatable
         $tableContainer.datatable(

--- a/test/searchModal/mocks/mocks.json
+++ b/test/searchModal/mocks/mocks.json
@@ -3,7 +3,7 @@
         "data": [
             {
                 "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e105be08844e7d7b605384c562c",
-                "http://www.w3.org/2000/01/rdf-schema#label": "Example_8_Geo 3"
+                "label": "Example_8_Geo 3"
             }
         ],
         "readonly": [],

--- a/test/searchModal/mocks/with-no-occurrences/search.json
+++ b/test/searchModal/mocks/with-no-occurrences/search.json
@@ -4,7 +4,7 @@
         "settings": {
             "availableColumns": [
                 {
-                    "id": "http://www.w3.org/2000/01/rdf-schema#label",
+                    "id": "label",
                     "sortId": "label",
                     "label": "Label",
                     "type": "text",

--- a/test/searchModal/mocks/with-occurrences/dataset.json
+++ b/test/searchModal/mocks/with-occurrences/dataset.json
@@ -2,52 +2,52 @@
     "data": [
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e105be08844e7d7b605384c562c",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_8_Geo 3",
+            "label": "Example_8_Geo 3",
             "custom_prop": "prop of 3",
             "custom_label": "Example 8 Geo 3"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e105718c244e85299956c0fbe44",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_7_Geo 2",
+            "label": "Example_7_Geo 2",
             "custom_prop": "prop of 2",
             "custom_label": "Example 7 Geo 2"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e10523c6344be9899ba13aaa40b",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_6_Geography",
+            "label": "Example_6_Geography",
             "custom_prop": "prop of 6",
             "custom_label": "Example 6 Geography"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e104c99fb44e842eb424d8e2cfe",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_5_picasso",
+            "label": "Example_5_picasso",
             "custom_prop": "prop of 5",
             "custom_label": "Example 5 picasso"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e1047c3f044770cb9cddcde9fd8",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_4_Appearance",
+            "label": "Example_4_Appearance",
             "custom_prop": "prop of 4",
             "custom_label": "Example 4 Appearance"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e1042a87e443b57482c2ed927c8",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_3_Baudelaire",
+            "label": "Example_3_Baudelaire",
             "custom_label": "Example 3 Baudelaire"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e103c32b144a6be0cf4a640e0a4",
-            "http://www.w3.org/2000/01/rdf-schema#label": "example_2_Math",
+            "label": "example_2_Math",
             "custom_prop": ""
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e10370a44445642b4249664cd56",
-            "http://www.w3.org/2000/01/rdf-schema#label": "example_1_TAO",
+            "label": "example_1_TAO",
             "custom_prop": "TAOprop"
         },
         {
             "id": "https://tao.docker.localhost/ontologies/tao.rdf#i5f48e1031ff3e4486d4bd1f46de2c04",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Example_0_Introduction",
+            "label": "Example_0_Introduction",
             "custom_label": "Example 0 Introduction",
             "custom_prop": [" "]
         }

--- a/test/searchModal/mocks/with-occurrences/search.json
+++ b/test/searchModal/mocks/with-occurrences/search.json
@@ -4,8 +4,8 @@
         "settings": {
             "availableColumns": [
                 {
-                    "id": "http://www.w3.org/2000/01/rdf-schema#label",
-                    "sortId": "label",
+                    "id": "label",
+                    "sortId": "label.raw",
                     "label": "Label",
                     "type": "text",
                     "alias": null,

--- a/test/searchModal/test.js
+++ b/test/searchModal/test.js
@@ -65,10 +65,7 @@ define([
             const searchStore = stores[0];
             const selectedColumnsStore = stores[1];
             selectedColumnsStore
-                .setItem('http://www.tao.lu/Ontologies/TAOItem.rdf#Item', [
-                    'http://www.w3.org/2000/01/rdf-schema#label',
-                    'custom_prop'
-                ])
+                .setItem('http://www.tao.lu/Ontologies/TAOItem.rdf#Item', ['label', 'custom_prop'])
                 .then(() => searchStore.setItem('results', mocks.mockedResults))
                 .then(() => {
                     const instance = searchModalFactory({
@@ -125,11 +122,7 @@ define([
             const searchStore = stores[0];
             const selectedColumnsStore = stores[1];
             selectedColumnsStore
-                .setItem('http://www.tao.lu/Ontologies/TAOItem.rdf#Item', [
-                    'http://www.w3.org/2000/01/rdf-schema#label',
-                    'custom_prop',
-                    'custom_label'
-                ])
+                .setItem('http://www.tao.lu/Ontologies/TAOItem.rdf#Item', ['label', 'custom_prop', 'custom_label'])
                 .then(() => searchStore.setItem('results', mocks.mockedResults))
                 .then(() => {
                     const instance = searchModalFactory({
@@ -161,12 +154,12 @@ define([
                             'datatable display the correct number of columns'
                         );
                         assert.equal(
-                            $datatable.find('thead [data-sort-by="label"]').length,
+                            $datatable.find('thead [data-sort-by="label.raw"]').length,
                             1,
                             'The default column is displayed'
                         );
                         assert.equal(
-                            $datatable.find('thead [data-sort-by="label"] .alias').length,
+                            $datatable.find('thead [data-sort-by="label.raw"] .alias').length,
                             0,
                             'The default column has no alias'
                         );
@@ -242,11 +235,7 @@ define([
             const searchStore = stores[0];
             const selectedColumnsStore = stores[1];
             selectedColumnsStore
-                .setItem('http://www.tao.lu/Ontologies/TAOItem.rdf#Item', [
-                    'http://www.w3.org/2000/01/rdf-schema#label',
-                    'custom_prop',
-                    'custom_label'
-                ])
+                .setItem('http://www.tao.lu/Ontologies/TAOItem.rdf#Item', ['label', 'custom_prop', 'custom_label'])
                 .then(() => searchStore.setItem('results', mocks.mockedResults))
                 .then(() => {
                     advancedSearchEnabled = true;
@@ -279,12 +268,12 @@ define([
                             'datatable display the correct number of columns'
                         );
                         assert.equal(
-                            $datatable.find('thead [data-sort-by="label"]').length,
+                            $datatable.find('thead [data-sort-by="label.raw"]').length,
                             1,
                             'The default column is displayed'
                         );
                         assert.equal(
-                            $datatable.find('thead [data-sort-by="label"] .alias').length,
+                            $datatable.find('thead [data-sort-by="label.raw"] .alias').length,
                             0,
                             'The default column has no alias'
                         );
@@ -586,7 +575,7 @@ define([
                         const options = resolutions[2];
 
                         assert.equal(criterias.search, 'query to be stored', 'query correctly stored');
-                        assert.equal(options.sortby, 'label', 'sorted column correctly stored');
+                        assert.equal(options.sortby, 'label.raw', 'sorted column correctly stored');
                         assert.equal(options.sortorder, 'asc', 'sort order correctly stored');
                         assert.equal(results.totalCount, 9, 'results correctly stored');
                         assert.equal(


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1220

### Summary

Fix the name of the default sorted column. The default config was setting up the wrong name with respect to the internal sort applied.

### Details

The default sorted column coming from the config was not compliant with the internal sort identifier the advanced search may have.

To use the expected identifier, a mapping is performed from the default config to the right identifier thanks to the search settings returned by the server.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)