### PR TITLE
Fix/ADF-1220/ghost columns

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -84,6 +84,7 @@ export default function searchModalFactory(config) {
     let advancedSearch = null;
     let propertySelectorInstance;
     let availableColumns = [];
+    let availableIdentifiers = {};
     let selectedColumns = [];
     let dataCache;
 
@@ -475,8 +476,10 @@ export default function searchModalFactory(config) {
      */
     function buildDataModel(data) {
         //save availableColumns to memory
+        availableIdentifiers = {};
         availableColumns = data.settings.availableColumns;
         data.model = columnsToModel(availableColumns);
+        data.model.forEach(column => (availableIdentifiers[column.id] = true));
 
         // adjust the default sorting and pagination
         let { sortby, sortorder, page } = instance.config;
@@ -513,9 +516,17 @@ export default function searchModalFactory(config) {
         return selectedColumnsStore
             .getItem(rootClassUri)
             .then(storedSelectedColumnIds => {
+                selectedColumns = [];
+
                 if (storedSelectedColumnIds && storedSelectedColumnIds.length) {
-                    selectedColumns = [...storedSelectedColumnIds];
-                } else {
+                    storedSelectedColumnIds.forEach(id => {
+                        if (availableIdentifiers[id]) {
+                            selectedColumns.push(id);
+                        }
+                    });
+                }
+
+                if (!selectedColumns.length) {
                     selectedColumns = data.settings.availableColumns.reduce((acc, column) => {
                         if (column.default) {
                             acc.push(column.id);

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -381,8 +381,7 @@ export default function searchModalFactory(config) {
      * Request search results and manages its results
      */
     function search() {
-        const query = buildComplexQuery();
-        searchHandler(query, getClassFilterUri());
+        searchHandler(buildComplexQuery(), getClassFilterUri());
     }
 
     /**
@@ -512,7 +511,7 @@ export default function searchModalFactory(config) {
      */
     function filterSelectedColumns(data) {
         return selectedColumnsStore
-            .getItem(getClassFilterUri())
+            .getItem(rootClassUri)
             .then(storedSelectedColumnIds => {
                 if (storedSelectedColumnIds && storedSelectedColumnIds.length) {
                     selectedColumns = [...storedSelectedColumnIds];
@@ -657,7 +656,7 @@ export default function searchModalFactory(config) {
                     //update table
                     selectedColumns = selection;
                     const { sortby, sortorder, page } = getTableOptions();
-                    updateSelectedStore(getClassFilterUri(), { selection, sortby, sortorder, page });
+                    updateSelectedStore({ selection, sortby, sortorder, page });
                 }
             });
         } else {
@@ -694,7 +693,6 @@ export default function searchModalFactory(config) {
 
     /**
      *
-     * @param {string} classFilterUri class will be used as key
      * @param {object} update - The changed configuration
      * @param {Array<string>} update.selection - array of column ids to display
      * @param {string} update.sortby - The sorted column
@@ -702,10 +700,10 @@ export default function searchModalFactory(config) {
      * @param {number} update.page - The current page
      * @returns
      */
-    function updateSelectedStore(classFilterUri, { selection = [], sortby = 'id', sortorder = 'asc', page = 1 } = {}) {
+    function updateSelectedStore({ selection = [], sortby = 'id', sortorder = 'asc', page = 1 } = {}) {
         const storedSearchOptions = { sortby, sortorder, page };
         return selectedColumnsStore
-            .setItem(classFilterUri, selection)
+            .setItem(rootClassUri, selection)
             .then(() => instance.trigger('selected-store-updated', { storedSearchOptions }))
             .catch(e => instance.trigger('error', e));
     }

--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -628,7 +628,7 @@ export default function searchModalFactory(config) {
             options: { sortby, sortorder },
             context: context.shownStructure,
             criterias: {
-                search: controls.$searchInput.val(),
+                search: controls.$searchInput && controls.$searchInput.val(),
                 class: isResourceSelector ? _.map(resourceSelector.getSelection(), 'uri')[0] : rootClassUri,
                 advancedCriteria: advancedSearch.getState()
             }

--- a/test/searchModal/mocks/with-occurrences/search.json
+++ b/test/searchModal/mocks/with-occurrences/search.json
@@ -22,7 +22,7 @@
                     "alias": "Additional property",
                     "classLabel": "Custom properties",
                     "isDuplicated": false,
-                    "default": true,
+                    "default": false,
                     "sortable": true
                 },
                 {
@@ -33,7 +33,7 @@
                     "alias": "Custom label",
                     "classLabel": "Custom properties",
                     "isDuplicated": true,
-                    "default": true,
+                    "default": false,
                     "sortable": true
                 }
             ]


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1220

### Summary

Prevent keeping inexistent columns in the selection.
Persist the selection for the root class instead of each subclass.

### Details

Maintain internally a list of existent identifiers for the columns.
Link the selection with the root class only.

### How to test
-  compile the code
    ```sh
    npm run build:all
    ```
-  run the unit tests
    ```sh
    npm run test:keepAlive
    ```
    Open the browser at:
    - http://127.0.0.1:5400/test/searchModal/advancedSearch/test.html
    - http://127.0.0.1:5400/test/searchModal/test.html
- checkout the branch in `tao/views/node_module/@oat-sa/tao-core-ui`, and check the advanced search in TAO (you will need to also checkout the integration branches in the other repositories)