### PR TITLE
Fix/TR-5205/Wrong type for the pagesize

### DIFF
--- a/src/pageSizeSelector.js
+++ b/src/pageSizeSelector.js
@@ -28,7 +28,7 @@ import 'select2';
  * Default config values
  * @type {Object}
  */
-var defaults = {
+const defaults = {
     defaultSize: 25,
     options: [
         { label: '25 ' + __('items per page'), value: 25 },
@@ -47,14 +47,14 @@ var defaults = {
  * @param {Object} [config.items] - available options
  * @returns {pageSizeSelector}
  */
-var pageSizeSelectorFactory = function pageSizeSelectorFactory(config) {
-    var pageSizeSelectorSpecs = {
-        setSelectedOption: function setSelectedOption() {
-            var options = this.config.options;
-            var defaultSize = this.config.defaultSize;
+export default function pageSizeSelectorFactory(config) {
+    const pageSizeSelectorSpecs = {
+        setSelectedOption() {
+            const options = this.config.options;
+            const defaultSize = this.config.defaultSize;
 
-            var selectedOption;
-            options.forEach(function (option) {
+            let selectedOption;
+            options.forEach(option => {
                 if (option.value === defaultSize) {
                     selectedOption = option;
 
@@ -73,34 +73,25 @@ var pageSizeSelectorFactory = function pageSizeSelectorFactory(config) {
 
     return component(pageSizeSelectorSpecs, defaults)
         .setTemplate(pageSizeSelectorTpl)
-        .on('init', function () {
+        .on('init', function onInit() {
             this.setSelectedOption();
         })
-        .on('render', function () {
-            var self = this;
-            var $component = this.getElement();
-
-            $('.select2', $component)
+        .on('render', function onRender() {
+            $('.select2', this.getElement())
                 .select2({
                     dropdownCssClass: 'page-size-dropdown',
                     minimumResultsForSearch: Infinity
                 })
-                .on('change', function (e) {
-                    self.trigger('change', e.val);
+                .on('change', e => {
+                    this.trigger('change', e.val);
                 });
         })
-        .after('render', function () {
-            var $component = this.getElement();
-
+        .after('render', function afterRender() {
             // Notify about the default value after render
-            this.trigger('change', $('select', $component).val());
+            this.trigger('change', $('select', this.getElement()).val());
         })
-        .on('destroy', function () {
-            var $component = this.getElement();
-
-            $('.select2', $component).select2('destroy');
+        .on('destroy', function onDestroy() {
+            $('.select2', this.getElement()).select2('destroy');
         })
         .init(config);
-};
-
-export default pageSizeSelectorFactory;
+}

--- a/src/pageSizeSelector.js
+++ b/src/pageSizeSelector.js
@@ -51,11 +51,11 @@ export default function pageSizeSelectorFactory(config) {
     const pageSizeSelectorSpecs = {
         setSelectedOption() {
             const options = this.config.options;
-            const defaultSize = this.config.defaultSize;
+            const defaultSize = parseInt(this.config.defaultSize, 10);
 
             let selectedOption;
             options.forEach(option => {
-                if (option.value === defaultSize) {
+                if (parseInt(option.value, 10) === defaultSize) {
                     selectedOption = option;
 
                     option.selected = true;

--- a/test/pageSizeSelector/test.js
+++ b/test/pageSizeSelector/test.js
@@ -110,6 +110,24 @@ define(['jquery', 'ui/pageSizeSelector'], function ($, pageSizeSelector) {
         instance.destroy();
     });
 
+    QUnit.test('Accept option even if the defaultSize is given as a string', function (assert) {
+        var instance = pageSizeSelector({
+            renderTo: '#fixture-render-with-config',
+            options: options,
+            defaultSize: `${defaultSize}`
+        });
+        assert.expect(5);
+
+        assert.equal(typeof instance, 'object', 'The dropdown instance is an object');
+        assert.ok(instance.getElement() instanceof $, 'The dropdown instance gets a DOM element');
+        assert.equal(instance.getElement().length, 1, 'The dropdown instance gets a single element');
+
+        assert.equal(instance.getElement().find('option').length, 3, 'The selector rendered with default options');
+        assert.equal(instance.getElement().find('select').val(), '500', 'The default page size option is selected');
+
+        instance.destroy();
+    });
+
     QUnit.test('trigger change event', function (assert) {
         const ready = assert.async(2);
         const instance = pageSizeSelector({


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5205

### Summary

When setting a page size to the datatable, it is not properly set because the internal page size is read as a string.

### Details

Make sure the page size is expressed as integers so that the check before updating the selected size properly applies even if the size is given as a string.

The component has been also converted to ES6.

The actual change is made in the commit 670d4b1027c351375a8b35915fe2fffc8ec0d658

### How to test
- install the patch: `npm i`
- run the tests: `npm test`
- it can also be run in a browser: `npm run test:keepAlive`, then open http://127.0.0.1:5400/test/pageSizeSelector/test.html