### PR TITLE
fix: fix alignment of form error message

### DIFF
--- a/scss/inc/_forms.scss
+++ b/scss/inc/_forms.scss
@@ -701,7 +701,7 @@ label {
         width: 35%;
         display:inline-block;
         padding: 0 10px 0 0;
-        vertical-align: top;
+        vertical-align: bottom;
 
         &.hidden-input-label {
             width: auto;


### PR DESCRIPTION
Related to : 
https://oat-sa.atlassian.net/browse/AUT-2349
https://github.com/oat-sa/tao-core/pull/3681
https://github.com/oat-sa/extension-tao-testtaker/pull/219

Following QA comments about error message alignment.

How to test:
Change the language to German
Create a test taker
Try to save with empty fields


CURRENT RESULT:
The error message when the labels take two lines have a larger space between them and the input

EXPECTED RESULT:
There is no space, the same way as behavior in other inputs with only one line.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/60346520/207025755-ff760f4b-f7a0-4d09-8115-662ca7753cba.png">
