### PR TITLE
fix/AUT-2673/display-image-inline-block

### DIFF
--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -402,6 +402,15 @@ body {
         & p {
             margin-bottom: 0;
         }
+
+        & > .custom-text-box {
+            display: flex;
+            align-items: flex-end;
+        
+            & p {
+                margin-bottom: 0;
+            }
+        }
     }
 
     .txt-ctr {

--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -395,6 +395,15 @@ body {
         margin: 20px 0 20px 20px;
     }
 
+    .parent-wrap-inline > div {
+        display: flex;
+        align-items: flex-end;
+
+        & p {
+            margin-bottom: 0;
+        }
+    }
+
     .txt-ctr {
         text-align: center;
     }

--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -18,14 +18,16 @@
 
 export const FLOAT_LEFT_CLASS = 'wrap-left';
 export const FLOAT_RIGHT_CLASS = 'wrap-right';
+export const INLINE_CLASS = 'wrap-inline';
 
 export const positionFloat = function positionFloat(widget, position) {
     if (!position) {
         return;
     }
 
-    widget.$container.removeClass(`${FLOAT_LEFT_CLASS} ${FLOAT_RIGHT_CLASS}`);
-    widget.$original.removeClass(`${FLOAT_LEFT_CLASS} ${FLOAT_RIGHT_CLASS}`);
+    widget.$container.removeClass(`${FLOAT_LEFT_CLASS} ${FLOAT_RIGHT_CLASS} ${INLINE_CLASS}`);
+    widget.$original.removeClass(`${FLOAT_LEFT_CLASS} ${FLOAT_RIGHT_CLASS} ${INLINE_CLASS}`);
+    widget.$container.parents('.widget-box').removeClass(`parent-${INLINE_CLASS}`);
 
     let className;
 
@@ -37,7 +39,8 @@ export const positionFloat = function positionFloat(widget, position) {
             className = FLOAT_LEFT_CLASS;
             break;
         case 'default':
-            className = '';
+            className = INLINE_CLASS;
+            widget.$container.parents('.widget-box').addClass(`parent-${className}`);
     }
 
     // Update DOM
@@ -55,8 +58,9 @@ export const positionFloat = function positionFloat(widget, position) {
 export const initAlignment = function initAlignment(widget) {
     if (widget.element.hasClass(FLOAT_LEFT_CLASS)) {
         return positionFloat(widget, 'left');
-    }
-    if (widget.element.hasClass(FLOAT_RIGHT_CLASS)) {
+    } else if (widget.element.hasClass(FLOAT_RIGHT_CLASS)) {
         return positionFloat(widget, 'right');
+    } else {
+        return positionFloat(widget, 'default');
     }
 };


### PR DESCRIPTION
**Related to:** [AUT-2673](https://oat-sa.atlassian.net/browse/AUT-2673)

**Description:**
Display Image inline on Figure tag

**Changes:**
The Figure tag is a block tag, so the better approach is to fake the flow with CSS.
- Toggle a CSS inline class to the Figure wrapper triggered by Widget Alignment actions

**Companion PRs**
- https://github.com/oat-sa/tao-core/pull/3654
- https://github.com/oat-sa/extension-tao-itemqti/pull/2256

**How to check:**

**On Assets** 
- Create an Asset with a text block. Add in the middle of the text an image. Play with the inline panel controls of the image to check if it is positioned correctly.
- Check Preview.

**On Items**
- Repeat the previous step on Assets.
- Add the previously created Asset with the Figure image on the inline position to check the position of the Asset image inside the Item.
- Check Preview

**On Tests**
- Check Terre Preview

**Delivery Terre**
- Check a test on Delivery