### PR TITLE
Fix/ADF-1220/broken layout

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -397,9 +397,7 @@ export default function searchModalFactory(config) {
      * build final complex query appending every filter
      */
     function buildComplexQuery() {
-        const $searchInputValue = controls.$searchInput.val().trim();
-
-        let query = $searchInputValue;
+        let query = controls.$searchInput.val().trim();
         query += advancedSearch.getAdvancedCriteriaQuery(query !== '');
 
         return query;
@@ -636,7 +634,7 @@ export default function searchModalFactory(config) {
         const available = columnsToModel(availableColumns);
 
         if (!propertySelectorInstance) {
-            const { bottom: btnBottom, right: btnRight } = $(this).get(0).getBoundingClientRect();
+            const { bottom: btnBottom, right: btnRight } = this.getBoundingClientRect();
             const { top: containerTop, right: containerRight } = $container.get(0).getBoundingClientRect();
             const position = {
                 top: btnBottom - containerTop,

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -542,14 +542,6 @@ export default function searchModalFactory(config) {
         // It is faster and cleaner to recreate the container than cleaning it explicitly.
         const $tableContainer = $(resultsContainerTpl());
         const $contentContainer = controls.$contentArea.empty();
-        const $contentToolbar = controls.$contentToolbar.empty();
-
-        if (instance.isAdvancedSearchEnabled()) {
-            const $manageColumnsBtn = $(propertySelectButtonTpl());
-            $contentToolbar.append($manageColumnsBtn);
-            $manageColumnsBtn.on('click', handleManageColumnsBtnClick);
-        }
-
         $contentContainer.append($tableContainer);
         $tableContainer.on('load.datatable', searchResultsLoaded);
 
@@ -606,6 +598,13 @@ export default function searchModalFactory(config) {
      * @param {object} dataset - datatable dataset
      */
     function searchResultsLoaded(e, dataset) {
+        const $contentToolbar = controls.$contentToolbar.empty();
+        if (instance.isAdvancedSearchEnabled()) {
+            const $manageColumnsBtn = $(propertySelectButtonTpl());
+            $contentToolbar.append($manageColumnsBtn);
+            $manageColumnsBtn.on('click', handleManageColumnsBtnClick);
+        }
+
         const { sortby, sortorder } = getTableOptions();
 
         if (dataset.records === 0) {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1220

### Summary

Fix the broken layout issue after a clear.

### Details

Once the search results were cleared, the search did not work anymore. This was due to one of the last changes, for moving the manage columns link outside of the table. The layout was reworked, but the code was still targeting the wrong selector for clearing the content, breaking the layout when a new search is done.

This is fixed thanks to a small refactor for removing the bad design with multiple inline selectors used here and there.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)