### PR TITLE
Feature/TR-5209/calculator engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1419,6 +1419,31 @@
                 "minimatch": "^3.0.4"
             }
         },
+        "@oat-sa/tao-calculator": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-calculator/-/tao-calculator-0.6.0.tgz",
+            "integrity": "sha512-UW6Mb3ZRBEoiuQf7IgNtnb6KnfLTdxU0k+tkMjb8gcD10x0eKKCkhcTHsRRgN+O321CUkSlrfPZvRnGSX1pg1g==",
+            "dev": true,
+            "requires": {
+                "@oat-sa/expr-eval": "^2.1.2",
+                "decimal.js": "^10.4.3",
+                "moo": "^0.5.2"
+            },
+            "dependencies": {
+                "@oat-sa/expr-eval": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/@oat-sa/expr-eval/-/expr-eval-2.1.2.tgz",
+                    "integrity": "sha512-pGB6lctCmqsyH/q7t19EK/svj1FrdqiR7VNg2T2MyO9mQ2vcqOYPTTF5gXf+f7GJdwy7gJVHK84Nv24MmgZCDQ==",
+                    "dev": true
+                },
+                "decimal.js": {
+                    "version": "10.4.3",
+                    "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+                    "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+                    "dev": true
+                }
+            }
+        },
         "@oat-sa/tao-core-libs": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.5.1.tgz",
@@ -3967,7 +3992,7 @@
         "idb-wrapper": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.0.tgz",
-            "integrity": "sha1-Cn+yxw4OF3+RGOZHPGdTVrXmKD4=",
+            "integrity": "sha512-X9Xgu7/c/HvMMxZ+TRJQ95q8Cv7QbEBz/3+SAgYSP6HpqEJyj3cRFIXRTN1mtSZxbdKbfAXBpxwi+VSJnfaexg==",
             "dev": true
         },
         "ieee754": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "@oat-sa/expr-eval": "^1.3.1",
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
+        "@oat-sa/tao-calculator": "^0.6.0",
         "@oat-sa/tao-core-libs": "^0.5.1",
         "@oat-sa/tao-core-sdk": "^1.21.1",
         "@oat-sa/tao-core-shared-libs": "^1.4.1",

--- a/src/maths/calculator/core/board.js
+++ b/src/maths/calculator/core/board.js
@@ -19,10 +19,15 @@
  * Defines the base component that will host the calculator UI and link it to the engine.
  */
 
-import { engineFactory, historyPlugin } from '@oat-sa/tao-calculator/dist';
+import Handlebars from 'handlebars';
+import { engineFactory, historyPlugin, defaultDecimalDigits, expressionHelper } from '@oat-sa/tao-calculator/dist';
 import areaBrokerFactory from 'ui/areaBroker';
 import componentFactory from 'ui/component';
 import boardTpl from 'ui/maths/calculator/core/tpl/board';
+import termsTpl from 'ui/maths/calculator/core/tpl/terms';
+
+Handlebars.registerHelper('isArray', Array.isArray);
+Handlebars.registerPartial('ui-maths-terms', termsTpl);
 
 /**
  * Default config values
@@ -412,6 +417,21 @@ function calculatorBoardFactory($container, pluginFactories, config) {
          */
         evaluate() {
             return calculator.evaluate();
+        },
+
+        /**
+         * Renders the expression into a string
+         * @param {string|object|token[]} expression
+         * @param {number} decimals - The number of decimals to present after the dot in the last result variable.
+         * @returns {string}
+         */
+        renderExpression(expression = null, decimals = defaultDecimalDigits) {
+            const tokens = expression === null ? calculator.getTokens() : expression;
+            const variables = expressionHelper.roundAllVariables(calculator.getAllVariables(), decimals);
+            const renderedTerms = expressionHelper.nestExponents(
+                expressionHelper.render(tokens, variables, calculator.getTokenizer())
+            );
+            return termsTpl(renderedTerms);
         },
 
         /**

--- a/src/maths/calculator/core/labels.js
+++ b/src/maths/calculator/core/labels.js
@@ -13,63 +13,61 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 Open Assessment Technologies SA ;
- */
-/**
- * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ * Copyright (c) 2019-2023 Open Assessment Technologies SA ;
  */
 import __ from 'i18n';
+import { exponentLeft, exponentRight, subscriptRight, symbols, terms } from '@oat-sa/tao-calculator/dist';
 import historyUpTpl from 'ui/maths/calculator/core/tpl/historyUp';
 import historyDownTpl from 'ui/maths/calculator/core/tpl/historyDown';
 import backspaceTpl from 'ui/maths/calculator/core/tpl/backspace';
 
 export default {
     // Digits definition
-    NUM0: '0',
-    NUM1: '1',
-    NUM2: '2',
-    NUM3: '3',
-    NUM4: '4',
-    NUM5: '5',
-    NUM6: '6',
-    NUM7: '7',
-    NUM8: '8',
-    NUM9: '9',
-    DOT: '.',
-    EXP10: '\u00D710',
-    POW10: '10<sup>x</sup>',
+    NUM0: terms.NUM0.label,
+    NUM1: terms.NUM1.label,
+    NUM2: terms.NUM2.label,
+    NUM3: terms.NUM3.label,
+    NUM4: terms.NUM4.label,
+    NUM5: terms.NUM5.label,
+    NUM6: terms.NUM6.label,
+    NUM7: terms.NUM7.label,
+    NUM8: terms.NUM8.label,
+    NUM9: terms.NUM9.label,
+    DOT: terms.DOT.label,
+    EXP10: terms.EXP10.label,
+    POW10: exponentRight('10', 'x'),
 
     // Aggregators
-    LPAR: '(',
-    RPAR: ')',
+    LPAR: terms.LPAR.label,
+    RPAR: terms.RPAR.label,
 
     // Separator
-    COMMA: ',',
-    ELLIPSIS: '\u2026',
+    COMMA: terms.COMMA.label,
+    ELLIPSIS: terms.ELLIPSIS.label,
     SPACER: '',
 
     // Operators
-    SUB: '-',
-    ADD: '+',
-    POS: '\u207A',
-    NEG: '\u207B',
-    MUL: '\u00D7',
-    DIV: '\u00F7',
+    SUB: terms.SUB.label,
+    ADD: terms.ADD.label,
+    POS: terms.POS.label,
+    NEG: terms.NEG.label,
+    MUL: terms.MUL.label,
+    DIV: terms.DIV.label,
     MOD: __('modulo'),
-    POW: '^',
-    POW2: 'x<sup>2</sup>',
-    POW3: 'x<sup>3</sup>',
-    POWY: 'x<sup>y</sup>',
-    POWMINUSONE: 'x<sup>\u207B' + '1</sup>',
-    FAC: '!',
-    ASSIGN: '=',
+    POW: terms.POW.label,
+    POW2: exponentRight('x', '2'),
+    POW3: exponentRight('x', '3'),
+    POWY: exponentRight('x', 'y'),
+    POWMINUSONE: exponentRight('x', symbols.minusOne),
+    FAC: terms.FAC.label,
+    ASSIGN: terms.ASSIGN.label,
 
     // Variables
     ANS: __('Ans'),
 
     // Constants
-    PI: '\u03C0',
-    E: 'e',
+    PI: terms.PI.label,
+    E: terms.E.label,
 
     // Errors
     NAN: __('Error'),
@@ -78,10 +76,10 @@ export default {
 
     // Functions
     EXP: __('exp'),
-    EXPX: 'e<sup>x</sup>',
-    SQRT: '\u221A',
-    CBRT: '<sup>3</sup>\u221A',
-    NTHRT: '<sup>y</sup>\u221Ax',
+    EXPX: exponentRight(symbols.euler, 'x'),
+    SQRT: terms.SQRT.label,
+    CBRT: exponentLeft(symbols.squareRoot, '3'),
+    NTHRT: `${exponentLeft(symbols.squareRoot, 'y')}x`,
     FLOOR: __('floor'),
     CEIL: __('ceil'),
     ROUND: __('round'),
@@ -89,23 +87,23 @@ export default {
     SIN: __('sin'),
     COS: __('cos'),
     TAN: __('tan'),
-    ASIN: __('sin') + '<sup>\u207B1</sup>',
-    ACOS: __('cos') + '<sup>\u207B1</sup>',
-    ATAN: __('tan') + '<sup>\u207B1</sup>',
+    ASIN: exponentRight(__('sin'), symbols.minusOne),
+    ACOS: exponentRight(__('cos'), symbols.minusOne),
+    ATAN: exponentRight(__('tan'), symbols.minusOne),
     SINH: __('sinh'),
     COSH: __('cosh'),
     TANH: __('tanh'),
-    ASINH: __('sinh') + '<sup>\u207B1</sup>',
-    ACOSH: __('cosh') + '<sup>\u207B1</sup>',
-    ATANH: __('tanh') + '<sup>\u207B1</sup>',
+    ASINH: exponentRight(__('sinh'), symbols.minusOne),
+    ACOSH: exponentRight(__('cosh'), symbols.minusOne),
+    ATANH: exponentRight(__('tanh'), symbols.minusOne),
     LN: 'ln',
-    LOG: 'log<sub>10</sub>',
+    LOG: subscriptRight('log', '10'),
     ABS: __('abs'),
     RAND: __('random'),
 
     // Actions
     CLEAR: __('C'),
-    CLEARALL: __('AC'),
+    RESET: __('AC'),
     EXECUTE: '=',
     HISTORYUP: historyUpTpl(),
     HISTORYDOWN: historyDownTpl(),

--- a/src/maths/calculator/core/plugin.js
+++ b/src/maths/calculator/core/plugin.js
@@ -13,23 +13,21 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2023 Open Assessment Technologies SA ;
  */
 /**
  * Wrapper for calculator plugins factory
- * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
-import _ from 'lodash';
 import pluginFactory from 'core/plugin';
 
 /**
  * A pluginFactory configured for the calculator
- * @returns {Function} the preconfigured plugin factory
+ * @returns {Function} the pre-configured plugin factory
  */
 export default function calculatorPluginFactory(provider, defaultConfig) {
     return pluginFactory(
         provider,
-        _.defaults(
+        Object.assign(
             {
                 //alias getHost to getCalculator
                 hostName: 'calculator'

--- a/src/maths/calculator/core/tpl/terms.tpl
+++ b/src/maths/calculator/core/tpl/terms.tpl
@@ -1,1 +1,7 @@
-{{#each .}}{{#each startExponent}}<sup>{{/each}}<span class="term term-{{type}}{{#if elide}} term-elide{{/if}}" data-value="{{value}}" data-token="{{token}}" data-type="{{type}}">{{{label}}}</span>{{#each endExponent}}</sup>{{/each}}{{/each}}
+{{~#each .~}}
+{{~#if (isArray label)~}}
+    <span class="term term-{{type}}{{#if elide}} term-elide{{/if}}" data-value="{{value}}" data-token="{{token}}" data-type="{{type}}">{{~> ui-maths-terms label~}}</span>
+{{~else~}}
+    <span class="term term-{{type}}{{#if elide}} term-elide{{/if}}" data-value="{{value}}" data-token="{{token}}" data-type="{{type}}">{{{label}}}</span>
+{{~/if~}}
+{{~/each~}}

--- a/src/maths/calculator/plugins/keyboard/templateKeyboard/defaultTemplate.tpl
+++ b/src/maths/calculator/plugins/keyboard/templateKeyboard/defaultTemplate.tpl
@@ -4,7 +4,7 @@
         <button class="key operator" data-command="term" data-param="LPAR"><span>{{{labels.LPAR}}}</span></button>
         <button class="key operator" data-command="term" data-param="RPAR"><span>{{{labels.RPAR}}}</span></button>
         <button class="key command" data-command="clear"><span>{{{labels.CLEAR}}}</span></button>
-        <button class="key command" data-command="clearAll"><span>{{{labels.CLEARALL}}}</span></button>
+        <button class="key command" data-command="reset"><span>{{{labels.RESET}}}</span></button>
     </div>
     <div class="row">
         <button class="key operator" data-command="term" data-param="CBRT"><span>{{{labels.CBRT}}}</span></button>
@@ -32,6 +32,6 @@
         <button class="key operand" data-command="term" data-param="NUM0"><span>{{{labels.NUM0}}}</span></button>
         <button class="key operand" data-command="term" data-param="DOT"><span>{{{labels.DOT}}}</span></button>
         <button class="key execute" data-command="execute"><span>{{{labels.EXECUTE}}}</span></button>
-        <button class="key operator" data-command="term" data-param="ADD"><span>{{{labels.SUB}}}</span></button>
+        <button class="key operator" data-command="term" data-param="ADD"><span>{{{labels.ADD}}}</span></button>
     </div>
 </div>

--- a/src/maths/calculator/plugins/keyboard/templateKeyboard/templateKeyboard.js
+++ b/src/maths/calculator/plugins/keyboard/templateKeyboard/templateKeyboard.js
@@ -13,25 +13,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2023 Open Assessment Technologies SA ;
  */
 /**
  * Plugin that manages a keyboard for the calculator, with configurable layout.
  * Each key must declare the target command, using DOM attributes:
  * - data-command: the name of the command to call
  * - data-param: the optional parameter to apply to the command
- * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 import $ from 'jquery';
-import _ from 'lodash';
 import nsHelper from 'util/namespace';
 import pluginFactory from 'ui/maths/calculator/core/plugin';
 import labels from 'ui/maths/calculator/core/labels';
 import defaultKeyboardTpl from 'ui/maths/calculator/plugins/keyboard/templateKeyboard/defaultTemplate';
 
-var pluginName = 'templateKeyboard';
+const pluginName = 'templateKeyboard';
 
-var defaultConfig = {
+const defaultConfig = {
     layout: defaultKeyboardTpl
 };
 
@@ -42,30 +40,30 @@ export default pluginFactory(
         /**
          * Called when the plugin should be initialized.
          */
-        init: function init() {
+        init() {
             // required by the plugin factory to validate this plugin
         },
 
         /**
          * Called when the plugin should be rendered.
          */
-        render: function render() {
-            var calculator = this.getCalculator();
-            var areaBroker = calculator.getAreaBroker();
-            var pluginConfig = this.getConfig();
-            var templateConfig = _.merge({ labels: labels }, pluginConfig);
+        render() {
+            const calculator = this.getCalculator();
+            const areaBroker = calculator.getAreaBroker();
+            const pluginConfig = this.getConfig();
+            const templateConfig = Object.assign({ labels }, pluginConfig);
 
-            if (!_.isFunction(pluginConfig.layout)) {
+            if ('function' !== typeof pluginConfig.layout) {
                 throw new TypeError('The keyboard plugin requires a template to render!');
             }
 
             this.$layout = $(pluginConfig.layout(templateConfig)).on(
                 nsHelper.namespaceAll('click', pluginName),
                 '.key',
-                function() {
-                    var $key = $(this).closest('.key');
-                    var command = $key.data('command');
-                    var param = $key.data('param');
+                function onClick() {
+                    const $key = $(this).closest('.key');
+                    const command = $key.data('command');
+                    const param = $key.data('param');
                     if (command) {
                         calculator.useCommand(command, param);
                     }
@@ -78,13 +76,12 @@ export default pluginFactory(
         /**
          * Called when the plugin is destroyed. Mostly when the host is destroyed itself.
          */
-        destroy: function destroy() {
-            var calculator = this.getCalculator();
+        destroy() {
             if (this.$layout) {
-                this.$layout.off('.' + pluginName).remove();
+                this.$layout.off(`.${pluginName}`).remove();
                 this.$layout = null;
             }
-            calculator.off('.' + pluginName);
+            this.getCalculator().off(`.${pluginName}`);
         }
     },
     defaultConfig

--- a/src/maths/calculator/scss/calculator.scss
+++ b/src/maths/calculator/scss/calculator.scss
@@ -67,6 +67,19 @@
         bottom: -0.5em;
     }
 
+    [data-type='exponent'] {
+        vertical-align: super;
+        font-size: 0.75em;
+    }
+
+    [data-type='variable'] {
+        font-weight: bold;
+    }
+
+    [data-type='function']:not([data-value*='rt']) {
+        padding-right: 0.3em;
+    }
+
     .screen,
     .input {
         position: relative;

--- a/src/maths/calculator/scss/calculator.scss
+++ b/src/maths/calculator/scss/calculator.scss
@@ -354,7 +354,7 @@
                 font-weight: bold;
                 color: $calculatorScreenSpecialTxt;
             }
-            &.term-variable[data-token='ANS'] {
+            &.term-variable[data-token='VAR_ANS'] {
                 background: $calculatorScreenSpecialBg;
                 padding: 0;
                 margin: 0 #{$calculatorTermSpace * 2};

--- a/src/maths/calculator/tpl/basicKeyboard.tpl
+++ b/src/maths/calculator/tpl/basicKeyboard.tpl
@@ -2,8 +2,8 @@
     <div class="row">
         <button class="key command" data-command="historyUp"><span>{{{labels.HISTORYUP}}}</span></button>
         <button class="key command" data-command="historyDown"><span>{{{labels.HISTORYDOWN}}}</span></button>
-        <button class="key command" data-command="stepDeleteLeft"><span>{{{labels.BACKSPACE}}}</span></button>
-        <button class="key command" data-command="clear"><span>{{{labels.CLEARALL}}}</span></button>
+        <button class="key command" data-command="deleteLeft"><span>{{{labels.BACKSPACE}}}</span></button>
+        <button class="key command" data-command="clear"><span>{{{labels.RESET}}}</span></button>
     </div>
     <div class="row">
         <button class="key operator" data-command="term" data-param="LPAR"><span>{{{labels.LPAR}}}</span></button>

--- a/src/maths/calculator/tpl/scientificKeyboard.tpl
+++ b/src/maths/calculator/tpl/scientificKeyboard.tpl
@@ -6,8 +6,8 @@
         <span class="spacer">{{{labels.SPACER}}}</span>
         <button class="key command" data-command="historyUp"><span>{{{labels.HISTORYUP}}}</span></button>
         <button class="key command" data-command="historyDown"><span>{{{labels.HISTORYDOWN}}}</span></button>
-        <button class="key command" data-command="stepDeleteLeft"><span>{{{labels.BACKSPACE}}}</span></button>
-        <button class="key command" data-command="clear"><span>{{{labels.CLEARALL}}}</span></button>
+        <button class="key command" data-command="deleteLeft"><span>{{{labels.BACKSPACE}}}</span></button>
+        <button class="key command" data-command="clear"><span>{{{labels.RESET}}}</span></button>
     </div>
     <div class="row">
         <button class="key operator" data-command="term" data-param="SIN"><span>{{{labels.SIN}}}</span></button>
@@ -43,7 +43,7 @@
         <button class="key operator" data-command="term" data-param="SQRT"><span>{{{labels.SQRT}}}</span></button>
         <button class="key operator" data-command="term" data-param="CBRT"><span>{{{labels.CBRT}}}</span></button>
         <button class="key operator" data-command="term" data-param="@NTHRT"><span>{{{labels.NTHRT}}}</span></button>
-        <button class="key operator" data-command="pow10"><span>{{{labels.POW10}}}</span></button>
+        <button class="key operator" data-command="term" data-param="TEN POW"><span>{{{labels.POW10}}}</span></button>
         <button class="key operand" data-command="term" data-param="NUM1"><span>{{{labels.NUM1}}}</span></button>
         <button class="key operand" data-command="term" data-param="NUM2"><span>{{{labels.NUM2}}}</span></button>
         <button class="key operand" data-command="term" data-param="NUM3"><span>{{{labels.NUM3}}}</span></button>

--- a/test/maths/calculator/basicCalculator/test.html
+++ b/test/maths/calculator/basicCalculator/test.html
@@ -14,11 +14,14 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #ccc;
-                height: 500px;
-                width: 1000px;
+                height: 800px;
+                width: 100%;
             }
         </style>
     </head>

--- a/test/maths/calculator/calculatorComponent/test.html
+++ b/test/maths/calculator/calculatorComponent/test.html
@@ -14,11 +14,14 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #ccc;
-                height: 500px;
-                width: 1000px;
+                height: 800px;
+                width: 100%;
             }
         </style>
     </head>

--- a/test/maths/calculator/core/board/test.html
+++ b/test/maths/calculator/core/board/test.html
@@ -33,6 +33,7 @@
             <div id="fixture-usevariable"></div>
             <div id="fixture-command"></div>
             <div id="fixture-evaluate"></div>
+            <div id="fixture-renderExpression"></div>
             <div id="fixture-clear"></div>
             <div id="fixture-replace"></div>
             <div id="fixture-insert"></div>

--- a/test/maths/calculator/core/board/test.js
+++ b/test/maths/calculator/core/board/test.js
@@ -13,52 +13,39 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2023 Open Assessment Technologies SA ;
  */
-/**
- * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
- */
-define([
-    'jquery',
-    'lodash',
-    'ui/maths/calculator/core/plugin',
-    'ui/maths/calculator/core/board',
-    'ui/maths/calculator/core/terms',
-    'ui/maths/calculator/core/tokenizer'
-], function ($, _, pluginFactory, calculatorBoardFactory, registeredTerms) {
+define(['jquery', 'ui/maths/calculator/core/plugin', 'ui/maths/calculator/core/board'], function (
+    $,
+    pluginFactory,
+    calculatorBoardFactory
+) {
     'use strict';
 
-    var builtInCommands = {
-        clear: {
-            description: 'Clear expression',
-            label: 'Clear',
-            name: 'clear'
-        },
-        clearAll: {
-            description: 'Clear all data',
-            label: 'Clear All',
-            name: 'clearAll'
-        },
-        execute: {
-            description: 'Compute the expression',
-            label: 'Execute',
-            name: 'execute'
-        },
-        var: {
-            description: 'Use a variable',
-            label: 'Variable',
-            name: 'var'
-        },
-        term: {
-            description: 'Use a term',
-            label: 'Term',
-            name: 'term'
-        }
-    };
+    const builtInCommands = [
+        'clear',
+        'reset',
+        'execute',
+        'var',
+        'term',
+        'sign',
+        'degree',
+        'radian',
+        'remind',
+        'memorize',
+        'forget',
+        'moveLeft',
+        'moveRight',
+        'deleteLeft',
+        'deleteRight',
+        'historyClear',
+        'historyUp',
+        'historyDown'
+    ];
 
     QUnit.module('Factory');
 
-    QUnit.test('module', function (assert) {
+    QUnit.test('module', assert => {
         assert.expect(3);
         assert.equal(typeof calculatorBoardFactory, 'function', 'The module exposes a function');
         assert.equal(typeof calculatorBoardFactory('#fixture-api'), 'object', 'The factory produces an object');
@@ -87,16 +74,16 @@ define([
             { title: 'setTemplate' },
             { title: 'getConfig' }
         ])
-        .test('inherited API ', function (data, assert) {
-            var instance = calculatorBoardFactory('#fixture-api');
+        .test('inherited API ', (data, assert) => {
+            const instance = calculatorBoardFactory('#fixture-api');
             assert.expect(1);
             assert.equal(typeof instance[data.title], 'function', `The instance exposes a "${data.title}" function`);
         });
 
     QUnit.cases
         .init([{ title: 'on' }, { title: 'off' }, { title: 'trigger' }, { title: 'spread' }])
-        .test('event API ', function (data, assert) {
-            var instance = calculatorBoardFactory('#fixture-api');
+        .test('event API ', (data, assert) => {
+            const instance = calculatorBoardFactory('#fixture-api');
             assert.expect(1);
             assert.equal(typeof instance[data.title], 'function', `The instance exposes a "${data.title}" function`);
         });
@@ -125,7 +112,6 @@ define([
             { title: 'getCommands' },
             { title: 'setCommand' },
             { title: 'deleteCommand' },
-            { title: 'addTerm' },
             { title: 'useTerm' },
             { title: 'useTerms' },
             { title: 'useVariable' },
@@ -141,38 +127,34 @@ define([
             { title: 'setupMathsEvaluator' },
             { title: 'getMathsEvaluator' }
         ])
-        .test('calculatorBoard API ', function (data, assert) {
-            var instance = calculatorBoardFactory('#fixture-api');
+        .test('calculatorBoard API ', (data, assert) => {
+            const instance = calculatorBoardFactory('#fixture-api');
             assert.expect(1);
             assert.equal(typeof instance[data.title], 'function', `The instance exposes a "${data.title}" function`);
         });
 
     QUnit.module('Life cycle');
 
-    QUnit.test('init', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-init');
-        var initExpression = '.1+.2';
-        var instance = calculatorBoardFactory($container, null, {
-            expression: initExpression,
-            position: initExpression.length
-        });
+    QUnit.test('init', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-init');
+        const expression = '.1+.2';
+        const position = expression.length;
+        const instance = calculatorBoardFactory($container, null, { expression, position });
 
         assert.expect(3);
 
         instance
-            .after('init', function () {
+            .after('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
-                assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
+                assert.equal(this.getExpression(), expression, 'The expression is initialized');
+                assert.equal(this.getPosition(), position, 'The expression is initialized');
             })
-            .after('render', function () {
+            .after('render', function onRender() {
                 this.destroy();
             })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .on('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -180,37 +162,35 @@ define([
             });
     });
 
-    QUnit.test('render', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-render');
+    QUnit.test('render', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-render');
 
-        var plugin1 = pluginFactory({
+        const plugin1 = pluginFactory({
             name: 'plugin1',
-            install: function installPlugin() {
+            install() {
                 assert.ok(true, 'Plugin1 has been installed');
             },
-            init: function initPlugin() {
+            init() {
                 assert.ok(true, 'Plugin1 has been initialized');
             },
-            render: function renderPlugin() {
+            render() {
                 assert.ok(true, 'Plugin1 has been rendered');
             }
         });
-
-        var instance;
 
         assert.expect(17);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, [plugin1]);
+        const instance = calculatorBoardFactory($container, [plugin1]);
         instance
-            .on('init', function () {
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(typeof areaBroker, 'undefined', 'The area broker is not yet created');
             })
-            .on('ready', function () {
-                var areaBroker = this.getAreaBroker();
+            .on('ready', function onReady() {
+                const areaBroker = this.getAreaBroker();
 
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 assert.ok($container.children().first().is('.calculator'), 'The expected element is rendered');
@@ -242,7 +222,7 @@ define([
                 assert.equal(
                     areaBroker.getScreenArea().get(0),
                     $container.find('.screen').get(0),
-                    'The sreen area is rendered'
+                    'The screen area is rendered'
                 );
                 assert.equal(
                     areaBroker.getInputArea().get(0),
@@ -257,10 +237,8 @@ define([
 
                 this.destroy();
             })
-            .on('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .on('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -268,49 +246,48 @@ define([
             });
     });
 
-    QUnit.test('destroy', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-destroy');
-        var plugin1 = pluginFactory({
+    QUnit.test('destroy', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-destroy');
+        const plugin1 = pluginFactory({
             name: 'plugin1',
-            install: function installPlugin() {
+            install() {
                 assert.ok(true, 'Plugin1 has been installed');
             },
-            init: function initPlugin() {
+            init() {
                 assert.ok(true, 'Plugin1 has been initialized');
             },
-            render: function renderPlugin() {
+            render() {
                 assert.ok(true, 'Plugin1 has been rendered');
             },
-            destroy: function renderPlugin() {
+            destroy() {
                 assert.ok(true, 'Plugin1 has been destroyed');
             }
         });
-        var instance;
 
         assert.expect(11);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, [plugin1]);
+        const instance = calculatorBoardFactory($container, [plugin1]);
         instance
-            .on('init', function () {
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(typeof areaBroker, 'undefined', 'The area broker is not yet created');
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 assert.equal(typeof this.getAreaBroker(), 'object', 'The area broker is created');
 
                 this.destroy();
             })
-            .after('destroy', function () {
+            .after('destroy', function onDestroy() {
                 assert.equal($container.children().length, 0, 'The container is now empty');
                 assert.equal(this.getAreaBroker(), null, 'The area broker is destroyed');
 
                 ready();
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -320,10 +297,10 @@ define([
 
     QUnit.module('API');
 
-    QUnit.test('plugins', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-plugins');
-        var config = {
+    QUnit.test('plugins', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-plugins');
+        const config = {
             plugins: {
                 plugin1: {
                     foo: 'bar'
@@ -333,63 +310,61 @@ define([
                 }
             }
         };
-        var plugins = [
+        const plugins = [
             pluginFactory({
                 name: 'plugin1',
-                install: function installPlugin() {
+                install() {
                     assert.ok(true, 'Plugin1 has been installed');
                 },
-                init: function initPlugin() {
+                init() {
                     assert.ok(true, 'Plugin1 has been initialized');
                 },
-                render: function renderPlugin() {
+                render() {
                     assert.ok(true, 'Plugin1 has been rendered');
                 },
-                destroy: function renderPlugin() {
+                destroy() {
                     assert.ok(true, 'Plugin1 has been destroyed');
                 },
-                enable: function enablePlugin() {
+                enable() {
                     assert.ok(true, 'Plugin1 has been enabled');
                 },
-                disable: function disablePlugin() {
+                disable() {
                     assert.ok(true, 'Plugin1 has been disabled');
                 }
             }),
             pluginFactory({
                 name: 'plugin2',
-                install: function installPlugin() {
+                install() {
                     assert.ok(true, 'Plugin2 has been installed');
                 },
-                init: function initPlugin() {
+                init() {
                     assert.ok(true, 'Plugin2 has been initialized');
                 },
-                render: function renderPlugin() {
+                render() {
                     assert.ok(true, 'Plugin2 has been rendered');
                 },
-                destroy: function renderPlugin() {
+                destroy() {
                     assert.ok(true, 'Plugin2 has been destroyed');
                 },
-                enable: function enablePlugin() {
+                enable() {
                     assert.ok(true, 'Plugin2 has been enabled');
                 },
-                disable: function disablePlugin() {
+                disable() {
                     assert.ok(true, 'Plugin2 has been disabled');
                 }
             })
         ];
-        var instance;
 
         assert.expect(22);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, plugins, config);
+        const instance = calculatorBoardFactory($container, plugins, config);
         instance
-            .on('init', function () {
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
             })
-            .on('ready', function () {
-                var self = this;
+            .on('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 assert.equal(this.getPlugins().length, 2, 'Plugins are registered');
                 assert.equal(this.getPlugin('plugin1').getName(), 'plugin1', 'Plugin1 is registered');
@@ -406,29 +381,23 @@ define([
                 );
 
                 this.runPlugins('disable')
-                    .then(function () {
+                    .then(() => {
                         assert.ok(
-                            _.every(self.getPlugins(), function (plugin) {
-                                return !plugin.getState('enabled');
-                            }),
+                            this.getPlugins().every(plugin => !plugin.getState('enabled')),
                             'Plugins have been disabled'
                         );
-                        return self.runPlugins('enable');
+                        return this.runPlugins('enable');
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.ok(
-                            _.every(self.getPlugins(), function (plugin) {
-                                return plugin.getState('enabled');
-                            }),
+                            this.getPlugins().every(plugin => plugin.getState('enabled')),
                             'Plugins have been enabled'
                         );
-                        self.destroy();
+                        return this.destroy();
                     });
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -436,97 +405,90 @@ define([
             });
     });
 
-    QUnit.test('plugins - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-plugins');
-        var pluginError = new TypeError('Should break here');
-        var plugins = [
+    QUnit.test('plugins - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-plugins');
+        const pluginError = new TypeError('Should break here');
+        const plugins = [
             pluginFactory({
                 name: 'plugin1',
-                install: function installPlugin() {
+                install() {
                     assert.ok(true, 'Plugin1 has been installed');
                 },
-                init: function initPlugin() {
+                init() {
                     assert.ok(true, 'Plugin1 has been initialized');
                 },
-                render: function renderPlugin() {
+                render() {
                     throw pluginError;
                 },
-                destroy: function renderPlugin() {
+                destroy() {
                     assert.ok(true, 'Plugin1 has been destroyed');
                 }
             }),
             pluginFactory({
                 name: 'plugin2',
-                install: function installPlugin() {
+                install() {
                     assert.ok(true, 'Plugin2 has been installed');
                 },
-                init: function initPlugin() {
+                init() {
                     assert.ok(true, 'Plugin2 has been initialized');
                 },
-                render: function renderPlugin() {
+                render() {
                     assert.ok(false, 'Should not reach that point!');
                 },
-                destroy: function renderPlugin() {
+                destroy() {
                     assert.ok(true, 'Plugin2 has been destroyed');
                 }
             })
         ];
-        var instance;
 
         assert.expect(9);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, plugins);
+        const instance = calculatorBoardFactory($container, plugins);
         instance
-            .on('init', function () {
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
             })
-            .on('error', function (err) {
-                assert.equal(err, pluginError, 'The error has been catch!');
+            .on('error', function onError(err) {
+                assert.equal(err, pluginError, 'The error has been caught!');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            });
+            .after('destroy', ready);
     });
 
-    QUnit.test('expression', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-expression');
-        var instance;
+    QUnit.test('expression', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-expression');
 
         assert.expect(7);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var newExpression = '3+1';
+            .on('init', function onInit() {
+                const newExpression = '3+1';
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 this.setExpression();
                 assert.equal(this.getExpression(), '', 'The expression is still empty');
-                return new Promise(function (resolve) {
-                    self.on('expressionchange.set1', function (expression) {
-                        self.off('expressionchange.set1');
+                return new Promise(resolve => {
+                    this.on('expressionchange', expression => {
                         assert.equal(expression, newExpression, 'New expression as been provided');
-                        assert.equal(self.getExpression(), newExpression, 'New expression has been set');
+                        assert.equal(this.getExpression(), newExpression, 'New expression has been set');
                         resolve();
-                    }).setExpression(newExpression);
+                    });
+                    this.setExpression(newExpression);
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -534,53 +496,48 @@ define([
             });
     });
 
-    QUnit.test('position', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-position');
-        var instance;
+    QUnit.test('position', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-position');
 
         assert.expect(10);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var newExpression = '3+1';
-                var newPosition = 2;
+            .on('init', function onInit() {
+                const newExpression = '3+1';
+                const newPosition = 2;
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
                 this.setPosition();
                 assert.equal(this.getPosition(), 0, 'The position is still 0');
-                return new Promise(function (resolve) {
-                    self.on('positionchange.set1', function (position) {
-                        self.off('positionchange.set1');
+                return new Promise(resolve => {
+                    this.on('positionchange', position => {
+                        this.off('positionchange');
 
                         assert.equal(position, newPosition, 'New position has been provided');
-                        assert.equal(self.getPosition(), newPosition, 'New position has been set');
+                        assert.equal(this.getPosition(), newPosition, 'New position has been set');
 
-                        self.setPosition(-1);
-                        assert.equal(self.getPosition(), 0, 'Negative position has been fixed');
+                        this.setPosition(-1);
+                        assert.equal(this.getPosition(), 0, 'Negative position has been fixed');
 
-                        self.setPosition(10);
-                        assert.equal(self.getPosition(), newExpression.length, 'Too big position has been fixed');
+                        this.setPosition(10);
+                        assert.equal(this.getPosition(), newExpression.length, 'Too big position has been fixed');
 
                         resolve();
-                    })
-                        .setExpression(newExpression)
-                        .setPosition(newPosition);
+                    });
+                    this.replace(newExpression, newPosition);
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -588,20 +545,17 @@ define([
             });
     });
 
-    QUnit.test('tokens', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-tokens');
-        var instance;
+    QUnit.test('tokens', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-tokens');
 
-        assert.expect(52);
+        assert.expect(50);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var tokens;
-
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
@@ -612,8 +566,8 @@ define([
 
                 this.setExpression('(.1 + .2) * 10^8');
 
-                tokens = this.getTokens();
-                assert.ok(_.isArray(tokens), 'Got a lis of tokens');
+                let tokens = this.getTokens();
+                assert.ok(Array.isArray(tokens), 'Got a lis of tokens');
                 assert.equal(tokens.length, 12, 'Found the expected number of tokens');
                 assert.equal(tokens[0].type, 'LPAR', 'The expected term is found at position 0');
                 assert.equal(tokens[0].offset, 0, 'The expected term is found at offset 0');
@@ -662,7 +616,7 @@ define([
 
                 this.setExpression(' 3+4 *$foo + sinh 1');
                 tokens = this.getTokens();
-                assert.ok(_.isArray(tokens), 'Got a lis of terms');
+                assert.ok(Array.isArray(tokens), 'Got a lis of terms');
                 assert.equal(tokens.length, 5, 'The expression has been tokenized in 5 terms');
                 assert.equal(tokens[4].type, 'syntaxError', 'The expected error has been found');
                 assert.equal(tokens[4].offset, 6, 'The expected error has been found at offset 6');
@@ -674,18 +628,12 @@ define([
                 this.setPosition(0);
                 assert.equal(this.getTokenIndex(), 0, 'Token index at position 0 is 0');
                 assert.equal(this.getToken().type, 'NUM3', 'Token is NUM3');
-
-                this.setPosition(2);
-                assert.equal(this.getTokenIndex(), 1, 'Token index at position 2 is 1');
-                assert.equal(this.getToken().type, 'ADD', 'Token is ADD');
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -693,68 +641,72 @@ define([
             });
     });
 
-    QUnit.test('command', function (assert) {
-        var ready = assert.async();
-        var expectedCommand = {
-            name: 'FOO',
-            label: 'bar',
-            description: 'Command FOO bar'
-        };
-        var $container = $('#fixture-command');
-        var instance;
+    QUnit.test('command', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-command');
+        const commandName = 'FOO';
+        const commandAction = () => {};
 
-        assert.expect(14);
+        assert.expect(15);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
-                return new Promise(function (resolve) {
-                    assert.equal(typeof self.getCommand('FOO'), 'undefined', 'The command FOO does not exist');
-                    assert.ok(!self.hasCommand('FOO'), 'The command FOO is not registered');
-                    assert.deepEqual(self.getCommands(), builtInCommands, 'Only builtin commands registered');
-                    self.on('commandadd', function (name) {
-                        assert.equal(name, 'FOO', 'Command FOO added');
-                        assert.ok(self.hasCommand('FOO'), 'The command FOO is now registered');
+                return new Promise(resolve => {
+                    assert.equal(
+                        typeof this.getCommand(commandName),
+                        'undefined',
+                        `The command ${commandName} does not exist`
+                    );
+                    assert.ok(!this.hasCommand(commandName), `The command ${commandName} is not registered`);
+                    assert.deepEqual(
+                        Object.keys(this.getCommands()),
+                        builtInCommands,
+                        'Only builtin commands registered'
+                    );
+                    this.on('command', name => {
+                        assert.equal(name, commandName, `Command ${commandName} called`);
+                    });
+                    this.on('commandadd', name => {
+                        assert.equal(name, commandName, `Command ${commandName} added`);
+                        assert.ok(this.hasCommand(commandName), `The command ${commandName} is now registered`);
                         assert.deepEqual(
-                            self.getCommand('FOO'),
-                            expectedCommand,
-                            'A descriptor is defined for command FOO'
+                            this.getCommand(commandName),
+                            commandAction,
+                            `A descriptor is defined for command ${commandName}`
                         );
                         assert.deepEqual(
-                            self.getCommands(),
-                            _.merge({ FOO: expectedCommand }, builtInCommands),
+                            Object.keys(this.getCommands()),
+                            [...builtInCommands, commandName],
                             'Can get the list of registered commands'
                         );
+                    });
+                    this.on('commanddelete', name => {
+                        assert.equal(name, commandName, `Command ${commandName} deleted`);
+                        assert.equal(
+                            typeof this.getCommand(commandName),
+                            'undefined',
+                            `The command ${commandName} does not exist anymore`
+                        );
+                        assert.ok(!this.hasCommand(commandName), `The command ${commandName} is not registered`);
 
-                        self.deleteCommand('FOO');
-                    })
-                        .on('commanddelete', function (name) {
-                            assert.equal(name, 'FOO', 'Command FOO deleted');
-                            assert.equal(
-                                typeof self.getCommand('FOO'),
-                                'undefined',
-                                'The command FOO does not exist anymore'
-                            );
-                            assert.ok(!self.hasCommand('FOO'), 'The command FOO is not registered');
-
-                            resolve();
-                        })
-                        .setCommand(expectedCommand.name, expectedCommand.label, expectedCommand.description);
+                        resolve();
+                    });
+                    this.setCommand(commandName, commandAction);
+                    this.useCommand(commandName);
+                    this.deleteCommand(commandName);
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -762,62 +714,78 @@ define([
             });
     });
 
-    QUnit.test('variable', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-variable');
-        var instance;
+    QUnit.test('variable', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-variable');
+        const variableName = 'x';
+        const variableValue = '42';
 
         assert.expect(17);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
-                return new Promise(function (resolve) {
-                    assert.ok(!self.hasVariable('x'), 'The variable x is not registered');
-                    assert.equal(typeof self.getVariable('x'), 'undefined', 'The variable x does not exist');
-                    self.on('variableadd', function (name, value) {
-                        assert.equal(name, 'x', 'Variable x added');
-                        assert.equal(typeof value, 'object', 'Value descriptor of variable x provided');
-                        assert.equal(value.expression, '42', 'Expression of variable x provided');
-                        assert.equal(value.value, '42', 'Value of variable x provided');
-                        assert.equal(typeof self.getVariable('x'), 'object', 'The variable now x exists');
+                return new Promise(resolve => {
+                    assert.ok(!this.hasVariable(variableName), `The variable ${variableName} is not registered`);
+                    assert.equal(
+                        typeof this.getVariable(variableName),
+                        'undefined',
+                        `The variable ${variableName} does not exist`
+                    );
+                    this.on('variableadd', (name, value) => {
+                        assert.equal(name, variableName, `Variable ${variableName} added`);
+                        assert.equal(typeof value, 'object', `Value descriptor of variable ${variableName} provided`);
                         assert.equal(
-                            self.getVariable('x').expression,
-                            '42',
-                            'The expression of variable x is available'
+                            value.expression,
+                            variableValue,
+                            `Expression of variable ${variableName} provided`
                         );
-                        assert.equal(self.getVariable('x').value, '42', 'The value of variable x is available');
-                        assert.ok(self.hasVariable('x'), 'The variable x is registered');
+                        assert.equal(value.value, variableValue, `Value of variable ${variableName} provided`);
+                        assert.equal(
+                            typeof this.getVariable(variableName),
+                            'object',
+                            `The variable now ${variableName} exists`
+                        );
+                        assert.equal(
+                            this.getVariable(variableName).expression,
+                            variableValue,
+                            `The expression of variable ${variableName} is available`
+                        );
+                        assert.equal(
+                            this.getVariable(variableName).value,
+                            variableValue,
+                            `The value of variable ${variableName} is available`
+                        );
+                        assert.ok(this.hasVariable(variableName), `The variable ${variableName} is registered`);
+                    });
+                    this.on('variabledelete', name => {
+                        assert.equal(name, variableName, `Variable ${variableName} deleted`);
+                        assert.equal(
+                            typeof this.getVariable(variableName),
+                            'undefined',
+                            `The variable ${variableName} does not exist anymore`
+                        );
+                        assert.ok(
+                            !this.hasVariable(variableName),
+                            `The variable ${variableName} is not registered anymore`
+                        );
 
-                        self.deleteVariable('x');
-                    })
-                        .on('variabledelete', function (name) {
-                            assert.equal(name, 'x', 'Variable x deleted');
-                            assert.equal(
-                                typeof self.getVariable('x'),
-                                'undefined',
-                                'The variable x does not exist anymore'
-                            );
-                            assert.ok(!self.hasVariable('x'), 'The variable x is not registered anymore');
-
-                            resolve();
-                        })
-                        .setVariable('x', '42');
+                        resolve();
+                    });
+                    this.setVariable(variableName, variableValue);
+                    this.deleteVariable(variableName);
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -825,221 +793,100 @@ define([
             });
     });
 
-    QUnit.test('variables', function (assert) {
-        var noop;
-        var ready = assert.async();
-        var defaultVariables = {
+    QUnit.test('variables', assert => {
+        const ready = assert.async();
+        const defaultVariables = {
             ans: {
                 expression: '0',
                 result: 0,
                 value: 0,
-                variables: noop
+                variables: void 0
+            },
+            mem: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
             }
         };
-        var expectedVariables = {
+        const expectedVariables = {
             foo: 'bar',
             x: '42',
             y: '3'
         };
-        var expectedResults = {
+        const expectedResults = {
             ans: {
                 expression: '0',
                 result: 0,
                 value: 0,
-                variables: noop
+                variables: void 0
+            },
+            mem: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
             },
             foo: {
                 expression: 'bar',
                 result: 0,
                 value: 0,
-                variables: noop
+                variables: void 0
             },
             x: {
                 expression: '42',
                 result: 42,
                 value: 42,
-                variables: noop
+                variables: void 0
             },
             y: {
                 expression: '3',
                 result: 3,
                 value: 3,
-                variables: noop
+                variables: void 0
             }
         };
-        var $container = $('#fixture-variables');
-        var instance;
+        const $container = $('#fixture-variables');
 
-        assert.expect(20);
+        assert.expect(17);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var addedVariables = 0;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
-                return new Promise(function (resolve) {
-                    assert.deepEqual(self.getVariables(), defaultVariables, 'Only default variables set for now');
-                    self.on('variableadd.set', function (name, value) {
+                return new Promise(resolve => {
+                    assert.deepEqual(this.getVariables(), defaultVariables, 'Only default variables set for now');
+                    this.on('variableadd.set', (name, value) => {
                         assert.equal(typeof expectedVariables[name], 'string', `Variable ${name} added`);
                         assert.equal(value.expression, expectedVariables[name], `Value of variable ${name} provided`);
                         assert.equal(
-                            self.getVariable(name).expression,
+                            this.getVariable(name).expression,
                             expectedVariables[name],
                             `The variable ${name} now exists`
                         );
-
-                        if (++addedVariables >= _.size(expectedVariables)) {
-                            assert.deepEqual(self.getVariables(), expectedResults, 'All expected variables now set');
-                            self.deleteVariables();
-                        }
-                    })
-                        .on('variabledelete', function (name) {
-                            self.off('.set');
-                            assert.equal(name, null, 'Variables deleted');
-                            assert.deepEqual(self.getVariables(), {}, 'No variable set anymore');
-
-                            self.on('variableadd.reset', function (varName, value) {
-                                self.off('.reset');
-                                assert.equal(varName, registeredTerms.ANS.value, 'Variable ans added');
-                                assert.equal(value.expression, '0', 'Variable ans reset');
-                                assert.equal(self.getVariable(varName).expression, '0', 'The variable ans now exists');
-
-                                resolve();
-                            });
-                        })
-                        .setVariables(expectedVariables);
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('addTerm - success', function (assert) {
-        var ready = assert.async();
-        var expectedTermName = 'FOO';
-        var expectedTerm = {
-            label: 'Foo',
-            value: 'bar'
-        };
-        var $container = $('#fixture-addterm');
-        var instance;
-
-        assert.expect(13);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-                assert.equal(this.getPosition(), 0, 'The position is at the beginning');
-
-                return new Promise(function (resolve) {
-                    self.on('termadd-FOO.test', function (term1) {
-                        self.off('termadd-FOO.test');
-
-                        assert.ok(true, 'The term FOO has been received');
-                        assert.equal(term1, expectedTerm, 'The right term has been added');
-                        assert.equal(self.getExpression(), expectedTerm.value, 'Expression has been properly updated');
-                        assert.equal(self.getPosition(), expectedTerm.value.length, 'New position has been set');
-                    })
-                        .on('termadd.test', function (n1, term1) {
-                            self.off('termadd.test');
-
-                            assert.equal(n1, expectedTermName, 'The right term has been received');
-                            assert.equal(term1, expectedTerm, 'The right term has been added');
-                            assert.equal(
-                                self.getExpression(),
-                                expectedTerm.value,
-                                'Expression has been properly updated'
-                            );
-                            assert.equal(self.getPosition(), expectedTerm.value.length, 'New position has been set');
-
-                            resolve();
-                        })
-                        .addTerm(expectedTermName, expectedTerm);
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error termerror', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('addTerm - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-addterm');
-        var instance;
-
-        assert.expect(6);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-
-                return new Promise(function (resolve) {
-                    self.on('termadd.test', function () {
-                        self.off('termadd.test');
-
-                        assert.ok(false, 'The term should not be added!');
+                    });
+                    this.on('variableclear', name => {
+                        this.off('.set');
+                        assert.equal(name, null, 'Variables deleted');
+                        assert.deepEqual(this.getVariables(), {}, 'No variable set anymore');
 
                         resolve();
-                    })
-                        .on('termerror.test', function (err) {
-                            self.off('termerror.test');
+                    });
+                    this.setVariables(expectedVariables);
 
-                            assert.ok(err instanceof TypeError, 'An error is triggered: the term is invalid');
-
-                            self.on('termerror.test', function (typeErr) {
-                                self.off('termerror.test');
-
-                                assert.ok(typeErr instanceof TypeError, 'An error is triggered: the term is invalid');
-
-                                resolve();
-                            }).addTerm('FOO', {});
-                        })
-                        .addTerm('FOO', 'BAR');
+                    assert.deepEqual(this.getVariables(), expectedResults, 'All expected variables now set');
+                    this.deleteVariables();
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -1047,396 +894,48 @@ define([
             });
     });
 
-    QUnit.test('useTerm - success', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-useterm');
-        var instance;
+    QUnit.test('useTerm - success', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-useterm');
 
-        assert.expect(36);
+        assert.expect(22);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-
-                return new Promise(function (resolve) {
-                    self.on('termadd-NUM2.test', function (term) {
-                        self.off('termadd-NUM2.test');
-
-                        assert.ok(true, 'The term NUM2 has been added');
-                        assert.equal(
-                            term,
-                            registeredTerms.NUM2,
-                            'The right term descriptor has been received for NUM2'
-                        );
-                    })
-                        .on('termadd-NUM4.test', function (term) {
-                            self.off('termadd-NUM4.test');
-
-                            assert.ok(true, 'The term NUM4 has been added');
-                            assert.equal(
-                                term,
-                                registeredTerms.NUM4,
-                                'The right term descriptor has been received for NUM4'
-                            );
-                        })
-                        .on('termadd-SUB.test', function (term) {
-                            self.off('termadd-SUB.test');
-
-                            assert.ok(true, 'The term SUB has been added');
-                            assert.equal(
-                                term,
-                                registeredTerms.SUB,
-                                'The right term descriptor has been received for SUB'
-                            );
-                        })
-                        .on('termadd-SIN.test', function (term) {
-                            self.off('termadd-SIN.test');
-
-                            assert.ok(true, 'The term SIN has been added');
-                            assert.equal(
-                                term,
-                                registeredTerms.SIN,
-                                'The right term descriptor has been received for SIN'
-                            );
-                        })
-                        .on('termadd.NUM4', function (n1, term1) {
-                            self.off('termadd.NUM4');
-
-                            assert.equal(n1, 'NUM4', 'The term NUM4 has been received');
-                            assert.equal(term1, registeredTerms.NUM4, 'The term NUM4 has been added');
-                            assert.equal(self.getExpression(), '4', 'Expression has been properly updated');
-                            assert.equal(self.getPosition(), 1, 'New position has been set');
-
-                            self.on('termadd.NUM2', function (n2, term2) {
-                                self.off('termadd.NUM2');
-
-                                assert.equal(n2, 'NUM2', 'The term NUM2 has been received');
-                                assert.equal(term2, registeredTerms.NUM2, 'The term NUM2 has been added');
-                                assert.equal(self.getExpression(), '42', 'Expression has been properly updated');
-                                assert.equal(self.getPosition(), 2, 'New position has been set');
-
-                                self.on('termadd.SUB', function (n3, term3) {
-                                    self.off('termadd.SUB');
-
-                                    assert.equal(n3, 'SUB', 'The term SUB has been received');
-                                    assert.equal(term3, registeredTerms.SUB, 'The term SUB has been added');
-                                    assert.equal(self.getExpression(), '-42', 'Expression has been properly updated');
-                                    assert.equal(self.getPosition(), 1, 'New position has been set');
-
-                                    self.on('termadd.SIN', function (n4, term4) {
-                                        self.off('termadd.SIN');
-
-                                        assert.equal(n4, 'SIN', 'The term SIN has been received');
-                                        assert.equal(term4, registeredTerms.SIN, 'The term SIN has been added');
-                                        assert.equal(
-                                            self.getExpression(),
-                                            'sin -42',
-                                            'Expression has been properly updated'
-                                        );
-                                        assert.equal(self.getPosition(), 4, 'New position has been set');
-
-                                        self.on('termadd.NTHRT', function (n5, term5) {
-                                            self.off('termadd.NTHRT');
-
-                                            assert.equal(n5, 'NTHRT', 'The term NTHRT has been received');
-                                            assert.deepEqual(
-                                                term5,
-                                                _.defaults({ value: '@nthrt' }, registeredTerms.NTHRT),
-                                                'The term NTHRT has been added'
-                                            );
-                                            assert.equal(
-                                                self.getExpression(),
-                                                '@nthrt sin -42',
-                                                'Expression has been properly updated'
-                                            );
-                                            assert.equal(self.getPosition(), 7, 'New position has been set');
-
-                                            self.on('termadd.NUM4', function (n6, term6) {
-                                                self.off('termadd.NUM4');
-
-                                                assert.equal(n6, 'NUM4', 'The term NUM4 has been received');
-                                                assert.deepEqual(
-                                                    term6,
-                                                    registeredTerms.NUM4,
-                                                    'The term NUM4 has been added'
-                                                );
-                                                assert.equal(
-                                                    self.getExpression(),
-                                                    '4 @nthrt sin -42',
-                                                    'Expression has been properly updated'
-                                                );
-                                                assert.equal(self.getPosition(), 2, 'New position has been set');
-
-                                                resolve();
-                                            })
-                                                .setPosition(0)
-                                                .useTerm('NUM4');
-                                        })
-                                            .setPosition(0)
-                                            .useTerm('@NTHRT');
-                                    })
-                                        .setPosition(0)
-                                        .useTerm('SIN');
-                                })
-                                    .setPosition(0)
-                                    .useTerm('SUB');
-                            }).useTerm('NUM2');
-                        })
-                        .useTerm('NUM4');
-                });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error termerror', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
 
-    QUnit.test('useTerm - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-useterm');
-        var instance;
-
-        assert.expect(11);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
 
-                return new Promise(function (resolve) {
-                    self.on('termadd.NUM4', function (name, term) {
-                        self.off('termadd.NUM4');
-
-                        assert.equal(name, 'NUM4', 'The term NUM4 has been received');
-                        assert.equal(term, registeredTerms.NUM4, 'The term NUM4 has been added');
-                        assert.equal(self.getExpression(), '4', 'Expression has been properly updated');
-                        assert.equal(self.getPosition(), 1, 'New position has been set');
-
-                        self.on('termadd.foo', function (n) {
-                            self.off('termadd.foo');
-
-                            assert.equal(n, 'foo', 'The term foo has been received');
-                            assert.ok(false, 'The term foo should not be added!');
-
+                const assertTerm = (term, position, expression) =>
+                    new Promise(resolve => {
+                        this.on(`termadd-${term}`, () => {
+                            this.off(`termadd-${term}`);
+                            assert.ok(true, `The term ${term} has been added`);
+                            assert.equal(this.getExpression(), expression, `The expression is ${expression}`);
+                            assert.equal(this.getPosition(), position, `The position is ${position}`);
                             resolve();
-                        })
-                            .on('termerror.foo', function (e) {
-                                self.off('.foo');
-
-                                assert.ok(e instanceof TypeError, 'The term foo cannot be added');
-                                assert.equal(self.getExpression(), '4', 'Expression did not change');
-                                assert.equal(self.getPosition(), 1, 'Position did not change');
-
-                                resolve();
-                            })
-                            .useTerm('foo');
-                    }).useTerm('NUM4');
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('useTerms - success', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-useterms');
-        var instance;
-
-        assert.expect(41);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
+                        });
+                        this.useTerm(term);
+                    });
 
                 return Promise.resolve()
-                    .then(function () {
-                        self.clear();
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        return new Promise(function (resolve) {
-                            self.on('termadd-NUM4.test', function (term) {
-                                self.off('termadd-NUM4.test');
-
-                                assert.ok(true, 'The term NUM4 has been added');
-                                assert.equal(
-                                    term,
-                                    registeredTerms.NUM4,
-                                    'The right term descriptor has been received for NUM4'
-                                );
-                            })
-                                .on('termadd-SUB.test', function (term) {
-                                    self.off('termadd-SUB.test');
-
-                                    assert.ok(true, 'The term SUB has been added');
-                                    assert.equal(
-                                        term,
-                                        registeredTerms.SUB,
-                                        'The right term descriptor has been received for SUB'
-                                    );
-                                })
-                                .on('termadd-NUM2.test', function (term) {
-                                    self.off('termadd-NUM2.test');
-
-                                    assert.ok(true, 'The term NUM2 has been added');
-                                    assert.equal(
-                                        term,
-                                        registeredTerms.NUM2,
-                                        'The right term descriptor has been received for NUM2'
-                                    );
-                                })
-                                .on('termadd.NUM4', function (n1, term1) {
-                                    self.off('termadd.NUM4');
-
-                                    assert.equal(n1, 'NUM4', 'The term NUM4 has been received');
-                                    assert.equal(term1, registeredTerms.NUM4, 'The term NUM4 has been added');
-                                    assert.equal(self.getExpression(), '4', 'Expression has been properly updated');
-                                    assert.equal(self.getPosition(), 1, 'New position has been set');
-
-                                    self.on('termadd.SUB', function (n2, term2) {
-                                        self.off('termadd.SUB');
-
-                                        assert.equal(n2, 'SUB', 'The term SUB has been received');
-                                        assert.equal(term2, registeredTerms.SUB, 'The term SUB has been added');
-                                        assert.equal(
-                                            self.getExpression(),
-                                            '4-',
-                                            'Expression has been properly updated'
-                                        );
-                                        assert.equal(self.getPosition(), 2, 'New position has been set');
-
-                                        self.on('termadd.NUM2', function (n3, term3) {
-                                            self.off('termadd.NUM2');
-
-                                            assert.equal(n3, 'NUM2', 'The term NUM2 has been received');
-                                            assert.equal(term3, registeredTerms.NUM2, 'The term NUM2 has been added');
-                                            assert.equal(
-                                                self.getExpression(),
-                                                '4-2',
-                                                'Expression has been properly updated'
-                                            );
-                                            assert.equal(self.getPosition(), 3, 'New position has been set');
-
-                                            resolve();
-                                        });
-                                    });
-                                })
-                                .useTerms('NUM4 SUB NUM2');
-                        });
-                    })
-                    .then(function () {
-                        self.clear();
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        return new Promise(function (resolve) {
-                            self.on('termadd-NUM3.test', function (term) {
-                                self.off('termadd-NUM3.test');
-
-                                assert.ok(true, 'The term NUM3 has been added');
-                                assert.equal(
-                                    term,
-                                    registeredTerms.NUM3,
-                                    'The right term descriptor has been received for NUM3'
-                                );
-                            })
-                                .on('termadd-ADD.test', function (term) {
-                                    self.off('termadd-ADD.test');
-
-                                    assert.ok(true, 'The term ADD has been added');
-                                    assert.equal(
-                                        term,
-                                        registeredTerms.ADD,
-                                        'The right term descriptor has been received for ADD'
-                                    );
-                                })
-                                .on('termadd-NUM5.test', function (term) {
-                                    self.off('termadd-NUM5.test');
-
-                                    assert.ok(true, 'The term NUM5 has been added');
-                                    assert.equal(
-                                        term,
-                                        registeredTerms.NUM5,
-                                        'The right term descriptor has been received for NUM5'
-                                    );
-                                })
-                                .on('termadd.NUM3', function (n1, term1) {
-                                    self.off('termadd.NUM3');
-
-                                    assert.equal(n1, 'NUM3', 'The term NUM3 has been received');
-                                    assert.equal(term1, registeredTerms.NUM3, 'The term NUM3 has been added');
-                                    assert.equal(self.getExpression(), '3', 'Expression has been properly updated');
-                                    assert.equal(self.getPosition(), 1, 'New position has been set');
-
-                                    self.on('termadd.ADD', function (n2, term2) {
-                                        self.off('termadd.ADD');
-
-                                        assert.equal(n2, 'ADD', 'The term ADD has been received');
-                                        assert.equal(term2, registeredTerms.ADD, 'The term ADD has been added');
-                                        assert.equal(
-                                            self.getExpression(),
-                                            '3+',
-                                            'Expression has been properly updated'
-                                        );
-                                        assert.equal(self.getPosition(), 2, 'New position has been set');
-
-                                        self.on('termadd.NUM5', function (n3, term3) {
-                                            self.off('termadd.NUM5');
-
-                                            assert.equal(n3, 'NUM5', 'The term NUM5 has been received');
-                                            assert.equal(term3, registeredTerms.NUM5, 'The term NUM5 has been added');
-                                            assert.equal(
-                                                self.getExpression(),
-                                                '3+5',
-                                                'Expression has been properly updated'
-                                            );
-                                            assert.equal(self.getPosition(), 3, 'New position has been set');
-
-                                            resolve();
-                                        });
-                                    });
-                                })
-                                .useTerms(['NUM3', 'ADD', 'NUM5']);
-                        });
-                    });
+                    .then(() => assertTerm('NUM3', 1, '3'))
+                    .then(() => assertTerm('ADD', 2, '3+'))
+                    .then(() => assertTerm('SIN', 5, '3+sin'))
+                    .then(() => assertTerm('NUM4', 7, '3+sin 4'))
+                    .then(() => assertTerm('NUM2', 8, '3+sin 42'))
+                    .then(() => this.setPosition(6))
+                    .then(() => assertTerm('SUB', 7, '3+sin -42'))
+                    .then(() => this.destroy());
             })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error termerror', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -1444,469 +943,468 @@ define([
             });
     });
 
-    QUnit.test('useTerms - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-useterms');
-        var instance;
-
-        assert.expect(19);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-
-                return Promise.resolve()
-                    .then(function () {
-                        self.clear();
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        return new Promise(function (resolve) {
-                            self.on('termadd.NUM4', function (name, term) {
-                                self.off('termadd.NUM4');
-
-                                assert.equal(name, 'NUM4', 'The term NUM4 has been received');
-                                assert.equal(term, registeredTerms.NUM4, 'The term NUM4 has been added');
-                                assert.equal(self.getExpression(), '4', 'Expression has been properly updated to 4');
-                                assert.equal(self.getPosition(), 1, 'Position has been set to 1');
-
-                                self.on('termadd.foo', function (n) {
-                                    self.off('termadd.foo');
-
-                                    assert.equal(n, 'foo', 'The term foo has been received');
-                                    assert.ok(false, 'The term foo should not be added!');
-
-                                    resolve();
-                                }).on('termerror.foo', function (e) {
-                                    self.off('.foo');
-
-                                    assert.ok(e instanceof TypeError, 'The term foo cannot be added');
-                                    assert.equal(self.getExpression(), '4', 'Expression did not change');
-                                    assert.equal(self.getPosition(), 1, 'Position did not change');
-
-                                    resolve();
-                                });
-                            }).useTerms('NUM4 foo');
-                        });
-                    })
-                    .then(function () {
-                        self.clear();
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        return new Promise(function (resolve) {
-                            self.on('termadd.NUM2', function (name, term) {
-                                self.off('termadd.NUM2');
-
-                                assert.equal(name, 'NUM2', 'The term NUM2 has been received');
-                                assert.equal(term, registeredTerms.NUM2, 'The term NUM2 has been added');
-                                assert.equal(self.getExpression(), '2', 'Expression has been properly updated to 2');
-                                assert.equal(self.getPosition(), 1, 'Position has been set to 1');
-
-                                self.on('termadd.bar', function (n) {
-                                    self.off('termadd.bar');
-
-                                    assert.equal(n, 'bar', 'The term bar has been received');
-                                    assert.ok(false, 'The term bar should not be added!');
-
-                                    resolve();
-                                }).on('termerror.bar', function (e) {
-                                    self.off('.bar');
-
-                                    assert.ok(e instanceof TypeError, 'The term bar cannot be added');
-                                    assert.equal(self.getExpression(), '2', 'Expression did not change');
-                                    assert.equal(self.getPosition(), 1, 'Position did not change');
-
-                                    resolve();
-                                });
-                            }).useTerms(['NUM2', 'bar']);
-                        });
-                    });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('useVariable - success', function (assert) {
-        var noop;
-        var ready = assert.async();
-        var defaultVariables = {
-            ans: {
-                expression: '0',
-                result: 0,
-                value: 0,
-                variables: noop
-            }
-        };
-        var expectedVariables = {
-            foo: 'bar',
-            x: '42',
-            y: '3'
-        };
-        var expectedResults = {
-            ans: {
-                expression: '0',
-                result: 0,
-                value: 0,
-                variables: noop
-            },
-            foo: {
-                expression: 'bar',
-                result: 0,
-                value: 0,
-                variables: noop
-            },
-            x: {
-                expression: '42',
-                result: 42,
-                value: 42,
-                variables: noop
-            },
-            y: {
-                expression: '3',
-                result: 3,
-                value: 3,
-                variables: noop
-            }
-        };
-        var $container = $('#fixture-usevariable');
-        var instance;
-
-        assert.expect(35);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-                assert.deepEqual(self.getVariables(), defaultVariables, 'Only default variables set for now');
-
-                self.setVariables(expectedVariables);
-                assert.deepEqual(self.getVariables(), expectedResults, 'All expected variables now set');
-
-                return new Promise(function (resolve) {
-                    self.on('termadd-VAR_X.test', function (term) {
-                        self.off('termadd-VAR_X.test');
-
-                        assert.ok(true, 'The term VAR_X has been added');
-                        assert.equal(typeof term, 'object', 'A term has been added');
-                        assert.equal(term.label, 'x', 'The expected term has been added');
-                        assert.equal(term.value, 'x', 'The expected term value has been added');
-                    })
-                        .on('termadd-VAR_Y.test', function (term) {
-                            self.off('termadd-VAR_Y.test');
-
-                            assert.ok(true, 'The term VAR_Y has been added');
-                            assert.equal(typeof term, 'object', 'A term has been added');
-                            assert.equal(term.label, 'y', 'The expected term has been added');
-                            assert.equal(term.value, 'y', 'The expected term value has been added');
-                        })
-                        .on('termadd-VAR_FOO.test', function (term) {
-                            self.off('termadd-VAR_FOO.test');
-
-                            assert.ok(true, 'The term VAR_FOO has been added');
-                            assert.equal(typeof term, 'object', 'A term has been added');
-                            assert.equal(term.label, 'foo', 'The expected term has been added');
-                            assert.equal(term.value, 'foo', 'The expected term value has been added');
-                        })
-                        .on('termadd.VAR_X', function (n1, term1) {
-                            self.off('termadd.VAR_X');
-
-                            assert.equal(n1, 'VAR_X', 'The right term has been received');
-                            assert.equal(typeof term1, 'object', 'A term has been added');
-                            assert.equal(term1.label, 'x', 'The expected term has been added');
-                            assert.equal(term1.value, 'x', 'The expected term value has been added');
-                            assert.equal(self.getExpression(), 'x', 'Expression has been properly updated');
-                            assert.equal(self.getPosition(), 1, 'New position has been set');
-
-                            self.on('termadd.VAR_Y', function (n2, term2) {
-                                self.off('termadd.VAR_Y');
-
-                                assert.equal(n2, 'VAR_Y', 'The right term has been received');
-                                assert.equal(typeof term2, 'object', 'A term has been added');
-                                assert.equal(term2.label, 'y', 'The expected term has been added');
-                                assert.equal(term2.value, 'y', 'The expected term value has been added');
-                                assert.equal(self.getExpression(), 'x y', 'Expression has been properly updated');
-                                assert.equal(self.getPosition(), 3, 'New position has been set');
-
-                                self.on('termadd.VAR_FOO', function (n3, term3) {
-                                    self.off('termadd.VAR_FOO');
-
-                                    assert.equal(n3, 'VAR_FOO', 'The right term has been received');
-                                    assert.equal(term3.label, 'foo', 'The expected term has been added');
-                                    assert.equal(term3.value, 'foo', 'The expected term value has been added');
-                                    assert.equal(
-                                        self.getExpression(),
-                                        'foo x y',
-                                        'Expression has been properly updated'
-                                    );
-                                    assert.equal(self.getPosition(), 4, 'New position has been set');
-
-                                    resolve();
-                                })
-                                    .setPosition(0)
-                                    .useVariable('foo');
-                            }).useVariable('y');
-                        })
-                        .useVariable('x');
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error termerror', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('useVariable - failure', function (assert) {
-        var noop;
-        var ready = assert.async();
-        var defaultVariables = {
-            ans: {
-                expression: '0',
-                result: 0,
-                value: 0,
-                variables: noop
-            }
-        };
-        var $container = $('#fixture-usevariable');
-        var instance;
-
-        assert.expect(8);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-                assert.deepEqual(self.getVariables(), defaultVariables, 'Only default variables set for now');
-
-                return new Promise(function (resolve) {
-                    self.on('termadd.varx', function (name) {
-                        self.off('termadd.varx');
-
-                        assert.equal(name, 'VAR_X', 'The term foo has been received');
-                        assert.ok(false, 'The term VAR_X should not be added!');
-
-                        resolve();
-                    })
-                        .on('termerror.varx', function (e) {
-                            self.off('.varx');
-
-                            assert.ok(e instanceof TypeError, 'The term cannot be added');
-                            assert.equal(self.getExpression(), '', 'Expression did not change');
-                            assert.equal(self.getPosition(), 0, 'Position did not change');
-
-                            resolve();
-                        })
-                        .useVariable('x');
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('useCommand - success', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-command');
-        var instance;
-
-        assert.expect(21);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-                assert.equal(this.getPosition(), 0, 'Position is at beginning');
-
-                return new Promise(function (resolve) {
-                    self.on('command-foo', function (p) {
-                        assert.ok(true, 'The foo command has been called');
-                        assert.equal(typeof p, 'undefined', 'No command parameter');
-                    })
-                        .on('command-bar', function (p1, p2, p3) {
-                            assert.ok(true, 'The bar command has been called');
-                            assert.equal(p1, 'tip', 'The first parameter is correct');
-                            assert.equal(p2, 'top', 'The second parameter is correct');
-                            assert.equal(p3, 42, 'The third parameter is correct');
-                        })
-                        .on('command.test', function (n1, p) {
-                            self.off('command.test');
-
-                            assert.equal(n1, 'foo', 'The right command has been received');
-                            assert.equal(typeof p, 'undefined', 'No command parameter');
-                            assert.equal(self.getExpression(), '', 'The expression is still empty');
-                            assert.equal(self.getPosition(), 0, 'Position did not change');
-
-                            self.on('command.test', function (n2, p1, p2, p3) {
-                                self.off('command.test');
-
-                                assert.equal(n2, 'bar', 'The right command has been received');
-                                assert.equal(p1, 'tip', 'The first parameter is correct');
-                                assert.equal(p2, 'top', 'The second parameter is correct');
-                                assert.equal(p3, 42, 'The third parameter is correct');
-                                assert.equal(self.getExpression(), '', 'The expression is still empty');
-                                assert.equal(self.getPosition(), 0, 'Position did not change');
-
-                                resolve();
-                            }).useCommand('bar', 'tip', 'top', 42);
-                        })
-                        .setCommand('foo')
-                        .setCommand('bar')
-                        .useCommand('foo');
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error commanderror', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('useCommand - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-command');
-        var instance;
-
-        assert.expect(8);
-
-        assert.equal($container.children().length, 0, 'The container is empty');
-
-        instance = calculatorBoardFactory($container);
-        instance
-            .on('init', function () {
-                var self = this;
-                assert.equal(this, instance, 'The instance has been initialized');
-                assert.equal(this.getExpression(), '', 'The expression is empty');
-                assert.equal(this.getPosition(), 0, 'Position is at beginning');
-
-                return new Promise(function (resolve) {
-                    self.on('command.test', function (name) {
-                        self.off('command.test');
-
-                        assert.equal(name, 'foo', 'The command foo should not be received!');
-                        assert.ok(false, 'The command foo should not be called!');
-
-                        resolve();
-                    })
-                        .on('commanderror.test', function (e) {
-                            self.off('commanderror.test');
-
-                            assert.ok(e instanceof TypeError, 'The command cannot be called');
-                            assert.equal(self.getExpression(), '', 'Expression did not change');
-                            assert.equal(self.getPosition(), 0, 'Position did not change');
-
-                            resolve();
-                        })
-                        .useCommand('foo');
-                });
-            })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-    });
-
-    QUnit.test('clear', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-clear');
-        var instance;
+    QUnit.test('useTerm - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-useterm');
 
         assert.expect(10);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var newExpression = '3+1';
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+
+                const expression = '4';
+                const position = 1;
+
+                return Promise.resolve()
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                const term = 'NUM4';
+
+                                this.on(`termadd-${term}`, () => {
+                                    this.off(`termadd-${term}`);
+                                    assert.ok(true, `The term ${term} has been added`);
+                                    assert.equal(this.getExpression(), expression, `The expression is ${expression}`);
+                                    assert.equal(this.getPosition(), position, `The position is ${position}`);
+                                    resolve();
+                                });
+                                this.useTerm(term);
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                const term = 'foo';
+                                this.on(`termadd-${term}`, () => {
+                                    this.off(`termadd-${term}`);
+                                    assert.ok(false, `The term ${term} should not be added`);
+                                    resolve();
+                                });
+                                this.off('error');
+                                this.on('error', err => {
+                                    this.off('error');
+                                    assert.ok(err instanceof TypeError, 'The term cannot be added');
+                                    assert.equal(this.getExpression(), expression, 'Expression did not change');
+                                    assert.equal(this.getPosition(), position, 'Position did not change');
+                                    resolve();
+                                });
+                                this.useTerm(term);
+                            })
+                    )
+                    .then(() => this.destroy());
+            })
+            .after('destroy', ready)
+            .on('error', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('useTerms - success', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-useterms');
+
+        assert.expect(6);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+
+                this.useTerms('NUM4 SUB NUM2');
+                assert.equal(this.getExpression(), '4-2', 'The expression is updated');
+                assert.equal(this.getPosition(), '3', 'The position is updated');
+                this.destroy();
+            })
+            .after('destroy', ready)
+            .on('error ', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('useTerms - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-useterms');
+
+        assert.expect(9);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+
+                return Promise.resolve()
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.off('error');
+                                this.on('error.foo', function (e) {
+                                    this.off('.foo');
+
+                                    assert.ok(e instanceof TypeError, 'The term foo cannot be added');
+                                    assert.equal(this.getExpression(), '4', 'Expression did not change');
+                                    assert.equal(this.getPosition(), 1, 'Position did not change');
+
+                                    resolve();
+                                });
+                                this.useTerms('NUM4 foo');
+                            })
+                    )
+                    .then(() => {
+                        assert.equal(this.getExpression(), '4', 'The expression is updated');
+                        assert.equal(this.getPosition(), '1', 'The position is updated');
+                        this.destroy();
+                    });
+            })
+            .after('destroy', ready)
+            .on('error', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('useVariable - success', assert => {
+        const ready = assert.async();
+        const defaultVariables = {
+            ans: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
+            },
+            mem: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
+            }
+        };
+        const expectedVariables = {
+            foo: 'bar',
+            x: '42',
+            y: '3'
+        };
+        const expectedResults = {
+            ans: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
+            },
+            mem: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
+            },
+            foo: {
+                expression: 'bar',
+                result: 0,
+                value: 0,
+                variables: void 0
+            },
+            x: {
+                expression: '42',
+                result: 42,
+                value: 42,
+                variables: void 0
+            },
+            y: {
+                expression: '3',
+                result: 3,
+                value: 3,
+                variables: void 0
+            }
+        };
+        const $container = $('#fixture-usevariable');
+
+        assert.expect(24);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+                assert.deepEqual(this.getVariables(), defaultVariables, 'Only default variables set for now');
+
+                this.setVariables(expectedVariables);
+                assert.deepEqual(this.getVariables(), expectedResults, 'All expected variables now set');
+
+                const assertVariable = (variable, position, expression) =>
+                    new Promise(resolve => {
+                        this.on(`termadd-VAR_${variable.toUpperCase()}`, term => {
+                            this.off(`termadd-VAR_${variable.toUpperCase()}`);
+                            assert.ok(true, `The variable ${variable} has been added`);
+                            assert.equal(typeof term, 'object', 'A term has been added');
+                            assert.equal(term.label, variable, 'The expected term has been added');
+                            assert.equal(term.value, variable, 'The expected value has been added');
+                            assert.equal(this.getExpression(), expression, `The expression is ${expression}`);
+                            assert.equal(this.getPosition(), position, `The position is ${position}`);
+                            resolve();
+                        });
+                        this.useVariable(variable);
+                    });
+
+                return Promise.resolve()
+                    .then(() => assertVariable('x', 1, 'x'))
+                    .then(() => this.useTerm('ADD'))
+                    .then(() => assertVariable('y', 3, 'x+y'))
+                    .then(() => this.useTerm('MUL'))
+                    .then(() => assertVariable('foo', 7, 'x+y*foo'))
+                    .then(() => this.destroy());
+            })
+            .after('destroy', ready)
+            .on('error', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('useVariable - failure', assert => {
+        const ready = assert.async();
+        const defaultVariables = {
+            ans: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
+            },
+            mem: {
+                expression: '0',
+                result: 0,
+                value: 0,
+                variables: void 0
+            }
+        };
+        const $container = $('#fixture-usevariable');
+
+        assert.expect(8);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+                assert.deepEqual(this.getVariables(), defaultVariables, 'Only default variables set for now');
+
+                return Promise.resolve()
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.on('termadd-VAR_X', name => {
+                                    assert.equal(name, 'VAR_X', 'The term foo has been received');
+                                    assert.ok(false, 'The term VAR_X should not be added!');
+
+                                    resolve();
+                                });
+                                this.off('error')
+                                    .on('error', e => {
+                                        assert.ok(e instanceof TypeError, 'The term cannot be added');
+                                        assert.equal(this.getExpression(), '', 'Expression did not change');
+                                        assert.equal(this.getPosition(), 0, 'Position did not change');
+
+                                        resolve();
+                                    })
+                                    .useVariable('x');
+                            })
+                    )
+                    .then(() => this.destroy());
+            })
+            .after('destroy', ready)
+            .on('error', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('useCommand - success', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-command');
+
+        assert.expect(13);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+                assert.equal(this.getPosition(), 0, 'Position is at beginning');
+
+                const assertCommand = (command, ...args) =>
+                    new Promise(resolve => {
+                        this.on(`command-${command}`, (...prms) => {
+                            this.off(`command-${command}`);
+                            assert.deepEqual(
+                                prms,
+                                args,
+                                `The expected parameters have been received for the command ${command}`
+                            );
+                            assert.equal(this.getExpression(), '', 'The expression is still empty');
+                            assert.equal(this.getPosition(), 0, 'Position did not change');
+                            resolve();
+                        });
+                        this.useCommand(command, ...args);
+                    });
+
+                this.setCommand('foo', () => {
+                    assert.ok(true, 'The command foo has been invoked');
+                });
+                this.setCommand('bar', () => {
+                    assert.ok(true, 'The command bar has been invoked');
+                });
+
+                return Promise.resolve()
+                    .then(() => assertCommand('foo'))
+                    .then(() => assertCommand('bar', 'tip', 'top', 42))
+                    .then(() => this.destroy());
+            })
+            .after('destroy', ready)
+            .on('error', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('useCommand - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-command');
+
+        assert.expect(8);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
+
+                assert.equal(this.getExpression(), '', 'The expression is empty');
+                assert.equal(this.getPosition(), 0, 'Position is at beginning');
+
+                return Promise.resolve()
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.on('command-test', name => {
+                                    assert.equal(name, 'foo', 'The command foo should not be received!');
+                                    assert.ok(false, 'The command foo should not be called!');
+
+                                    resolve();
+                                });
+                                this.off('error')
+                                    .on('error', e => {
+                                        assert.ok(e instanceof TypeError, 'The command cannot be called');
+                                        assert.equal(this.getExpression(), '', 'Expression did not change');
+                                        assert.equal(this.getPosition(), 0, 'Position did not change');
+
+                                        resolve();
+                                    })
+                                    .useCommand('foo');
+                            })
+                    )
+                    .then(() => this.destroy());
+            })
+            .after('destroy', ready)
+            .on('error', err => {
+                //eslint-disable-next-line no-console
+                console.error(err);
+                assert.ok(false, 'The operation should not fail!');
+                ready();
+            });
+    });
+
+    QUnit.test('clear', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-clear');
+
+        assert.expect(10);
+
+        assert.equal($container.children().length, 0, 'The container is empty');
+
+        const instance = calculatorBoardFactory($container);
+        instance
+            .on('init', function onInit() {
+                assert.equal(this, instance, 'The instance has been initialized');
+            })
+            .after('ready', function onReady() {
+                assert.equal($container.children().length, 1, 'The container contains an element');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
 
+                const newExpression = '3+1';
                 this.setExpression(newExpression);
                 this.setPosition(newExpression.length);
 
                 assert.equal(this.getExpression(), newExpression, 'The expression is set');
                 assert.equal(this.getPosition(), newExpression.length, 'The position is set');
 
-                return new Promise(function (resolve) {
-                    self.on('clear.test', function () {
-                        self.off('clear.test');
-
-                        assert.ok(true, 'The expression is cleared');
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        assert.equal(self.getPosition(), 0, 'The position is 0');
-                        resolve();
-                    }).clear();
-                });
+                return Promise.resolve()
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.on('clear', () => {
+                                    assert.ok(true, 'The expression is cleared');
+                                    assert.equal(this.getExpression(), '', 'The expression is empty');
+                                    assert.equal(this.getPosition(), 0, 'The position is 0');
+                                    resolve();
+                                }).clear();
+                            })
+                    )
+                    .then(() => this.destroy());
             })
-            .after('ready', function () {
-                assert.equal($container.children().length, 1, 'The container contains an element');
-                this.destroy();
-            })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -1914,21 +1412,19 @@ define([
             });
     });
 
-    QUnit.test('replace', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-replace');
-        var instance;
+    QUnit.test('replace', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-replace');
 
         assert.expect(21);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var oldExpression = '3+1';
-                var newExpression = '4*(4+1)';
+            .on('init', function onInit() {
+                const oldExpression = '3+1';
+                const newExpression = '4*(4+1)';
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
@@ -1940,63 +1436,67 @@ define([
                 assert.equal(this.getPosition(), oldExpression.length, 'The old position is set');
 
                 return Promise.resolve()
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            self.on('expressionchange.test', function (expr) {
-                                self.off('expressionchange.test');
-                                assert.equal(expr, newExpression, 'The new expression is set');
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.on('expressionchange.test', expr => {
+                                    this.off('expressionchange.test');
+                                    assert.equal(expr, newExpression, 'The new expression is set');
+                                })
+                                    .on('positionchange.test', pos => {
+                                        this.off('positionchange.test');
+                                        assert.equal(pos, newExpression.length, 'The new position is set');
+                                    })
+                                    .on('replace.test', (oldExpr, oldPos) => {
+                                        this.off('replace.test');
+
+                                        assert.ok(true, 'The expression is replaced');
+                                        assert.equal(this.getExpression(), newExpression, 'The new expression is set');
+                                        assert.equal(
+                                            this.getPosition(),
+                                            newExpression.length,
+                                            'The new position is set'
+                                        );
+
+                                        assert.equal(oldExpr, oldExpression, 'The previous expression is provided');
+                                        assert.equal(oldPos, oldExpression.length, 'The previous position is provided');
+                                        resolve();
+                                    })
+                                    .replace(newExpression);
                             })
-                                .on('positionchange.test', function (pos) {
-                                    self.off('positionchange.test');
-                                    assert.equal(pos, newExpression.length, 'The new position is set');
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.on('expressionchange.test', expr => {
+                                    this.off('expressionchange.test');
+                                    assert.equal(expr, oldExpression, 'The old expression is set');
                                 })
-                                .on('replace.test', function (oldExpr, oldPos) {
-                                    self.off('replace.test');
+                                    .on('positionchange.test', pos => {
+                                        this.off('positionchange.test');
+                                        assert.equal(pos, 1, 'The arbitrary position is set');
+                                    })
+                                    .on('replace.test', (oldExpr, oldPos) => {
+                                        this.off('replace.test');
 
-                                    assert.ok(true, 'The expression is replaced');
-                                    assert.equal(self.getExpression(), newExpression, 'The new expression is set');
-                                    assert.equal(self.getPosition(), newExpression.length, 'The new position is set');
+                                        assert.ok(true, 'The expression is replaced');
+                                        assert.equal(this.getExpression(), oldExpression, 'The old expression is set');
+                                        assert.equal(this.getPosition(), 1, 'The arbitrary position is set');
 
-                                    assert.equal(oldExpr, oldExpression, 'The previous expression is provided');
-                                    assert.equal(oldPos, oldExpression.length, 'The previous position is provided');
-                                    resolve();
-                                })
-                                .replace(newExpression);
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            self.on('expressionchange.test', function (expr) {
-                                self.off('expressionchange.test');
-                                assert.equal(expr, oldExpression, 'The old expression is set');
+                                        assert.equal(oldExpr, newExpression, 'The previous expression is provided');
+                                        assert.equal(oldPos, newExpression.length, 'The previous position is provided');
+                                        resolve();
+                                    })
+                                    .replace(oldExpression, 1);
                             })
-                                .on('positionchange.test', function (pos) {
-                                    self.off('positionchange.test');
-                                    assert.equal(pos, 1, 'The arbitrary position is set');
-                                })
-                                .on('replace.test', function (oldExpr, oldPos) {
-                                    self.off('replace.test');
-
-                                    assert.ok(true, 'The expression is replaced');
-                                    assert.equal(self.getExpression(), oldExpression, 'The old expression is set');
-                                    assert.equal(self.getPosition(), 1, 'The arbitrary position is set');
-
-                                    assert.equal(oldExpr, newExpression, 'The previous expression is provided');
-                                    assert.equal(oldPos, newExpression.length, 'The previous position is provided');
-                                    resolve();
-                                })
-                                .replace(oldExpression, 1);
-                        });
-                    });
+                    );
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2004,23 +1504,21 @@ define([
             });
     });
 
-    QUnit.test('insert', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-insert');
-        var instance;
+    QUnit.test('insert', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-insert');
 
         assert.expect(14);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var oldExpression = '3+1';
-                var oldPosition = oldExpression.length - 1;
-                var insertedExpression = '2*(5-4)-';
-                var newExpression = '3+2*(5-4)-1';
+            .on('init', function onInit() {
+                const oldExpression = '3+1';
+                const oldPosition = oldExpression.length - 1;
+                const insertedExpression = '2*(5-4)-';
+                const newExpression = '3+2*(5-4)-1';
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
@@ -2031,20 +1529,20 @@ define([
                 assert.equal(this.getExpression(), oldExpression, 'The old expression is set');
                 assert.equal(this.getPosition(), oldPosition, 'The old position is set');
 
-                return new Promise(function (resolve) {
-                    self.on('expressionchange.test', function (expr) {
+                return new Promise(resolve => {
+                    this.on('expressionchange.test', expr => {
                         assert.equal(expr, newExpression, 'The new expression is set');
                     })
-                        .on('positionchange.test', function (pos) {
+                        .on('positionchange.test', pos => {
                             assert.equal(pos, oldPosition + insertedExpression.length, 'The new position is set');
                         })
-                        .on('insert.test', function (oldExpr, oldPos) {
-                            self.off('insert.test');
+                        .on('insert.test', (oldExpr, oldPos) => {
+                            this.off('insert.test');
 
                             assert.ok(true, 'The expression is inserted');
-                            assert.equal(self.getExpression(), newExpression, 'The new expression is set');
+                            assert.equal(this.getExpression(), newExpression, 'The new expression is set');
                             assert.equal(
-                                self.getPosition(),
+                                this.getPosition(),
                                 oldPosition + insertedExpression.length,
                                 'new The position is set'
                             );
@@ -2056,14 +1554,12 @@ define([
                         .insert(insertedExpression);
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2071,67 +1567,65 @@ define([
             });
     });
 
-    QUnit.test('evaluate - success', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-evaluate');
-        var initExpression = '.1+.2';
-        var expectedResult = '0.3';
-        var instance;
+    QUnit.test('evaluate - success', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-evaluate');
+        const initExpression = '.1+.2';
+        const expectedResult = '0.3';
 
         assert.expect(10);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, null, {
+        const instance = calculatorBoardFactory($container, null, {
             expression: initExpression,
             position: initExpression.length
         });
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
                 assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
                 return Promise.resolve()
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            self.on('evaluate.expr', function (result) {
-                                self.off('evaluate.expr');
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.on('evaluate.expr', result => {
+                                    this.off('evaluate.expr');
+                                    assert.equal(
+                                        result.value,
+                                        expectedResult,
+                                        'The expression has been properly evaluated'
+                                    );
+                                    resolve();
+                                });
                                 assert.equal(
-                                    result.value,
+                                    this.evaluate().value,
                                     expectedResult,
-                                    'The expression has been properly evaluated'
+                                    'The expression is successfully evaluated'
                                 );
-                                resolve();
-                            });
-                            assert.equal(
-                                self.evaluate().value,
-                                expectedResult,
-                                'The expression is successfully evaluated'
-                            );
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            self.clear();
-                            assert.equal(self.getExpression(), '', 'The expression is cleared');
-                            self.on('evaluate.empty', function (result) {
-                                self.off('evaluate.empty');
-                                assert.equal(result.value, '0', 'An empty expression should be evaluated as 0');
-                                resolve();
-                            });
-                            assert.equal(self.evaluate().value, '0', 'The empty expression is evaluated to 0');
-                        });
-                    });
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                this.clear();
+                                assert.equal(this.getExpression(), '', 'The expression is cleared');
+                                this.on('evaluate.empty', result => {
+                                    this.off('evaluate.empty');
+                                    assert.equal(result.value, '0', 'An empty expression should be evaluated as 0');
+                                    resolve();
+                                });
+                                assert.equal(this.evaluate().value, '0', 'The empty expression is evaluated to 0');
+                            })
+                    );
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error syntaxerror', function (err) {
+            .after('destroy', ready)
+            .on('error syntaxerror', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2139,45 +1633,41 @@ define([
             });
     });
 
-    QUnit.test('evaluate - error', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-evaluate');
-        var initExpression = '.1+*.2';
-        var instance;
+    QUnit.test('evaluate - error', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-evaluate');
+        const initExpression = '.1+*.2';
 
         assert.expect(7);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, null, {
+        const instance = calculatorBoardFactory($container, null, {
             expression: initExpression,
             position: initExpression.length
         });
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
                 assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
-                return new Promise(function (resolve) {
-                    self.on('evaluate', function () {
+                return new Promise(resolve => {
+                    this.on('evaluate', () => {
                         assert.ok(false, 'The expression should not be evaluated');
                         resolve();
-                    }).on('syntaxerror', function (e) {
+                    }).on('syntaxerror', e => {
                         assert.ok(e instanceof Error, 'The evaluation of the expression has failed');
                         resolve();
                     });
-                    assert.equal(self.evaluate(), null, 'The expression cannot be evaluated');
+                    assert.equal(this.evaluate(), null, 'The expression cannot be evaluated');
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2185,44 +1675,40 @@ define([
             });
     });
 
-    QUnit.test('evaluate variable - success', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-evaluate');
-        var initExpression = '(.1+.2)*x';
-        var expectedResult = '0.9';
-        var instance;
+    QUnit.test('evaluate variable - success', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-evaluate');
+        const initExpression = '(.1+.2)*x';
+        const expectedResult = '0.9';
 
         assert.expect(7);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, null, {
+        const instance = calculatorBoardFactory($container, null, {
             expression: initExpression,
             position: initExpression.length
         });
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
                 assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
-                return new Promise(function (resolve) {
-                    self.on('evaluate', function (result) {
+                return new Promise(resolve => {
+                    this.on('evaluate', result => {
                         assert.equal(result.value, expectedResult, 'The expression has been properly evaluated');
                         resolve();
                     });
-                    self.setVariable('x', '3');
-                    assert.equal(self.evaluate().value, expectedResult, 'The expression is successfully evaluated');
+                    this.setVariable('x', '3');
+                    assert.equal(this.evaluate().value, expectedResult, 'The expression is successfully evaluated');
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error syntaxerror', function (err) {
+            .after('destroy', ready)
+            .on('error syntaxerror', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2230,45 +1716,41 @@ define([
             });
     });
 
-    QUnit.test('evaluate variable - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-evaluate');
-        var initExpression = '(.1+.2)*x';
-        var instance;
+    QUnit.test('evaluate variable - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-evaluate');
+        const initExpression = '(.1+.2)*x';
 
         assert.expect(7);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, null, {
+        const instance = calculatorBoardFactory($container, null, {
             expression: initExpression,
             position: initExpression.length
         });
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
                 assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
-                return new Promise(function (resolve) {
-                    self.on('evaluate', function () {
+                return new Promise(resolve => {
+                    this.on('evaluate', () => {
                         assert.ok(false, 'The expression should not be evaluated');
                         resolve();
-                    }).on('syntaxerror', function (e) {
+                    }).on('syntaxerror', e => {
                         assert.ok(e instanceof Error, 'The evaluation of the expression has failed');
                         resolve();
                     });
-                    assert.equal(self.evaluate(), null, 'The expression cannot be evaluated');
+                    assert.equal(this.evaluate(), null, 'The expression cannot be evaluated');
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2276,19 +1758,19 @@ define([
             });
     });
 
-    QUnit.test('ans variable', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-ans');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
+    QUnit.test('ans variable', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-ans');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', function onReady() {
                 function evaluatePromise(expression) {
-                    return new Promise(function (resolve, reject) {
+                    return new Promise((resolve, reject) => {
                         calculator
-                            .on('error.test', function (err) {
+                            .on('error.test', err => {
                                 calculator.off('.test');
                                 reject(err);
                             })
-                            .after('evaluate.test', function (result) {
+                            .after('result.test', result => {
                                 calculator.off('.test');
                                 resolve(result);
                             })
@@ -2298,96 +1780,91 @@ define([
                 }
 
                 Promise.resolve()
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.hasVariable('ans'), true, 'The variable ans is defined');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The variable ans contains 0');
                         assert.equal(calculator.getLastResult().value, '0', 'The last result contains 0');
 
                         return evaluatePromise('ans');
                     })
-                    .then(function (result) {
+                    .then(result => {
                         assert.equal(result.value, '0', 'The expression "ans" is evaluated to 0');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The variable ans now contains 0');
                         assert.equal(calculator.getLastResult().value, '0', 'The last result now contains 0');
 
                         return evaluatePromise('40+2');
                     })
-                    .then(function (result) {
+                    .then(result => {
                         assert.equal(result.value, '42', 'The expression "40+2" is evaluated to 42');
                         assert.equal(calculator.getVariable('ans').value, '42', 'The variable ans now contains 42');
                         assert.equal(calculator.getLastResult().value, '42', 'The last result now contains 42');
 
                         return evaluatePromise('ans*2');
                     })
-                    .then(function (result) {
+                    .then(result => {
                         assert.equal(result.value, '84', 'The expression "ans*2" is evaluated to 84');
                         assert.equal(calculator.getVariable('ans').value, '84', 'The variable ans now contains 84');
                         assert.equal(calculator.getLastResult().value, '84', 'The last result now contains 84');
 
                         return evaluatePromise('3*2');
                     })
-                    .then(function (result) {
+                    .then(result => {
                         assert.equal(result.value, '6', 'The expression "3*2" is evaluated to 6');
                         assert.equal(calculator.getVariable('ans').value, '6', 'The variable ans now contains 6');
                         assert.equal(calculator.getLastResult().value, '6', 'The last result now contains 6');
 
                         return evaluatePromise('sqrt -2');
                     })
-                    .then(function (result) {
+                    .then(result => {
                         assert.equal(String(result.value), 'NaN', 'The expression "sqrt -2" is evaluated to NaN');
-                        assert.equal(calculator.getVariable('ans').value, '0', 'The variable ans now contains 0');
-                        assert.equal(calculator.getLastResult().value, '0', 'The last result now contains 0');
+                        assert.equal(calculator.getVariable('ans').value, '6', 'The variable ans now contains 6');
+                        assert.equal(calculator.getLastResult().value, '6', 'The last result now contains 6');
                     })
-                    .then(function () {
+                    .then(() => {
                         calculator.setLastResult('42');
                         assert.equal(calculator.getVariable('ans').value, '42', 'The variable ans now contains 42');
                         assert.equal(calculator.getLastResult().value, '42', 'The last result now contains 42');
                     })
-                    .then(function () {
+                    .then(() => {
                         calculator.setLastResult('Infinity');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The variable ans now contains 0');
                         assert.equal(calculator.getLastResult().value, '0', 'The last result now contains 0');
                     })
-                    .then(function () {
+                    .then(() => {
                         calculator.setLastResult('NaN');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The variable ans now contains 0');
                         assert.equal(calculator.getLastResult().value, '0', 'The last result now contains 0');
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
                 ready();
             })
-            .after('destroy', function () {
-                assert.equal(calculator.hasVariable('ans'), false, 'The variable ans has been removed');
-                ready();
-            });
+            .after('destroy', ready);
 
-        assert.expect(25);
+        assert.expect(24);
     });
 
-    QUnit.test('built-in commands - clear', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-builtin');
-        var instance;
+    QUnit.test('built-in commands - clear', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-builtin');
 
         assert.expect(10);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var newExpression = '3+1';
+            .on('init', function onInit() {
+                const newExpression = '3+1';
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
@@ -2398,25 +1875,23 @@ define([
                 assert.equal(this.getExpression(), newExpression, 'The expression is set');
                 assert.equal(this.getPosition(), newExpression.length, 'The position is set');
 
-                return new Promise(function (resolve) {
-                    self.on('clear.test', function () {
-                        self.off('clear.test');
+                return new Promise(resolve => {
+                    this.on('clear.test', () => {
+                        this.off('clear.test');
 
                         assert.ok(true, 'The expression is cleared');
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        assert.equal(self.getPosition(), 0, 'The position is 0');
+                        assert.equal(this.getExpression(), '', 'The expression is empty');
+                        assert.equal(this.getPosition(), 0, 'The position is 0');
                         resolve();
                     }).useCommand('clear');
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2424,20 +1899,18 @@ define([
             });
     });
 
-    QUnit.test('built-in commands - clearAll', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-builtin');
-        var instance;
+    QUnit.test('built-in commands - reset', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-builtin');
 
         assert.expect(10);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var self = this;
-                var newExpression = '3+1';
+            .on('init', function onInit() {
+                const newExpression = '3+1';
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is empty');
                 assert.equal(this.getPosition(), 0, 'The position is 0');
@@ -2448,25 +1921,23 @@ define([
                 assert.equal(this.getExpression(), newExpression, 'The expression is set');
                 assert.equal(this.getPosition(), newExpression.length, 'The position is set');
 
-                return new Promise(function (resolve) {
-                    self.on('clear.test', function () {
-                        self.off('clear.test');
+                return new Promise(resolve => {
+                    this.on('reset.test', () => {
+                        this.off('reset.test');
 
                         assert.ok(true, 'The expression is cleared');
-                        assert.equal(self.getExpression(), '', 'The expression is empty');
-                        assert.equal(self.getPosition(), 0, 'The position is 0');
+                        assert.equal(this.getExpression(), '', 'The expression is empty');
+                        assert.equal(this.getPosition(), 0, 'The position is 0');
                         resolve();
-                    }).useCommand('clearAll');
+                    }).useCommand('reset');
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error', function (err) {
+            .after('destroy', ready)
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2474,42 +1945,38 @@ define([
             });
     });
 
-    QUnit.test('built-in commands - execute', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-builtin');
-        var initExpression = '.1+.2';
-        var expectedResult = '0.3';
-        var instance;
+    QUnit.test('built-in commands - execute', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-builtin');
+        const initExpression = '.1+.2';
+        const expectedResult = '0.3';
 
         assert.expect(6);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, null, {
+        const instance = calculatorBoardFactory($container, null, {
             expression: initExpression,
             position: initExpression.length
         });
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
                 assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
-                return new Promise(function (resolve) {
-                    self.on('evaluate', function (result) {
+                return new Promise(resolve => {
+                    this.on('evaluate', result => {
                         assert.equal(result.value, expectedResult, 'The expression has been properly evaluated');
                         resolve();
                     }).useCommand('execute');
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error syntaxerror', function (err) {
+            .after('destroy', ready)
+            .on('error syntaxerror', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2517,33 +1984,31 @@ define([
             });
     });
 
-    QUnit.test('built-in commands - var and term', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-builtin');
-        var initExpression = '.1+.2';
-        var expectedExpression = '.1+.2+x^2';
-        var expectedResult = '9.3';
-        var instance;
+    QUnit.test('built-in commands - const and term', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-builtin');
+        const initExpression = '.1+.2';
+        const expectedExpression = '.1+.2+x^2';
+        const expectedResult = '9.3';
 
         assert.expect(8);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container, null, {
+        const instance = calculatorBoardFactory($container, null, {
             expression: initExpression,
             position: initExpression.length
         });
         instance
-            .on('init', function () {
-                var self = this;
+            .on('init', function onInit() {
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), initExpression, 'The expression is initialized');
                 assert.equal(this.getPosition(), initExpression.length, 'The expression is initialized');
-                return new Promise(function (resolve) {
-                    self.after('evaluate.test', function (result) {
-                        self.off('evaluate.test');
-                        assert.equal(self.getExpression(), expectedExpression, 'The expression has been updated');
-                        assert.equal(self.getPosition(), expectedExpression.length, 'The position has been updated');
+                return new Promise(resolve => {
+                    this.after('evaluate.test', result => {
+                        this.off('evaluate.test');
+                        assert.equal(this.getExpression(), expectedExpression, 'The expression has been updated');
+                        assert.equal(this.getPosition(), expectedExpression.length, 'The position has been updated');
                         assert.equal(result.value, expectedResult, 'The expression has been properly evaluated');
                         resolve();
                     })
@@ -2554,14 +2019,12 @@ define([
                         .evaluate();
                 });
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error syntaxerror', function (err) {
+            .after('destroy', ready)
+            .on('error syntaxerror', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2569,19 +2032,18 @@ define([
             });
     });
 
-    QUnit.test('mathsEvaluator', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-evaluator');
-        var instance;
+    QUnit.test('mathsEvaluator', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-evaluator');
 
         assert.expect(11);
 
         assert.equal($container.children().length, 0, 'The container is empty');
 
-        instance = calculatorBoardFactory($container);
+        const instance = calculatorBoardFactory($container);
         instance
-            .on('init', function () {
-                var mathsEvaluator = this.getMathsEvaluator();
+            .on('init', function onInit() {
+                let mathsEvaluator = this.getMathsEvaluator();
                 assert.equal(this, instance, 'The instance has been initialized');
                 assert.equal(this.getExpression(), '', 'The expression is initialized');
                 assert.equal(this.getPosition(), 0, 'The expression is initialized');
@@ -2603,14 +2065,12 @@ define([
                 );
                 assert.equal(mathsEvaluator('sin 90').value, '1', 'The mathsEvaluator now works in degree');
             })
-            .after('ready', function () {
+            .after('ready', function onReady() {
                 assert.equal($container.children().length, 1, 'The container contains an element');
                 this.destroy();
             })
-            .after('destroy', function () {
-                ready();
-            })
-            .on('error syntaxerror', function (err) {
+            .after('destroy', ready)
+            .on('error syntaxerror', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2618,19 +2078,19 @@ define([
             });
     });
 
-    QUnit.test('0 and operator', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-zero-op');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
+    QUnit.test('0 and operator', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-zero-op');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', function onReady() {
                 function addTermPromise(term) {
-                    return new Promise(function (resolve, reject) {
+                    return new Promise((resolve, reject) => {
                         calculator
-                            .on('error.test', function (err) {
+                            .on('error.test', err => {
                                 calculator.off('.test');
                                 reject(err);
                             })
-                            .after('termadd.test', function () {
+                            .after('termadd.test', () => {
                                 calculator.off('.test');
                                 resolve();
                             })
@@ -2641,33 +2101,33 @@ define([
                 calculator.replace('0');
 
                 Promise.resolve()
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), '0', 'The expression should be set to 0');
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
                         return addTermPromise('NUM0');
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), '0', 'The expression should still be 0');
                         assert.equal(calculator.getPosition(), 1, 'The position should still be 1');
                         return addTermPromise('ADD');
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), '0+', 'The expression should be now 0+');
                         assert.equal(calculator.getPosition(), 2, 'The position should be now 2');
                         return addTermPromise('NUM5');
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), '0+5', 'The expression should be now 0+5');
                         assert.equal(calculator.getPosition(), 3, 'The position should be now 3');
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2687,55 +2147,50 @@ define([
                 term: 'PI',
                 expression: 'PI',
                 value: 'PI',
-                type: 'constant',
-                label: registeredTerms.PI.label
+                type: 'constant'
             },
             {
                 title: '3',
                 term: 'NUM3',
                 expression: '3',
                 value: '3',
-                type: 'digit',
-                label: '3'
+                type: 'digit'
             },
             {
                 title: '(',
                 term: 'LPAR',
                 expression: '(',
                 value: '(',
-                type: 'aggregator',
-                label: '('
+                type: 'aggregator'
             },
             {
                 title: 'sqrt',
                 term: 'SQRT',
                 expression: 'sqrt',
                 value: 'sqrt',
-                type: 'function',
-                label: registeredTerms.SQRT.label
+                type: 'function'
             },
             {
                 title: 'nthrt',
                 term: '@NTHRT',
-                expression: '0 @nthrt',
+                expression: '0@nthrt',
                 value: '@nthrt',
-                type: 'function',
-                label: registeredTerms.NTHRT.label
+                type: 'function'
             }
         ])
-        .test('0 and const', function (data, assert) {
-            var ready = assert.async();
-            var $container = $('#fixture-zero-const');
-            var calculator = calculatorBoardFactory($container)
-                .on('ready', function () {
+        .test('0 and const', (data, assert) => {
+            const ready = assert.async();
+            const $container = $('#fixture-zero-const');
+            const calculator = calculatorBoardFactory($container)
+                .on('ready', function onReady() {
                     function addTermPromise(term) {
-                        return new Promise(function (resolve, reject) {
+                        return new Promise((resolve, reject) => {
                             calculator
-                                .on('error.test', function (err) {
+                                .on('error.test', err => {
                                     calculator.off('.test');
                                     reject(err);
                                 })
-                                .after('termadd.test', function () {
+                                .after('termadd.test', () => {
                                     calculator.off('.test');
                                     resolve();
                                 })
@@ -2746,17 +2201,17 @@ define([
                     calculator.replace('0');
 
                     Promise.resolve()
-                        .then(function () {
+                        .then(() => {
                             assert.equal(calculator.getExpression(), '0', 'The expression should be set to 0');
                             assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
                             return addTermPromise('NUM0');
                         })
-                        .then(function () {
+                        .then(() => {
                             assert.equal(calculator.getExpression(), '0', 'The expression should still be 0');
                             assert.equal(calculator.getPosition(), 1, 'The position should still be 1');
                             return addTermPromise(data.term);
                         })
-                        .then(function () {
+                        .then(() => {
                             assert.equal(
                                 calculator.getExpression(),
                                 data.expression,
@@ -2768,84 +2223,80 @@ define([
                                 `The position should be ${data.expression.length}`
                             );
                         })
-                        .catch(function (err) {
+                        .catch(err => {
                             assert.ok(false, `Unexpected failure : ${err.message}`);
                         })
-                        .then(function () {
+                        .then(() => {
                             calculator.destroy();
                         });
                 })
-                .on('error', function (runtimeErr) {
+                .on('error', runtimeErr => {
                     //eslint-disable-next-line no-console
                     console.error(runtimeErr);
                     assert.ok(false, 'The operation should not fail!');
                     ready();
                 })
-                .on('destroy', function () {
-                    ready();
-                });
+                .on('destroy', ready);
 
             assert.expect(6);
         });
 
-    QUnit.test('ans and operator', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-ans-op');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                function addTermPromise(term) {
-                    return new Promise(function (resolve, reject) {
+    QUnit.test('ans and operator', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-ans-op');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', function onReady() {
+                function termPromise(call) {
+                    return new Promise((resolve, reject) => {
                         calculator
-                            .on('error.test', function (err) {
+                            .on('error.test', err => {
                                 calculator.off('.test');
                                 reject(err);
                             })
-                            .after('termadd.test', function () {
+                            .after('termadd.test', () => {
                                 calculator.off('.test');
                                 resolve();
-                            })
-                            .useTerm(term);
+                            });
+                        call();
                     });
                 }
 
                 calculator.replace('ans');
 
                 Promise.resolve()
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), 'ans', 'The expression should be set to ans');
                         assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-                        return addTermPromise('ANS');
+                        return termPromise(() => this.useVariable('ans'));
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), 'ans', 'The expression should still be ans');
                         assert.equal(calculator.getPosition(), 3, 'The position should still be 3');
-                        return addTermPromise('ADD');
+                        return termPromise(() => this.useTerm('ADD'));
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), 'ans+', 'The expression should be now ans+');
                         assert.equal(calculator.getPosition(), 4, 'The position should be now 4');
-                        return addTermPromise('NUM8');
+                        return termPromise(() => this.useTerm('NUM8'));
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(calculator.getExpression(), 'ans+8', 'The expression should be now ans+8');
                         assert.equal(calculator.getPosition(), 5, 'The position should be now 5');
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
                 ready();
             })
-            .on('destroy', function () {
-                ready();
-            });
+            .on('destroy', ready);
 
         assert.expect(8);
     });
@@ -2857,76 +2308,71 @@ define([
                 term: 'PI',
                 expression: 'PI',
                 value: 'PI',
-                type: 'constant',
-                label: registeredTerms.PI.label
+                type: 'constant'
             },
             {
                 title: '3',
                 term: 'NUM3',
                 expression: '3',
                 value: '3',
-                type: 'digit',
-                label: '3'
+                type: 'digit'
             },
             {
                 title: '(',
                 term: 'LPAR',
                 expression: '(',
                 value: '(',
-                type: 'aggregator',
-                label: '('
+                type: 'aggregator'
             },
             {
                 title: 'sqrt',
                 term: 'SQRT',
                 expression: 'sqrt',
                 value: 'sqrt',
-                type: 'function',
-                label: registeredTerms.SQRT.label
+                type: 'function'
             },
             {
                 title: 'nthrt',
                 term: '@NTHRT',
-                expression: 'ans @nthrt',
+                expression: 'ans@nthrt',
                 value: '@nthrt',
-                type: 'function',
-                label: registeredTerms.NTHRT.label
+                type: 'function'
             }
         ])
-        .test('ans and const', function (data, assert) {
-            var ready = assert.async();
-            var $container = $('#fixture-ans-const');
-            var calculator = calculatorBoardFactory($container)
-                .on('ready', function () {
-                    function addTermPromise(term) {
-                        return new Promise(function (resolve, reject) {
+        .test('ans and const', (data, assert) => {
+            const ready = assert.async();
+            const $container = $('#fixture-ans-const');
+            const calculator = calculatorBoardFactory($container)
+                .on('ready', function onReady() {
+                    function termPromise(call) {
+                        return new Promise((resolve, reject) => {
                             calculator
-                                .on('error.test', function (err) {
+                                .on('error.test', err => {
                                     calculator.off('.test');
                                     reject(err);
                                 })
-                                .after('termadd.test', function () {
+                                .after('termadd.test', () => {
                                     calculator.off('.test');
                                     resolve();
-                                })
-                                .useTerm(term);
+                                });
+                            call();
                         });
                     }
 
                     calculator.replace('ans');
 
                     Promise.resolve()
-                        .then(function () {
+                        .then(() => {
                             assert.equal(calculator.getExpression(), 'ans', 'The expression should be set to ans');
                             assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-                            return addTermPromise('ANS');
+                            return termPromise(() => this.useVariable('ans'));
                         })
-                        .then(function () {
+                        .then(() => {
                             assert.equal(calculator.getExpression(), 'ans', 'The expression should still be ans');
                             assert.equal(calculator.getPosition(), 3, 'The position should still be 3');
-                            return addTermPromise(data.term);
+                            return termPromise(() => this.useTerm(data.term));
                         })
-                        .then(function () {
+                        .then(() => {
                             assert.equal(
                                 calculator.getExpression(),
                                 data.expression,
@@ -2938,22 +2384,20 @@ define([
                                 `The position should be ${data.expression.length}`
                             );
                         })
-                        .catch(function (err) {
+                        .catch(err => {
                             assert.ok(false, `Unexpected failure : ${err.message}`);
                         })
-                        .then(function () {
+                        .then(() => {
                             calculator.destroy();
                         });
                 })
-                .on('error', function (err) {
+                .on('error', err => {
                     //eslint-disable-next-line no-console
                     console.error(err);
                     assert.ok(false, 'The operation should not fail!');
                     ready();
                 })
-                .on('destroy', function () {
-                    ready();
-                });
+                .on('destroy', ready);
 
             assert.expect(6);
         });

--- a/test/maths/calculator/core/labels/test.html
+++ b/test/maths/calculator/core/labels/test.html
@@ -14,6 +14,9 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #eee;

--- a/test/maths/calculator/defaultCalculator/test.html
+++ b/test/maths/calculator/defaultCalculator/test.html
@@ -14,11 +14,14 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #ccc;
-                height: 500px;
-                width: 1000px;
+                height: 800px;
+                width: 100%;
             }
         </style>
     </head>

--- a/test/maths/calculator/plugins/keyboard/templateKeyboard/test.html
+++ b/test/maths/calculator/plugins/keyboard/templateKeyboard/test.html
@@ -14,14 +14,54 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #ccc;
+                margin: 4rem auto;
+            }
+            #visual-test input {
+                width: 100%;
+            }
+            #visual-test .input input {
+                background: hsl(43 100% 91%);
+                color: hsl(0 0% 12%);
+            }
+            #visual-test .output input {
+                background: hsl(43 100% 91%);
+                color: hsl(0 0% 12%);
+                font-weight: bold;
+                text-align: right;
+            }
+            #visual-test button {
+                padding: 0;
+                margin: 1px;
+                width: 4rem;
+            }
+            #visual-test .row {
+                display: flex;
+            }
+            #visual-test .operator {
+                background: hsl(208, 100%, 53%);
+                color: hsl(0, 0%, 100%);
+            }
+            #visual-test .operand {
+                background: hsl(109 68% 39%);
+                color: hsl(0, 0%, 100%);
+            }
+            #visual-test .command {
+                background: hsl(41 96% 44%);
+                color: hsl(0, 0%, 100%);
+            }
+            #visual-test .execute {
+                background: hsl(358 86% 45%);
+                color: hsl(0, 0%, 100%);
             }
             .calculator {
                 position: relative;
-                width: 200px;
-                height: 300px;
+                width: 21rem;
             }
         </style>
     </head>

--- a/test/maths/calculator/plugins/keyboard/templateKeyboard/test.js
+++ b/test/maths/calculator/plugins/keyboard/templateKeyboard/test.js
@@ -13,23 +13,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 Open Assessment Technologies SA ;
- */
-/**
- * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ * Copyright (c) 2018-2023 Open Assessment Technologies SA ;
  */
 define([
     'jquery',
-    'lodash',
     'ui/maths/calculator/core/board',
     'ui/maths/calculator/plugins/keyboard/templateKeyboard/templateKeyboard'
-], function ($, _, calculatorBoardFactory, templateKeyboardPluginFactory) {
+], function ($, calculatorBoardFactory, templateKeyboardPluginFactory) {
     'use strict';
 
     QUnit.module('module');
 
-    QUnit.test('templateKeyboard', function (assert) {
-        var calculator = calculatorBoardFactory();
+    QUnit.test('templateKeyboard', assert => {
+        const calculator = calculatorBoardFactory();
 
         assert.expect(3);
 
@@ -66,9 +62,9 @@ define([
             { title: 'enable' },
             { title: 'disable' }
         ])
-        .test('plugin API ', function (data, assert) {
-            var calculator = calculatorBoardFactory();
-            var plugin = templateKeyboardPluginFactory(calculator);
+        .test('plugin API ', (data, assert) => {
+            const calculator = calculatorBoardFactory();
+            const plugin = templateKeyboardPluginFactory(calculator);
             assert.expect(1);
             assert.equal(
                 typeof plugin[data.title],
@@ -79,34 +75,30 @@ define([
 
     QUnit.module('behavior');
 
-    QUnit.test('install', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-install');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = templateKeyboardPluginFactory(calculator, areaBroker);
+    QUnit.test('install', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-install');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = templateKeyboardPluginFactory(calculator, areaBroker);
 
                 assert.expect(1);
 
                 calculator
-                    .on('plugin-install.templateKeyboard', function () {
+                    .on('plugin-install.templateKeyboard', () => {
                         assert.ok(true, 'The plugin has been installed');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -114,37 +106,31 @@ define([
             });
     });
 
-    QUnit.test('init', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-init');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = templateKeyboardPluginFactory(calculator, areaBroker);
+    QUnit.test('init', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-init');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = templateKeyboardPluginFactory(calculator, areaBroker);
 
                 assert.expect(1);
 
                 calculator
-                    .on('plugin-init.templateKeyboard', function () {
+                    .on('plugin-init.templateKeyboard', () => {
                         assert.ok(plugin.getState('init'), 'The plugin has been initialized');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .catch(function (err) {
+                    .then(() => plugin.init())
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -152,33 +138,27 @@ define([
             });
     });
 
-    QUnit.test('render', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-render');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = templateKeyboardPluginFactory(calculator, areaBroker);
+    QUnit.test('render', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-render');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = templateKeyboardPluginFactory(calculator, areaBroker);
 
                 assert.expect(29);
 
                 calculator
-                    .on('plugin-render.templateKeyboard', function () {
+                    .on('plugin-render.templateKeyboard', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getKeyboardArea().find('.calculator-keyboard').length,
                             1,
@@ -316,10 +296,9 @@ define([
                             'The layout contains a key for clear'
                         );
                         assert.equal(
-                            areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-command="clearAll"]')
-                                .length,
+                            areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-command="reset"]').length,
                             1,
-                            'The layout contains a key for clearAll'
+                            'The layout contains a key for reset'
                         );
                         assert.equal(
                             areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-command="execute"]')
@@ -328,14 +307,12 @@ define([
                             'The layout contains a key for execute'
                         );
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -343,76 +320,62 @@ define([
             });
     });
 
-    QUnit.test('render - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-render');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = templateKeyboardPluginFactory(calculator, areaBroker);
+    QUnit.test('render - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-render');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = templateKeyboardPluginFactory(calculator, areaBroker);
                 plugin.setConfig({ layout: 'foo' });
 
                 assert.expect(1);
 
                 calculator
-                    .on('plugin-render.templateKeyboard', function () {
+                    .on('plugin-render.templateKeyboard', () => {
                         assert.ok(false, 'Should not reach that point!');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.ok(false, 'Should not reach that point!');
                     })
-                    .catch(function () {
+                    .catch(() => {
                         assert.ok(true, 'The operation should fail!');
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function () {
+            .on('error', () => {
                 assert.ok(true, 'The operation should fail!');
                 calculator.destroy();
             });
     });
 
-    QUnit.test('destroy', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-destroy');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = templateKeyboardPluginFactory(calculator, areaBroker);
+    QUnit.test('destroy', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-destroy');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = templateKeyboardPluginFactory(calculator, areaBroker);
 
                 assert.expect(3);
 
                 calculator
-                    .on('plugin-render.templateKeyboard', function () {
+                    .on('plugin-render.templateKeyboard', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getKeyboardArea().find('.calculator-keyboard').length,
                             1,
@@ -421,21 +384,19 @@ define([
 
                         return plugin.destroy();
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(
                             areaBroker.getKeyboardArea().find('.calculator-keyboard').length,
                             0,
                             'The keyboard layout has been removed'
                         );
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -443,33 +404,27 @@ define([
             });
     });
 
-    QUnit.test('use keys', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-keys');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = templateKeyboardPluginFactory(calculator, areaBroker);
+    QUnit.test('use keys', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-keys');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = templateKeyboardPluginFactory(calculator, areaBroker);
 
                 assert.expect(15);
 
                 calculator
-                    .on('plugin-render.templateKeyboard', function () {
+                    .on('plugin-render.templateKeyboard', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getKeyboardArea().find('.calculator-keyboard').length,
                             1,
@@ -483,101 +438,138 @@ define([
 
                         assert.equal(calculator.getExpression(), '', 'The expression is empty');
                     })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            calculator.after('command-term.test', function (term) {
-                                calculator.off('command-term.test');
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .on('command-term', term => {
+                                        calculator.off('command-term');
 
-                                assert.equal(term, 'NUM4', 'The term NUM4 has been used');
-                                assert.equal(calculator.getExpression(), '4', 'The expression contains 4');
+                                        assert.equal(term, 'NUM4', 'The term NUM4 has been used');
+                                    })
+                                    .on('expressionchange', expression => {
+                                        calculator.off('expressionchange');
 
-                                resolve();
-                            });
-                            areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-param="NUM4"]').click();
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            calculator.after('command-term.test', function (term) {
-                                calculator.off('command-term.test');
+                                        assert.equal(expression, '4', 'The expression contains 4');
 
-                                assert.equal(term, 'NUM2', 'The term NUM2 has been used');
-                                assert.equal(calculator.getExpression(), '42', 'The expression contains 42');
+                                        resolve();
+                                    });
+                                areaBroker
+                                    .getKeyboardArea()
+                                    .find('.calculator-keyboard .key[data-param="NUM4"]')
+                                    .click();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .on('command-term', term => {
+                                        calculator.off('command-term');
 
-                                resolve();
-                            });
-                            areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-param="NUM2"]').click();
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            calculator.after('command-term.test', function (term) {
-                                calculator.off('command-term.test');
+                                        assert.equal(term, 'NUM2', 'The term NUM2 has been used');
+                                    })
+                                    .on('expressionchange', expression => {
+                                        calculator.off('expressionchange');
+                                        assert.equal(expression, '42', 'The expression contains 42');
 
-                                assert.equal(term, 'ADD', 'The term ADD has been used');
-                                assert.equal(calculator.getExpression(), '42+', 'The expression contains 42+');
+                                        resolve();
+                                    });
+                                areaBroker
+                                    .getKeyboardArea()
+                                    .find('.calculator-keyboard .key[data-param="NUM2"]')
+                                    .click();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .on('command-term', term => {
+                                        calculator.off('command-term');
 
-                                resolve();
-                            });
-                            areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-param="ADD"]').click();
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            calculator.after('command-term.test', function (term) {
-                                calculator.off('command-term.test');
+                                        assert.equal(term, 'ADD', 'The term ADD has been used');
+                                    })
+                                    .on('expressionchange', expression => {
+                                        calculator.off('expressionchange');
+                                        assert.equal(expression, '42+', 'The expression contains 42+');
 
-                                assert.equal(term, 'NUM3', 'The term NUM3 has been used');
-                                assert.equal(calculator.getExpression(), '42+3', 'The expression contains 42+3');
+                                        resolve();
+                                    });
+                                areaBroker
+                                    .getKeyboardArea()
+                                    .find('.calculator-keyboard .key[data-param="ADD"]')
+                                    .click();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .on('command-term', term => {
+                                        calculator.off('command-term');
 
-                                resolve();
-                            });
-                            areaBroker.getKeyboardArea().find('.calculator-keyboard .key[data-param="NUM3"]').click();
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            calculator.after('evaluate.test', function (result) {
-                                calculator.off('evaluate.test');
+                                        assert.equal(term, 'NUM3', 'The term NUM3 has been used');
+                                    })
+                                    .on('expressionchange', expression => {
+                                        calculator.off('expressionchange');
+                                        assert.equal(expression, '42+3', 'The expression contains 42+3');
 
-                                assert.equal(
-                                    result.value,
-                                    '45',
-                                    'The expression has been computed and the result is 45'
-                                );
-                                assert.equal(calculator.getExpression(), '42+3', 'The expression still contains 42+3');
+                                        resolve();
+                                    });
+                                areaBroker
+                                    .getKeyboardArea()
+                                    .find('.calculator-keyboard .key[data-param="NUM3"]')
+                                    .click();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator.on('evaluate', result => {
+                                    calculator.off('evaluate');
 
-                                resolve();
-                            });
-                            areaBroker
-                                .getKeyboardArea()
-                                .find('.calculator-keyboard .key[data-command="execute"]')
-                                .click();
-                        });
-                    })
-                    .then(function () {
-                        return new Promise(function (resolve) {
-                            calculator.after('command-clear.test', function () {
-                                calculator.off('command-clear.test');
+                                    assert.equal(
+                                        result.value,
+                                        '45',
+                                        'The expression has been computed and the result is 45'
+                                    );
+                                    assert.equal(
+                                        calculator.getExpression(),
+                                        '42+3',
+                                        'The expression still contains 42+3'
+                                    );
 
-                                assert.equal(calculator.getExpression(), '', 'The expression has been cleared');
+                                    resolve();
+                                });
+                                areaBroker
+                                    .getKeyboardArea()
+                                    .find('.calculator-keyboard .key[data-command="execute"]')
+                                    .click();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator.on('clear', () => {
+                                    calculator.off('clear');
 
-                                resolve();
-                            });
-                            areaBroker
-                                .getKeyboardArea()
-                                .find('.calculator-keyboard .key[data-command="clear"]')
-                                .click();
-                        });
-                    })
-                    .catch(function (err) {
+                                    assert.equal(calculator.getExpression(), '', 'The expression has been cleared');
+
+                                    resolve();
+                                });
+                                areaBroker
+                                    .getKeyboardArea()
+                                    .find('.calculator-keyboard .key[data-command="clear"]')
+                                    .click();
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -587,12 +579,11 @@ define([
 
     QUnit.module('visual test');
 
-    $.fn.setCursorPosition = function (pos) {
-        var range;
+    $.fn.setCursorPosition = function setCursorPosition(pos) {
         if (this.setSelectionRange) {
             this.setSelectionRange(pos, pos);
         } else if (this.createTextRange) {
-            range = this.createTextRange();
+            const range = this.createTextRange();
             range.collapse(true);
             if (pos < 0) {
                 pos = $(this).val().length + pos;
@@ -603,29 +594,20 @@ define([
         }
     };
 
-    QUnit.test('keyboard', function (assert) {
-        var ready = assert.async();
-        var $container = $('#visual-test');
-        var $output = $('#visual-test .output input');
-        var $input = $('#visual-test .input input');
+    QUnit.test('keyboard', assert => {
+        const ready = assert.async();
+        const $container = $('#visual-test');
+        const $output = $('#visual-test .output input');
+        const $input = $('#visual-test .input input');
         calculatorBoardFactory($container, [templateKeyboardPluginFactory])
-            .on('expressionchange', function () {
-                $input.val(this.getExpression());
-            })
-            .on('positionchange', function () {
-                $input.setCursorPosition(this.getPosition());
-            })
-            .on('evaluate', function (result) {
-                $output.val(result.value);
-            })
-            .on('syntaxerror', function (err) {
-                $output.val(err);
-            })
-            .on('command-clearAll', function () {
-                $output.val('');
-            })
-            .on('ready', function () {
-                var areaBroker = this.getAreaBroker();
+            .on('ready', function onReady() {
+                this.on('expressionchange', expression => $input.val(expression))
+                    .on('positionchange', position => $input.setCursorPosition(position))
+                    .on('result', result => $output.val(result.value))
+                    .on('syntaxerror', err => $output.val(err))
+                    .on('clear', () => $output.val(''));
+
+                const areaBroker = this.getAreaBroker();
                 assert.equal(
                     areaBroker.getKeyboardArea().find('.calculator-keyboard').length,
                     1,
@@ -634,7 +616,7 @@ define([
 
                 ready();
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');

--- a/test/maths/calculator/plugins/screen/simpleScreen/test.html
+++ b/test/maths/calculator/plugins/screen/simpleScreen/test.html
@@ -14,6 +14,9 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #ccc;

--- a/test/maths/calculator/plugins/screen/simpleScreen/test.js
+++ b/test/maths/calculator/plugins/screen/simpleScreen/test.js
@@ -13,36 +13,33 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 Open Assessment Technologies SA ;
- */
-/**
- * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ * Copyright (c) 2018-2023 Open Assessment Technologies SA ;
  */
 define([
     'jquery',
     'lodash',
     'ui/maths/calculator/core/board',
-    'ui/maths/calculator/core/terms',
-    'ui/maths/calculator/core/expression',
-    'ui/maths/calculator/plugins/screen/simpleScreen/simpleScreen',
-    'util/mathsEvaluator'
-], function (
-    $,
-    _,
-    calculatorBoardFactory,
-    registeredTerms,
-    expressionHelper,
-    simpleScreenPluginFactory,
-    mathsEvaluatorFactory
-) {
+    'ui/maths/calculator/core/labels',
+    'ui/maths/calculator/plugins/screen/simpleScreen/simpleScreen'
+], function ($, _, calculatorBoardFactory, labels, simpleScreenPluginFactory) {
     'use strict';
 
-    var mathsEvaluator = mathsEvaluatorFactory();
+    function assertToken(assert, $container, index, token, type, value, label) {
+        const element = $container.find(`.term:eq(${index})`).get(0);
+        assert.equal(element.dataset.token, token, `the term ${index} has the token ${token}`);
+        assert.equal(element.dataset.type, type, `the term ${index} has the type ${type}`);
+        assert.equal(element.dataset.value, value, `the term ${index} has the value ${value}`);
+        assert.equal(element.innerHTML.trim(), label, `the term ${index} has the label ${label}`);
+    }
+
+    function assertTokenNumber(assert, $container, count) {
+        assert.equal($container.find('.term').length, count, `${count} terms has been transformed`);
+    }
 
     QUnit.module('module');
 
-    QUnit.test('simpleScreen', function (assert) {
-        var calculator = calculatorBoardFactory();
+    QUnit.test('simpleScreen', assert => {
+        const calculator = calculatorBoardFactory();
 
         assert.expect(3);
 
@@ -75,9 +72,9 @@ define([
             { title: 'enable' },
             { title: 'disable' }
         ])
-        .test('plugin API ', function (data, assert) {
-            var calculator = calculatorBoardFactory();
-            var plugin = simpleScreenPluginFactory(calculator);
+        .test('plugin API ', (data, assert) => {
+            const calculator = calculatorBoardFactory();
+            const plugin = simpleScreenPluginFactory(calculator);
             assert.expect(1);
             assert.equal(
                 typeof plugin[data.title],
@@ -88,35 +85,33 @@ define([
 
     QUnit.module('behavior');
 
-    QUnit.test('install', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-install');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('install', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-install');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(1);
 
                 calculator
-                    .on('plugin-install.simpleScreen', function () {
+                    .on('plugin-install.simpleScreen', () => {
                         assert.ok(true, 'The plugin has been installed');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -124,38 +119,34 @@ define([
             });
     });
 
-    QUnit.test('init', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-init');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('init', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-init');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(1);
 
                 calculator
-                    .on('plugin-init.simpleScreen', function () {
+                    .on('plugin-init.simpleScreen', () => {
                         assert.ok(plugin.getState('init'), 'The plugin has been initialized');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .catch(function (err) {
+                    .then(() => plugin.init())
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -163,46 +154,32 @@ define([
             });
     });
 
-    QUnit.test('render', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-render');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('render', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-render');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
-                assert.expect(10);
+                assert.expect(11);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
+                        const $screen = areaBroker.getScreenArea().find('.calculator-screen');
+                        assert.equal($screen.length, 1, 'The screen layout has been inserted');
+                        assert.equal($screen.find('.history').length, 1, 'The screen layout contains area for history');
                         assert.equal(
-                            areaBroker.getScreenArea().find('.calculator-screen').length,
-                            1,
-                            'The screen layout has been inserted'
-                        );
-                        assert.equal(
-                            areaBroker.getScreenArea().find('.calculator-screen .history').length,
-                            1,
-                            'The screen layout contains area for history'
-                        );
-                        assert.equal(
-                            areaBroker.getScreenArea().find('.calculator-screen .expression').length,
+                            $screen.find('.expression').length,
                             1,
                             'The screen layout contains area for expression'
                         );
@@ -216,31 +193,17 @@ define([
                             'The expected number of terms has been transformed'
                         );
 
-                        assert.equal(
-                            $screen.find('.term:eq(0)').data('value'),
-                            '0',
-                            'the first operand is transformed - data-value'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(0)').data('token'),
-                            'NUM0',
-                            'the first operand is transformed - data-token'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(0)').text().trim(),
-                            '0',
-                            'the first operand is transformed - content'
-                        );
+                        assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -248,76 +211,62 @@ define([
             });
     });
 
-    QUnit.test('render - failure', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-render');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('render - failure', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-render');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
                 plugin.setConfig({ layout: 'foo' });
 
                 assert.expect(1);
 
                 calculator
-                    .on('plugin-render.templateScreen', function () {
+                    .on('plugin-render.templateScreen', () => {
                         assert.ok(false, 'Should not reach that point!');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.ok(false, 'Should not reach that point!');
                     })
-                    .catch(function () {
+                    .catch(() => {
                         assert.ok(true, 'The operation should fail!');
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function () {
+            .on('error', () => {
                 assert.ok(true, 'The operation should fail!');
                 calculator.destroy();
             });
     });
 
-    QUnit.test('destroy', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-destroy');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('destroy', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-destroy');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(3);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -326,21 +275,19 @@ define([
 
                         return plugin.destroy();
                     })
-                    .then(function () {
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             0,
                             'The screen layout has been removed'
                         );
                     })
-                    .catch(function (err) {
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
-                        calculator.destroy();
-                    });
+                    .then(() => calculator.destroy());
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -348,33 +295,27 @@ define([
             });
     });
 
-    QUnit.test('transform expression', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-transform');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('transform expression', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-transform');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(51);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -384,297 +325,71 @@ define([
                         assert.equal(calculator.getExpression(), '0', 'The expression should be set to 0');
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.term').length,
-                                        3,
-                                        'The expected number of terms has been transformed'
-                                    );
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(assert, $screen, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 1, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $screen, 2, 'NUM2', 'digit', '2', '2');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .replace('3+2');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(assert, $screen, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 1, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $screen, 2, 'term', 'unknown', 'x', 'x');
 
-                                    resolve();
-                                })
-                                .replace('3+2');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.term').length,
-                                        3,
-                                        'The expected number of terms has been transformed'
-                                    );
+                                        resolve();
+                                    })
+                                    .replace('3+x');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 5);
+                                        assertToken(assert, $screen, 0, 'SQRT', 'function', 'sqrt', labels.SQRT);
+                                        assertToken(assert, $screen, 1, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 2, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $screen, 3, 'SIN', 'function', 'sin', labels.SIN);
+                                        assertToken(assert, $screen, 4, 'PI', 'constant', 'PI', labels.PI);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        'x',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'term',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'unknown',
-                                        'the second operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').html().trim(),
-                                        'x',
-                                        'the second operand is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .replace('3+x');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.term').length,
-                                        5,
-                                        'The expected number of terms has been transformed'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'sqrt',
-                                        'the term SQRT is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'SQRT',
-                                        'the term SQRT is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'function',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '\u221A',
-                                        'the term SQRT is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '3',
-                                        'the term NUM3 is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM3',
-                                        'the term NUM3 is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '3',
-                                        'the term NUM3 is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the term ADD is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the term ADD is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the term ADD is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').data('value'),
-                                        'sin',
-                                        'the term SIN is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').data('token'),
-                                        'SIN',
-                                        'the term SIN is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').data('type'),
-                                        'function',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').text().trim(),
-                                        'sin',
-                                        'the term SIN is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(4)').data('value'),
-                                        'PI',
-                                        'the term PI is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(4)').data('token'),
-                                        'PI',
-                                        'the term PI is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(4)').data('type'),
-                                        'constant',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(4)').html().trim(),
-                                        '\u03C0',
-                                        'the term PI is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .replace('sqrt 3+sin PI');
-                        });
-                    })
-                    .catch(function (err) {
+                                        resolve();
+                                    })
+                                    .replace('sqrt 3+sin PI');
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -682,152 +397,27 @@ define([
             });
     });
 
-    QUnit.test('transform all', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-transform-all');
-        var expectedTokens = [];
-        var expression = '';
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
-
-                calculator
-                    .on('plugin-render.simpleScreen', function () {
-                        assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
-                    })
-                    .on('destroy', function () {
-                        ready();
-                    });
-
-                plugin
-                    .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
-                        assert.equal(
-                            areaBroker.getScreenArea().find('.calculator-screen').length,
-                            1,
-                            'The screen layout has been inserted'
-                        );
-
-                        assert.equal(calculator.getExpression(), '0', 'The expression should be set to 0');
-                        assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.term').length,
-                                        expectedTokens.length + 1,
-                                        'The expected number of terms has been transformed'
-                                    );
-
-                                    _.forEach(expectedTokens, function (term, index) {
-                                        var el = $screen.find(`.expression .term[data-token="${term.token}"]`).get(0);
-                                        if (term.token === 'ANS') {
-                                            term.label = expressionHelper.render(calculator.getLastResult());
-                                        }
-                                        assert.equal(
-                                            el.dataset.value,
-                                            term.value,
-                                            `the term ${index} is transformed - data-value`
-                                        );
-                                        assert.equal(
-                                            el.dataset.token,
-                                            term.token,
-                                            `the term ${index} is transformed - data-token`
-                                        );
-                                        assert.equal(
-                                            el.dataset.type,
-                                            term.type,
-                                            `the term ${index} is transformed - data-type`
-                                        );
-                                        assert.equal(
-                                            el.innerHTML.trim(),
-                                            term.label,
-                                            `the term ${index} is transformed - content`
-                                        );
-                                    });
-
-                                    resolve();
-                                })
-                                .replace(expression);
-                        });
-                    })
-                    .catch(function (err) {
-                        assert.ok(false, `Unexpected failure : ${err.message}`);
-                    })
-                    .then(function () {
-                        plugin.destroy();
-                        calculator.destroy();
-                    });
-            })
-            .on('error', function (err) {
-                //eslint-disable-next-line no-console
-                console.error(err);
-                assert.ok(false, 'The operation should not fail!');
-                ready();
-            });
-
-        _.forEach(registeredTerms, function (term, token) {
-            if (token === 'ADD') {
-                // append a digit just before the ADD operator
-                // otherwise the operator will be displayed as positive sign change and the test will fail
-                expectedTokens.push({
-                    value: registeredTerms.NUM1.value,
-                    label: registeredTerms.NUM1.label,
-                    type: registeredTerms.NUM1.type,
-                    token: 'NUM1'
-                });
-                expression += `${registeredTerms.NUM1.value} `;
-            }
-            expression += `${term.value} `;
-            expectedTokens.push({
-                value: term.value,
-                label: term.label,
-                type: term.type,
-                token: token
-            });
-        });
-
-        assert.expect(expectedTokens.length * 4 + 5);
-    });
-
-    QUnit.test('evaluate expression', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-evaluate');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('evaluate expression', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-evaluate');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(135);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -840,716 +430,262 @@ define([
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed'
-                                    );
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                const $screen = $container.find('.calculator-screen .expression');
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(assert, $screen, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 1, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $screen, 2, 'NUM2', 'digit', '2', '2');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .replace('3+2');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('result.test', () => {
+                                        calculator.off('result.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history .history-expression');
+                                        const $result = $screen.find('.history .history-result');
 
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans',
+                                            'The expression should be set with the last result variable'
+                                        );
+                                        assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
+                                        assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    resolve();
-                                })
-                                .replace('3+2');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('evaluate.test', function () {
-                                    calculator.off('evaluate.test');
+                                        assert.equal(calculator.getVariable('ans').value, '5', 'The last result is 5');
 
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        'ans',
-                                        'The expression should be set with the last result variable'
-                                    );
-                                    assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        assertTokenNumber(assert, $expression, 2);
+                                        assertToken(
+                                            assert,
+                                            $expression,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('5')
+                                        );
+                                        assertToken(assert, $expression, 1, 'NUM5', 'digit', '5', '5');
 
-                                    assert.equal(calculator.getVariable('ans').value, '5', 'The last result is 5');
+                                        assert.equal(
+                                            $screen.find('.history .history-line').length,
+                                            1,
+                                            'The expected number of history lines has been added in the history'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-expression').length,
+                                            1,
+                                            'The history contains an expression'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-result').length,
+                                            1,
+                                            'The history contains a result'
+                                        );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        2,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assertTokenNumber(assert, $history, 3);
+                                        assertToken(assert, $history, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $history, 1, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $history, 2, 'NUM2', 'digit', '2', '2');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '5',
-                                        'the expression is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $result, 1);
+                                        assertToken(assert, $result, 0, 'NUM5', 'digit', '5', '5');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '5',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM5',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '5',
-                                        'the expression is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .evaluate();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.test', () => {
+                                        calculator.off('termadd.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-line').length,
-                                        1,
-                                        'The expected number of history lines has been added in the history'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression').length,
-                                        1,
-                                        'The history contains an expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result').length,
-                                        1,
-                                        'The history contains a result'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the history expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the history result'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans+',
+                                            'The expression should be ans+'
+                                        );
+                                        assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(
+                                            assert,
+                                            $screen,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('5')
+                                        );
+                                        assertToken(assert, $screen, 1, 'NUM5', 'digit', '5', '5');
+                                        assertToken(assert, $screen, 2, 'ADD', 'operator', '+', '+');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .useTerm('ADD');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.test', () => {
+                                        calculator.off('termadd.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans+3',
+                                            'The expression should be ans+'
+                                        );
+                                        assert.equal(calculator.getPosition(), 5, 'The position should be set to 5');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('value'),
-                                        '5',
-                                        'the result term is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('token'),
-                                        'NUM5',
-                                        'the result term is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the result term is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').html().trim(),
-                                        '5',
-                                        'the result term is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 4);
+                                        assertToken(
+                                            assert,
+                                            $screen,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('5')
+                                        );
+                                        assertToken(assert, $screen, 1, 'NUM5', 'digit', '5', '5');
+                                        assertToken(assert, $screen, 2, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $screen, 3, 'NUM3', 'digit', '3', '3');
 
-                                    resolve();
-                                })
-                                .evaluate();
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.test', function () {
-                                    calculator.off('termadd.test');
+                                        resolve();
+                                    })
+                                    .useTerm('NUM3');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('result.test', () => {
+                                        calculator.off('result.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history .history-expression');
+                                        const $result = $screen.find('.history .history-result');
 
-                                    assert.equal(calculator.getExpression(), 'ans+', 'The expression should be ans+');
-                                    assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans',
+                                            'The expression should be set with the last result variable'
+                                        );
+                                        assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
+                                        assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assert.equal(calculator.getVariable('ans').value, '8', 'The last result is 8');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '5',
-                                        'the variable is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $expression, 2);
+                                        assertToken(
+                                            assert,
+                                            $expression,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('8')
+                                        );
+                                        assertToken(assert, $expression, 1, 'NUM8', 'digit', '8', '8');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '5',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM5',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '5',
-                                        'the variable is transformed - content'
-                                    );
+                                        assert.equal(
+                                            $screen.find('.history .history-line').length,
+                                            1,
+                                            'The expected number of history lines has been added in the history'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-expression').length,
+                                            1,
+                                            'The history contains an expression'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-result').length,
+                                            1,
+                                            'The history contains a result'
+                                        );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $history, 4);
+                                        assertToken(
+                                            assert,
+                                            $history,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('8')
+                                        );
+                                        assertToken(assert, $history, 1, 'NUM8', 'digit', '8', '8');
+                                        assertToken(assert, $history, 2, 'ADD', 'operator', '+', '+');
+                                        assertToken(assert, $history, 3, 'NUM3', 'digit', '3', '3');
 
-                                    resolve();
-                                })
-                                .useTerm('ADD');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.test', function () {
-                                    calculator.off('termadd.test');
+                                        assertTokenNumber(assert, $result, 1);
+                                        assertToken(assert, $result, 0, 'NUM8', 'digit', '8', '8');
 
-                                    assert.equal(calculator.getExpression(), 'ans+3', 'The expression should be ans+');
-                                    assert.equal(calculator.getPosition(), 5, 'The position should be set to 5');
+                                        resolve();
+                                    })
+                                    .evaluate();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('command-reset.test', () => {
+                                        calculator.off('command-reset.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        4,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            '0',
+                                            'The expression should be clear to 0'
+                                        );
+                                        assert.equal(calculator.getPosition(), 1, 'The position should be clear to 1');
+                                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '5',
-                                        'the variable is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $expression, 1);
+                                        assertToken(assert, $expression, 0, 'NUM0', 'digit', '0', '0');
+                                        assertTokenNumber(assert, $history, 0);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '5',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM5',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '5',
-                                        'the variable is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').data('value'),
-                                        '3',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').data('token'),
-                                        'NUM3',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(3)').html().trim(),
-                                        '3',
-                                        'the second operand is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .useTerm('NUM3');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('evaluate.test', function () {
-                                    calculator.off('evaluate.test');
-
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        'ans',
-                                        'The expression should be set with the last result variable'
-                                    );
-                                    assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
-
-                                    assert.equal(calculator.getVariable('ans').value, '8', 'The last result is 8');
-
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        2,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '8',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '8',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM8',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '8',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-line').length,
-                                        1,
-                                        'The expected number of history lines has been added in the history'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression').length,
-                                        1,
-                                        'The history contains an expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result').length,
-                                        1,
-                                        'The history contains a result'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term').length,
-                                        4,
-                                        'The expected number of terms has been transformed in the history expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the history result'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').text().trim(),
-                                        '5',
-                                        'the first operand is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('value'),
-                                        '5',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('token'),
-                                        'NUM5',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').text().trim(),
-                                        '5',
-                                        'the first operand is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(3)').data('value'),
-                                        '3',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(3)').data('token'),
-                                        'NUM3',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(3)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(3)').html().trim(),
-                                        '3',
-                                        'the second operand is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('value'),
-                                        '8',
-                                        'the result term is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('token'),
-                                        'NUM8',
-                                        'the result term is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the result term is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').html().trim(),
-                                        '8',
-                                        'the result term is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .evaluate();
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('command-clearAll.test', function () {
-                                    calculator.off('command-clearAll.test');
-
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        '0',
-                                        'The expression should be reset to 0'
-                                    );
-                                    assert.equal(calculator.getPosition(), 1, 'The position should be reset to 1');
-                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
-
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '0',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM0',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal($screen.find('.history .term').length, 0, 'The history is cleared');
-
-                                    resolve();
-                                })
-                                .useCommand('clearAll');
-                        });
-                    })
-                    .catch(function (err) {
+                                        resolve();
+                                    })
+                                    .useCommand('reset');
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -1557,33 +693,27 @@ define([
             });
     });
 
-    QUnit.test('evaluate NaN', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-error-nan');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('evaluate NaN', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-error-nan');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(74);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -1596,389 +726,149 @@ define([
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed'
-                                    );
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'sqrt',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'SQRT',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'function',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        registeredTerms.SQRT.label,
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(assert, $screen, 0, 'SQRT', 'function', 'sqrt', labels.SQRT);
+                                        assertToken(assert, $screen, 1, 'NEG', 'operator', '-', labels.NEG);
+                                        assertToken(assert, $screen, 2, 'NUM2', 'digit', '2', '2');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '-',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NEG',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        registeredTerms.NEG.label,
-                                        'the operator is transformed - content'
-                                    );
+                                        assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .replace('sqrt -2');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('result.test', () => {
+                                        calculator.off('result.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history .history-expression');
+                                        const $result = $screen.find('.history .history-result');
 
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans',
+                                            'The expression should be set with the last result variable'
+                                        );
+                                        assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
+                                        assert.equal(calculator.is('error'), true, 'There is an error');
 
-                                    resolve();
-                                })
-                                .replace('sqrt -2');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('evaluate.test', function () {
-                                    calculator.off('evaluate.test');
+                                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        'ans',
-                                        'The expression should be set with the last result variable'
-                                    );
-                                    assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        assertTokenNumber(assert, $expression, 1);
+                                        assertToken(assert, $expression, 0, 'NAN', 'error', 'NaN', labels.NAN);
 
-                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
+                                        assert.equal(
+                                            $screen.find('.history .history-line').length,
+                                            1,
+                                            'The expected number of history lines has been added in the history'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-expression').length,
+                                            1,
+                                            'The history contains an expression'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-result').length,
+                                            1,
+                                            'The history contains a result'
+                                        );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assertTokenNumber(assert, $history, 3);
+                                        assertToken(assert, $history, 0, 'SQRT', 'function', 'sqrt', labels.SQRT);
+                                        assertToken(assert, $history, 1, 'NEG', 'operator', '-', labels.NEG);
+                                        assertToken(assert, $history, 2, 'NUM2', 'digit', '2', '2');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').get(0).dataset.value,
-                                        'NaN',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NAN',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'error',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        registeredTerms.NAN.label,
-                                        'the expression is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $result, 1);
+                                        assertToken(assert, $result, 0, 'NAN', 'error', 'NaN', labels.NAN);
 
-                                    assert.equal(
-                                        $screen.find('.history .history-line').length,
-                                        1,
-                                        'The expected number of history lines has been added in the history'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression').length,
-                                        1,
-                                        'The history contains an expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result').length,
-                                        1,
-                                        'The history contains a result'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the history expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the history result'
-                                    );
+                                        resolve();
+                                    })
+                                    .evaluate();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.test', () => {
+                                        calculator.off('termadd.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('value'),
-                                        'sqrt',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('token'),
-                                        'SQRT',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('type'),
-                                        'function',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').text().trim(),
-                                        registeredTerms.SQRT.label,
-                                        'the first operand is transformed - content'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans+',
+                                            'The expression should be ans+'
+                                        );
+                                        assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('value'),
-                                        '-',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('token'),
-                                        'NEG',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').text().trim(),
-                                        registeredTerms.NEG.label,
-                                        'the operator is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(
+                                            assert,
+                                            $screen,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('0')
+                                        );
+                                        assertToken(assert, $screen, 1, 'NUM0', 'digit', '0', '0');
+                                        assertToken(assert, $screen, 2, 'ADD', 'operator', '+', labels.ADD);
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .useTerm('ADD');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('command-clear.test', () => {
+                                        calculator.off('command-clear.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').get(0).dataset.value,
-                                        'NaN',
-                                        'the result term is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('token'),
-                                        'NAN',
-                                        'the result term is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('type'),
-                                        'error',
-                                        'the result term is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').html().trim(),
-                                        registeredTerms.NAN.label,
-                                        'the result term is transformed - content'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            '0',
+                                            'The expression should be clear to 0'
+                                        );
+                                        assert.equal(calculator.getPosition(), 1, 'The position should be clear to 1');
+                                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
-                                    resolve();
-                                })
-                                .evaluate();
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.test', function () {
-                                    calculator.off('termadd.test');
+                                        assertTokenNumber(assert, $expression, 1);
+                                        assertToken(assert, $expression, 0, 'NUM0', 'digit', '0', '0');
 
-                                    assert.equal(calculator.getExpression(), 'ans+', 'The expression should be ans+');
-                                    assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
+                                        assertTokenNumber(assert, $history, 0);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the variable is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '0',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM0',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '0',
-                                        'the variable is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .useTerm('ADD');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('command-clearAll.test', function () {
-                                    calculator.off('command-clearAll.test');
-
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        '0',
-                                        'The expression should be reset to 0'
-                                    );
-                                    assert.equal(calculator.getPosition(), 1, 'The position should be reset to 1');
-                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
-
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '0',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM0',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal($screen.find('.history .term').length, 0, 'The history is cleared');
-
-                                    resolve();
-                                })
-                                .useCommand('clearAll');
-                        });
-                    })
-                    .catch(function (err) {
+                                        resolve();
+                                    })
+                                    .useCommand('clear');
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -1986,33 +876,27 @@ define([
             });
     });
 
-    QUnit.test('evaluate Infinity', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-error-infinity');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('evaluate Infinity', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-error-infinity');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(74);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -2025,389 +909,166 @@ define([
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed'
-                                    );
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(assert, $screen, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 1, 'DIV', 'operator', '/', labels.DIV);
+                                        assertToken(assert, $screen, 2, 'NUM0', 'digit', '0', '0');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '/',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'DIV',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        registeredTerms.DIV.label,
-                                        'the operator is transformed - content'
-                                    );
+                                        assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '0',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'NUM0',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').html().trim(),
-                                        '0',
-                                        'the second operand is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .replace('3/0');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('result.test', () => {
+                                        calculator.off('result.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history .history-expression');
+                                        const $result = $screen.find('.history .history-result');
 
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans',
+                                            'The expression should be set with the last result variable'
+                                        );
+                                        assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
+                                        assert.equal(calculator.is('error'), true, 'There is an error');
 
-                                    resolve();
-                                })
-                                .replace('3/0');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('evaluate.test', function () {
-                                    calculator.off('evaluate.test');
+                                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        'ans',
-                                        'The expression should be set with the last result variable'
-                                    );
-                                    assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        assertTokenNumber(assert, $expression, 1);
+                                        assertToken(
+                                            assert,
+                                            $expression,
+                                            0,
+                                            'INFINITY',
+                                            'error',
+                                            'Infinity',
+                                            labels.INFINITY
+                                        );
 
-                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
+                                        assert.equal(
+                                            $screen.find('.history .history-line').length,
+                                            1,
+                                            'The expected number of history lines has been added in the history'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-expression').length,
+                                            1,
+                                            'The history contains an expression'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-result').length,
+                                            1,
+                                            'The history contains a result'
+                                        );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assertTokenNumber(assert, $history, 3);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').get(0).dataset.value,
-                                        'Infinity',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'INFINITY',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'error',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        registeredTerms.INFINITY.label,
-                                        'the expression is transformed - content'
-                                    );
+                                        assertToken(assert, $history, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $history, 1, 'DIV', 'operator', '/', labels.DIV);
+                                        assertToken(assert, $history, 2, 'NUM0', 'digit', '0', '0');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-line').length,
-                                        1,
-                                        'The expected number of history lines has been added in the history'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression').length,
-                                        1,
-                                        'The history contains an expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result').length,
-                                        1,
-                                        'The history contains a result'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the history expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the history result'
-                                    );
+                                        assertTokenNumber(assert, $result, 1);
+                                        assertToken(
+                                            assert,
+                                            $result,
+                                            0,
+                                            'INFINITY',
+                                            'error',
+                                            'Infinity',
+                                            labels.INFINITY
+                                        );
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .evaluate();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.test', () => {
+                                        calculator.off('termadd.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('value'),
-                                        '/',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('token'),
-                                        'DIV',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').text().trim(),
-                                        registeredTerms.DIV.label,
-                                        'the operator is transformed - content'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans+',
+                                            'The expression should be ans+'
+                                        );
+                                        assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
 
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('value'),
-                                        '0',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('token'),
-                                        'NUM0',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').html().trim(),
-                                        '0',
-                                        'the second operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(
+                                            assert,
+                                            $screen,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('0')
+                                        );
+                                        assertToken(assert, $screen, 1, 'NUM0', 'digit', '0', '0');
+                                        assertToken(assert, $screen, 2, 'ADD', 'operator', '+', labels.ADD);
 
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').get(0).dataset.value,
-                                        'Infinity',
-                                        'the result term is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('token'),
-                                        'INFINITY',
-                                        'the result term is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('type'),
-                                        'error',
-                                        'the result term is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').html().trim(),
-                                        registeredTerms.INFINITY.label,
-                                        'the result term is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .useTerm('ADD');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('command-clear.test', () => {
+                                        calculator.off('command-clear.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history');
 
-                                    resolve();
-                                })
-                                .evaluate();
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.test', function () {
-                                    calculator.off('termadd.test');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            '0',
+                                            'The expression should be clear to 0'
+                                        );
+                                        assert.equal(calculator.getPosition(), 1, 'The position should be clear to 1');
+                                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
-                                    assert.equal(calculator.getExpression(), 'ans+', 'The expression should be ans+');
-                                    assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
+                                        assertTokenNumber(assert, $expression, 1);
+                                        assertToken(assert, $expression, 0, 'NUM0', 'digit', '0', '0');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assertTokenNumber(assert, $history, 0);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the variable is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '0',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM0',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '0',
-                                        'the variable is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .useTerm('ADD');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('command-clearAll.test', function () {
-                                    calculator.off('command-clearAll.test');
-
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        '0',
-                                        'The expression should be reset to 0'
-                                    );
-                                    assert.equal(calculator.getPosition(), 1, 'The position should be reset to 1');
-                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
-
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '0',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM0',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal($screen.find('.history .term').length, 0, 'The history is cleared');
-
-                                    resolve();
-                                })
-                                .useCommand('clearAll');
-                        });
-                    })
-                    .catch(function (err) {
+                                        resolve();
+                                    })
+                                    .useCommand('clear');
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2415,33 +1076,27 @@ define([
             });
     });
 
-    QUnit.test('evaluate syntax error', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-error-syntax');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('evaluate syntax error', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-error-syntax');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                 assert.expect(82);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
-
+                    .on('destroy', ready);
+                // calculator.getCalculator().setCorrectorMode(false);
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -2454,431 +1109,156 @@ define([
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
                         assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('expressionchange.test', function () {
-                                    calculator.off('expressionchange.test');
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        2,
-                                        'The expected number of terms has been transformed'
-                                    );
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('expressionchange.test', () => {
+                                        calculator.off('expressionchange.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $screen, 2);
+                                        assertToken(assert, $screen, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 1, 'ADD', 'operator', '+', labels.ADD);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(calculator.is('error'), false, 'There is no error');
+                                        resolve();
+                                    })
+                                    .replace('3+');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('result.test', () => {
+                                        assert.ok(false, 'The expresion should raise a syntax error!');
+                                    })
+                                    .after('syntaxerror.test', () => {
+                                        calculator.off('result.test');
+                                        calculator.off('syntaxerror.test');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            '3+',
+                                            'The expression should not change'
+                                        );
+                                        assert.equal(calculator.getPosition(), 2, 'The position should be set to 2');
+                                        assert.equal(calculator.is('error'), true, 'There is an error');
 
-                                    resolve();
-                                })
-                                .replace('3+');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('evaluate.test', function () {
-                                    assert.ok(false, 'The expresion should raise a syntax error!');
-                                })
-                                .after('syntaxerror.test', function () {
-                                    calculator.off('evaluate.test');
-                                    calculator.off('syntaxerror.test');
-                                    assert.equal(calculator.getExpression(), '3+', 'The expression should not change');
-                                    assert.equal(calculator.getPosition(), 2, 'The position should be set to 2');
-                                    assert.equal(calculator.is('error'), true, 'There is an error');
+                                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
-                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed'
-                                    );
+                                        assertTokenNumber(assert, $expression, 3);
+                                        assertToken(assert, $expression, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $expression, 1, 'ADD', 'operator', '+', labels.ADD);
+                                        assertToken(assert, $expression, 2, 'ERROR', 'error', 'Syntax', labels.ERROR);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $history, 0);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .evaluate();
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.test', () => {
+                                        calculator.off('termadd.test');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '#',
-                                        'the error is added - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ERROR',
-                                        'the error is added - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'error',
-                                        'the error is added - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        registeredTerms.ERROR.label,
-                                        'the expression is transformed - content'
-                                    );
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            '3+2',
+                                            'The expression should be ans+'
+                                        );
+                                        assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
 
-                                    assert.equal($screen.find('.history .term').length, 0, 'The history is empty');
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(assert, $screen, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $screen, 1, 'ADD', 'operator', '+', labels.ADD);
+                                        assertToken(assert, $screen, 2, 'NUM2', 'digit', '2', '2');
 
-                                    resolve();
-                                })
-                                .evaluate();
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.test', function () {
-                                    calculator.off('termadd.test');
+                                        resolve();
+                                    })
+                                    .useTerm('NUM2');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('result.test', () => {
+                                        calculator.off('result.test');
+                                        const $screen = $container.find('.calculator-screen');
+                                        const $expression = $screen.find('.expression');
+                                        const $history = $screen.find('.history .history-expression');
+                                        const $result = $screen.find('.history .history-result');
 
-                                    assert.equal(calculator.getExpression(), '3+2', 'The expression should be ans+');
-                                    assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans',
+                                            'The expression should be set with the last result variable'
+                                        );
+                                        assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assert.equal(calculator.getVariable('ans').value, '5', 'The last result is 5');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $expression, 2);
+                                        assertToken(
+                                            assert,
+                                            $expression,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('5')
+                                        );
+                                        assertToken(assert, $expression, 1, 'NUM5', 'digit', '5', '5');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                        assert.equal(
+                                            $screen.find('.history .history-line').length,
+                                            1,
+                                            'The expected number of history lines has been added in the history'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-expression').length,
+                                            1,
+                                            'The history contains an expression'
+                                        );
+                                        assert.equal(
+                                            $screen.find('.history .history-result').length,
+                                            1,
+                                            'The history contains a result'
+                                        );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
+                                        assertTokenNumber(assert, $history, 3);
+                                        assertToken(assert, $history, 0, 'NUM3', 'digit', '3', '3');
+                                        assertToken(assert, $history, 1, 'ADD', 'operator', '+', labels.ADD);
+                                        assertToken(assert, $history, 2, 'NUM2', 'digit', '2', '2');
 
-                                    resolve();
-                                })
-                                .useTerm('NUM2');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('evaluate.test', function () {
-                                    calculator.off('evaluate.test');
+                                        assertTokenNumber(assert, $result, 1);
+                                        assertToken(assert, $result, 0, 'NUM5', 'digit', '5', '5');
 
-                                    assert.equal(
-                                        calculator.getExpression(),
-                                        'ans',
-                                        'The expression should be set with the last result variable'
-                                    );
-                                    assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
-
-                                    assert.equal(calculator.getVariable('ans').value, '5', 'The last result is 5');
-
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        2,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '5',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '5',
-                                        'the expression is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM5',
-                                        'the expression is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the expression is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '5',
-                                        'the expression is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-line').length,
-                                        1,
-                                        'The expected number of history lines has been added in the history'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression').length,
-                                        1,
-                                        'The history contains an expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result').length,
-                                        1,
-                                        'The history contains a result'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the history expression'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term').length,
-                                        1,
-                                        'The expected number of terms has been transformed in the history result'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('value'),
-                                        '3',
-                                        'the first operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('token'),
-                                        'NUM3',
-                                        'the first operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(0)').text().trim(),
-                                        '3',
-                                        'the first operand is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('value'),
-                                        '2',
-                                        'the second operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('token'),
-                                        'NUM2',
-                                        'the second operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').data('type'),
-                                        'digit',
-                                        'the first operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-expression .term:eq(2)').html().trim(),
-                                        '2',
-                                        'the second operand is transformed - content'
-                                    );
-
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('value'),
-                                        '5',
-                                        'the result term is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('token'),
-                                        'NUM5',
-                                        'the result term is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the result term is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.history .history-result .term:eq(0)').html().trim(),
-                                        '5',
-                                        'the result term is transformed - content'
-                                    );
-
-                                    resolve();
-                                })
-                                .evaluate();
-                        });
-                    })
-                    .catch(function (err) {
+                                        resolve();
+                                    })
+                                    .evaluate();
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -2886,34 +1266,28 @@ define([
             });
     });
 
-    QUnit.test('0 and operator', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-zero-op');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('0 and operator', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-zero-op');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
-                assert.expect(40);
+                assert.expect(42);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
+                        const $screen = $container.find('.calculator-screen');
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -2923,223 +1297,83 @@ define([
                         assert.equal(calculator.getExpression(), '0', 'The expression should be set to 0');
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
 
-                        assert.equal(
-                            $screen.find('.term').length,
-                            1,
-                            'The expected number of terms has been transformed'
-                        );
-
-                        assert.equal(
-                            $screen.find('.term:eq(0)').data('value'),
-                            '0',
-                            'the first operand is transformed - data-value'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(0)').data('token'),
-                            'NUM0',
-                            'the first operand is transformed - data-token'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(0)').text().trim(),
-                            '0',
-                            'the first operand is transformed - content'
-                        );
+                        assertTokenNumber(assert, $screen, 1);
+                        assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.test', function () {
-                                    calculator.off('termadd.test');
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.test', () => {
+                                        calculator.off('termadd.test');
+                                        const $screen = $container.find('.calculator-screen');
 
-                                    assert.equal(calculator.getExpression(), '0', 'The expression should still be 0');
-                                    assert.equal(calculator.getPosition(), 1, 'The position should still be 1');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            '0',
+                                            'The expression should still be 0'
+                                        );
+                                        assert.equal(calculator.getPosition(), 1, 'The position should still be 1');
 
-                                    assert.equal(
-                                        $screen.find('.term').length,
-                                        1,
-                                        'The expected number of terms should remain the same'
-                                    );
+                                        assertTokenNumber(assert, $screen, 1);
+                                        assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
 
-                                    assert.equal(
-                                        $screen.find('.term:eq(0)').data('value'),
-                                        '0',
-                                        'the operand is unchanged - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.term:eq(0)').data('token'),
-                                        'NUM0',
-                                        'the operand is unchanged - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.term:eq(0)').text().trim(),
-                                        '0',
-                                        'the operand is unchanged - content'
-                                    );
+                                        resolve();
+                                    })
+                                    .useTerm('NUM0');
+                            })
+                    )
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.ADD', () => {
+                                        calculator.off('termadd.ADD');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    resolve();
-                                })
-                                .useTerm('NUM0');
-                        });
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.ADD', function () {
-                                    calculator.off('termadd.ADD');
+                                        assert.equal(calculator.getExpression(), '0+', 'The expression should be 0+');
+                                        assert.equal(calculator.getPosition(), 2, 'The position should be set to 2');
 
-                                    assert.equal(calculator.getExpression(), '0+', 'The expression should be 0+');
-                                    assert.equal(calculator.getPosition(), 2, 'The position should be set to 2');
+                                        assertTokenNumber(assert, $screen, 2);
+                                        assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
+                                        assertToken(assert, $screen, 1, 'ADD', 'operator', '+', labels.ADD);
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        2,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        calculator
+                                            .after('termadd.NUM5', () => {
+                                                calculator.off('termadd.NUM5');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        '0',
-                                        'the operand is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'NUM0',
-                                        'the operand is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'digit',
-                                        'the operand is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the operand is transformed - content'
-                                    );
+                                                assert.equal(
+                                                    calculator.getExpression(),
+                                                    '0+5',
+                                                    'The expression should be 0+5'
+                                                );
+                                                assert.equal(
+                                                    calculator.getPosition(),
+                                                    3,
+                                                    'The position should be set to 3'
+                                                );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                                assertTokenNumber(assert, $screen, 3);
+                                                assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
+                                                assertToken(assert, $screen, 1, 'ADD', 'operator', '+', labels.ADD);
+                                                assertToken(assert, $screen, 2, 'NUM5', 'digit', '5', '5');
 
-                                    calculator
-                                        .after('termadd.NUM5', function () {
-                                            calculator.off('termadd.NUM5');
-
-                                            assert.equal(
-                                                calculator.getExpression(),
-                                                '0+5',
-                                                'The expression should be 0+5'
-                                            );
-                                            assert.equal(
-                                                calculator.getPosition(),
-                                                3,
-                                                'The position should be set to 3'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term').length,
-                                                3,
-                                                'The expected number of terms has been transformed in the expression'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').data('value'),
-                                                '0',
-                                                'the operand is transformed - data-value'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').data('token'),
-                                                'NUM0',
-                                                'the operand is transformed - data-token'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').data('type'),
-                                                'digit',
-                                                'the operand is transformed - data-type'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').text().trim(),
-                                                '0',
-                                                'the operand is transformed - content'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(1)').data('value'),
-                                                '+',
-                                                'the operator is transformed - data-value'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(1)').data('token'),
-                                                'ADD',
-                                                'the operator is transformed - data-token'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(1)').data('type'),
-                                                'operator',
-                                                'the operator is transformed - data-type'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(1)').text().trim(),
-                                                '+',
-                                                'the operator is transformed - content'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').data('value'),
-                                                '5',
-                                                'the operand is transformed - data-value'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').data('token'),
-                                                'NUM5',
-                                                'the operand is transformed - data-token'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').data('type'),
-                                                'digit',
-                                                'the operand is transformed - data-type'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').text().trim(),
-                                                '5',
-                                                'the operand is transformed - content'
-                                            );
-
-                                            resolve();
-                                        })
-                                        .useTerm('NUM5');
-                                })
-                                .useTerm('ADD');
-                        });
-                    })
-                    .catch(function (err) {
+                                                resolve();
+                                            })
+                                            .useTerm('NUM5');
+                                    })
+                                    .useTerm('ADD');
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -3155,7 +1389,7 @@ define([
                 expression: 'PI',
                 value: 'PI',
                 type: 'constant',
-                label: registeredTerms.PI.label
+                label: labels.PI
             },
             {
                 title: '3',
@@ -3179,37 +1413,31 @@ define([
                 expression: 'sqrt',
                 value: 'sqrt',
                 type: 'function',
-                label: registeredTerms.SQRT.label
+                label: labels.SQRT
             }
         ])
-        .test('0 and const', function (data, assert) {
-            var ready = assert.async();
-            var $container = $('#fixture-zero-const');
-            var calculator = calculatorBoardFactory($container)
-                .on('ready', function () {
-                    var areaBroker = calculator.getAreaBroker();
-                    var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+        .test('0 and const', (data, assert) => {
+            const ready = assert.async();
+            const $container = $('#fixture-zero-const');
+            const calculator = calculatorBoardFactory($container)
+                .on('ready', () => {
+                    const areaBroker = calculator.getAreaBroker();
+                    const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
-                    assert.expect(21);
+                    assert.expect(23);
 
                     calculator
-                        .on('plugin-render.simpleScreen', function () {
+                        .on('plugin-render.simpleScreen', () => {
                             assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                         })
-                        .on('destroy', function () {
-                            ready();
-                        });
+                        .on('destroy', ready());
 
                     plugin
                         .install()
-                        .then(function () {
-                            return plugin.init();
-                        })
-                        .then(function () {
-                            return plugin.render();
-                        })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen');
+                        .then(() => plugin.init())
+                        .then(() => plugin.render())
+                        .then(() => {
+                            const $screen = $container.find('.calculator-screen');
                             assert.equal(
                                 areaBroker.getScreenArea().find('.calculator-screen').length,
                                 1,
@@ -3219,128 +1447,76 @@ define([
                             assert.equal(calculator.getExpression(), '0', 'The expression should be set to 0');
                             assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
 
-                            assert.equal(
-                                $screen.find('.term').length,
-                                1,
-                                'The expected number of terms has been transformed'
-                            );
-
-                            assert.equal(
-                                $screen.find('.term:eq(0)').data('value'),
-                                '0',
-                                'the first operand is transformed - data-value'
-                            );
-                            assert.equal(
-                                $screen.find('.term:eq(0)').data('token'),
-                                'NUM0',
-                                'the first operand is transformed - data-token'
-                            );
-                            assert.equal(
-                                $screen.find('.term:eq(0)').text().trim(),
-                                '0',
-                                'the first operand is transformed - content'
-                            );
+                            assertTokenNumber(assert, $screen, 1);
+                            assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
                         })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen');
-                            return new Promise(function (resolve) {
-                                calculator
-                                    .after('termadd.test', function () {
-                                        calculator.off('termadd.test');
+                        .then(
+                            () =>
+                                new Promise(resolve => {
+                                    calculator
+                                        .after('termadd.test', () => {
+                                            calculator.off('termadd.test');
+                                            const $screen = $container.find('.calculator-screen');
 
-                                        assert.equal(
-                                            calculator.getExpression(),
-                                            '0',
-                                            'The expression should still be 0'
-                                        );
-                                        assert.equal(calculator.getPosition(), 1, 'The position should still be 1');
+                                            assert.equal(
+                                                calculator.getExpression(),
+                                                '0',
+                                                'The expression should still be 0'
+                                            );
+                                            assert.equal(calculator.getPosition(), 1, 'The position should still be 1');
 
-                                        assert.equal(
-                                            $screen.find('.term').length,
-                                            1,
-                                            'The expected number of terms should remain the same'
-                                        );
+                                            assertTokenNumber(assert, $screen, 1);
+                                            assertToken(assert, $screen, 0, 'NUM0', 'digit', '0', '0');
 
-                                        assert.equal(
-                                            $screen.find('.term:eq(0)').data('value'),
-                                            '0',
-                                            'the operand is unchanged - data-value'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.term:eq(0)').data('token'),
-                                            'NUM0',
-                                            'the operand is unchanged - data-token'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.term:eq(0)').text().trim(),
-                                            '0',
-                                            'the operand is unchanged - content'
-                                        );
+                                            resolve();
+                                        })
+                                        .useTerm('NUM0');
+                                })
+                        )
+                        .then(
+                            () =>
+                                new Promise(resolve => {
+                                    calculator
+                                        .after('termadd.test', () => {
+                                            calculator.off('termadd.test');
+                                            const $screen = $container.find('.calculator-screen .expression');
 
-                                        resolve();
-                                    })
-                                    .useTerm('NUM0');
-                            });
-                        })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen');
-                            return new Promise(function (resolve) {
-                                calculator
-                                    .after('termadd.test', function () {
-                                        calculator.off('termadd.test');
+                                            assert.equal(
+                                                calculator.getExpression(),
+                                                data.expression,
+                                                `The expression should be ${data.expression}`
+                                            );
+                                            assert.equal(
+                                                calculator.getPosition(),
+                                                data.expression.length,
+                                                `The position should be ${data.expression.length}`
+                                            );
 
-                                        assert.equal(
-                                            calculator.getExpression(),
-                                            data.expression,
-                                            `The expression should be ${data.expression}`
-                                        );
-                                        assert.equal(
-                                            calculator.getPosition(),
-                                            data.expression.length,
-                                            `The position should be ${data.expression.length}`
-                                        );
+                                            assertTokenNumber(assert, $screen, 1);
+                                            assertToken(
+                                                assert,
+                                                $screen,
+                                                0,
+                                                data.term,
+                                                data.type,
+                                                data.value,
+                                                data.label
+                                            );
 
-                                        assert.equal(
-                                            $screen.find('.expression .term').length,
-                                            1,
-                                            'The expected number of terms has been transformed in the expression'
-                                        );
-
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').data('value'),
-                                            data.value,
-                                            'the operand is transformed - data-value'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').data('token'),
-                                            data.term,
-                                            'the operand is transformed - data-token'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').data('type'),
-                                            data.type,
-                                            'the operand is transformed - data-type'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').text().trim(),
-                                            data.label,
-                                            'the operand is transformed - content'
-                                        );
-
-                                        resolve();
-                                    })
-                                    .useTerm(data.term);
-                            });
-                        })
-                        .catch(function (err) {
+                                            resolve();
+                                        })
+                                        .useTerm(data.term);
+                                })
+                        )
+                        .catch(err => {
                             assert.ok(false, `Unexpected failure : ${err.message}`);
                         })
-                        .then(function () {
+                        .then(() => {
                             plugin.destroy();
                             calculator.destroy();
                         });
                 })
-                .on('error', function (err) {
+                .on('error', err => {
                     //eslint-disable-next-line no-console
                     console.error(err);
                     assert.ok(false, 'The operation should not fail!');
@@ -3348,34 +1524,28 @@ define([
                 });
         });
 
-    QUnit.test('ans and operator', function (assert) {
-        var ready = assert.async();
-        var $container = $('#fixture-ans-op');
-        var calculator = calculatorBoardFactory($container)
-            .on('ready', function () {
-                var areaBroker = calculator.getAreaBroker();
-                var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+    QUnit.test('ans and operator', assert => {
+        const ready = assert.async();
+        const $container = $('#fixture-ans-op');
+        const calculator = calculatorBoardFactory($container)
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
+                const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
-                assert.expect(41);
+                assert.expect(47);
 
                 calculator
-                    .on('plugin-render.simpleScreen', function () {
+                    .on('plugin-render.simpleScreen', () => {
                         assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                     })
-                    .on('destroy', function () {
-                        ready();
-                    });
+                    .on('destroy', ready);
 
                 plugin
                     .install()
-                    .then(function () {
-                        return plugin.init();
-                    })
-                    .then(function () {
-                        return plugin.render();
-                    })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
+                    .then(() => plugin.init())
+                    .then(() => plugin.render())
+                    .then(() => {
+                        const $screen = $container.find('.calculator-screen');
                         assert.equal(
                             areaBroker.getScreenArea().find('.calculator-screen').length,
                             1,
@@ -3387,223 +1557,83 @@ define([
                         assert.equal(calculator.getExpression(), 'ans', 'The expression should be set to ans');
                         assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
 
-                        assert.equal(
-                            $screen.find('.term').length,
-                            2,
-                            'The expected number of terms has been transformed'
-                        );
-
-                        assert.equal(
-                            $screen.find('.term:eq(0)').data('value'),
-                            'ans',
-                            'the first operand is transformed - data-value'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(0)').data('token'),
-                            'ANS',
-                            'the first operand is transformed - data-token'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(0)').text().trim(),
-                            '0',
-                            'the first operand is transformed - content'
-                        );
-
-                        assert.equal(
-                            $screen.find('.term:eq(1)').data('value'),
-                            '0',
-                            'the first operand is transformed - data-value'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(1)').data('token'),
-                            'NUM0',
-                            'the first operand is transformed - data-token'
-                        );
-                        assert.equal(
-                            $screen.find('.term:eq(1)').text().trim(),
-                            '0',
-                            'the first operand is transformed - content'
-                        );
+                        assertTokenNumber(assert, $screen, 2);
+                        assertToken(assert, $screen, 0, 'VAR_ANS', 'variable', 'ans', calculator.renderExpression('0'));
+                        assertToken(assert, $screen, 1, 'NUM0', 'digit', '0', '0');
                     })
-                    .then(function () {
-                        var $screen = $container.find('.calculator-screen');
-                        return new Promise(function (resolve) {
-                            calculator
-                                .after('termadd.ADD', function () {
-                                    calculator.off('termadd.ADD');
+                    .then(
+                        () =>
+                            new Promise(resolve => {
+                                calculator
+                                    .after('termadd.ADD', () => {
+                                        calculator.off('termadd.ADD');
+                                        const $screen = $container.find('.calculator-screen .expression');
 
-                                    assert.equal(calculator.getExpression(), 'ans+', 'The expression should be ans+');
-                                    assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
+                                        assert.equal(
+                                            calculator.getExpression(),
+                                            'ans+',
+                                            'The expression should be ans+'
+                                        );
+                                        assert.equal(calculator.getPosition(), 4, 'The position should be set to 4');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term').length,
-                                        3,
-                                        'The expected number of terms has been transformed in the expression'
-                                    );
+                                        assertTokenNumber(assert, $screen, 3);
+                                        assertToken(
+                                            assert,
+                                            $screen,
+                                            0,
+                                            'VAR_ANS',
+                                            'variable',
+                                            'ans',
+                                            calculator.renderExpression('0')
+                                        );
+                                        assertToken(assert, $screen, 1, 'NUM0', 'digit', '0', '0');
+                                        assertToken(assert, $screen, 2, 'ADD', 'operator', '+', '+');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('value'),
-                                        'ans',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('token'),
-                                        'ANS',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').data('type'),
-                                        'variable',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(0)').text().trim(),
-                                        '0',
-                                        'the variable is transformed - content'
-                                    );
+                                        calculator
+                                            .after('termadd.NUM8', () => {
+                                                calculator.off('termadd.NUM8');
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('value'),
-                                        '0',
-                                        'the variable is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('token'),
-                                        'NUM0',
-                                        'the variable is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').data('type'),
-                                        'digit',
-                                        'the variable is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(1)').text().trim(),
-                                        '0',
-                                        'the variable is transformed - content'
-                                    );
+                                                assert.equal(
+                                                    calculator.getExpression(),
+                                                    'ans+8',
+                                                    'The expression should be ans+8'
+                                                );
+                                                assert.equal(
+                                                    calculator.getPosition(),
+                                                    5,
+                                                    'The position should be set to 5'
+                                                );
 
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('value'),
-                                        '+',
-                                        'the operator is transformed - data-value'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('token'),
-                                        'ADD',
-                                        'the operator is transformed - data-token'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').data('type'),
-                                        'operator',
-                                        'the operator is transformed - data-type'
-                                    );
-                                    assert.equal(
-                                        $screen.find('.expression .term:eq(2)').text().trim(),
-                                        '+',
-                                        'the operator is transformed - content'
-                                    );
+                                                assertTokenNumber(assert, $screen, 4);
+                                                assertToken(
+                                                    assert,
+                                                    $screen,
+                                                    0,
+                                                    'VAR_ANS',
+                                                    'variable',
+                                                    'ans',
+                                                    calculator.renderExpression('0')
+                                                );
+                                                assertToken(assert, $screen, 1, 'NUM0', 'digit', '0', '0');
+                                                assertToken(assert, $screen, 2, 'ADD', 'operator', '+', '+');
+                                                assertToken(assert, $screen, 3, 'NUM8', 'digit', '8', '8');
 
-                                    calculator
-                                        .after('termadd.NUM8', function () {
-                                            calculator.off('termadd.NUM8');
-
-                                            assert.equal(
-                                                calculator.getExpression(),
-                                                'ans+8',
-                                                'The expression should be ans+8'
-                                            );
-                                            assert.equal(
-                                                calculator.getPosition(),
-                                                5,
-                                                'The position should be set to 5'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term').length,
-                                                4,
-                                                'The expected number of terms has been transformed in the expression'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').data('value'),
-                                                'ans',
-                                                'the variable is transformed - data-value'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').data('token'),
-                                                'ANS',
-                                                'the variable is transformed - data-token'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').data('type'),
-                                                'variable',
-                                                'the variable is transformed - data-type'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(0)').text().trim(),
-                                                '0',
-                                                'the variable is transformed - content'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').data('value'),
-                                                '+',
-                                                'the operator is transformed - data-value'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').data('token'),
-                                                'ADD',
-                                                'the operator is transformed - data-token'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').data('type'),
-                                                'operator',
-                                                'the operator is transformed - data-type'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(2)').text().trim(),
-                                                '+',
-                                                'the operator is transformed - content'
-                                            );
-
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(3)').data('value'),
-                                                '8',
-                                                'the operand is transformed - data-value'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(3)').data('token'),
-                                                'NUM8',
-                                                'the operand is transformed - data-token'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(3)').data('type'),
-                                                'digit',
-                                                'the operand is transformed - data-type'
-                                            );
-                                            assert.equal(
-                                                $screen.find('.expression .term:eq(3)').text().trim(),
-                                                '8',
-                                                'the operand is transformed - content'
-                                            );
-
-                                            resolve();
-                                        })
-                                        .useTerm('NUM8');
-                                })
-                                .useTerm('ADD');
-                        });
-                    })
-                    .catch(function (err) {
+                                                resolve();
+                                            })
+                                            .useTerm('NUM8');
+                                    })
+                                    .useTerm('ADD');
+                            })
+                    )
+                    .catch(err => {
                         assert.ok(false, `Unexpected failure : ${err.message}`);
                     })
-                    .then(function () {
+                    .then(() => {
                         plugin.destroy();
                         calculator.destroy();
                     });
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');
@@ -3619,7 +1649,7 @@ define([
                 expression: 'PI',
                 value: 'PI',
                 type: 'constant',
-                label: registeredTerms.PI.label
+                label: labels.PI
             },
             {
                 title: '3',
@@ -3643,37 +1673,31 @@ define([
                 expression: 'sqrt',
                 value: 'sqrt',
                 type: 'function',
-                label: registeredTerms.SQRT.label
+                label: labels.SQRT
             }
         ])
-        .test('ans and const', function (data, assert) {
-            var ready = assert.async();
-            var $container = $('#fixture-ans-const');
-            var calculator = calculatorBoardFactory($container)
-                .on('ready', function () {
-                    var areaBroker = calculator.getAreaBroker();
-                    var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+        .test('ans and const', (data, assert) => {
+            const ready = assert.async();
+            const $container = $('#fixture-ans-const');
+            const calculator = calculatorBoardFactory($container)
+                .on('ready', () => {
+                    const areaBroker = calculator.getAreaBroker();
+                    const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
-                    assert.expect(18);
+                    assert.expect(20);
 
                     calculator
-                        .on('plugin-render.simpleScreen', function () {
+                        .on('plugin-render.simpleScreen', () => {
                             assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                         })
-                        .on('destroy', function () {
-                            ready();
-                        });
+                        .on('destroy', ready);
 
                     plugin
                         .install()
-                        .then(function () {
-                            return plugin.init();
-                        })
-                        .then(function () {
-                            return plugin.render();
-                        })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen');
+                        .then(() => plugin.init())
+                        .then(() => plugin.render())
+                        .then(() => {
+                            const $screen = $container.find('.calculator-screen');
                             assert.equal(
                                 areaBroker.getScreenArea().find('.calculator-screen').length,
                                 1,
@@ -3685,103 +1709,62 @@ define([
                             assert.equal(calculator.getExpression(), 'ans', 'The expression should be set to ans');
                             assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
 
-                            assert.equal(
-                                $screen.find('.term').length,
-                                2,
-                                'The expected number of terms has been transformed'
-                            );
-
-                            assert.equal(
-                                $screen.find('.term:eq(0)').data('value'),
+                            assertTokenNumber(assert, $screen, 2);
+                            assertToken(
+                                assert,
+                                $screen,
+                                0,
+                                'VAR_ANS',
+                                'variable',
                                 'ans',
-                                'the first operand is transformed - data-value'
+                                calculator.renderExpression('0')
                             );
-                            assert.equal(
-                                $screen.find('.term:eq(0)').data('token'),
-                                'ANS',
-                                'the first operand is transformed - data-token'
-                            );
-                            assert.equal(
-                                $screen.find('.term:eq(0)').text().trim(),
-                                '0',
-                                'the first operand is transformed - content'
-                            );
-
-                            assert.equal(
-                                $screen.find('.term:eq(1)').data('value'),
-                                '0',
-                                'the first operand is transformed - data-value'
-                            );
-                            assert.equal(
-                                $screen.find('.term:eq(1)').data('token'),
-                                'NUM0',
-                                'the first operand is transformed - data-token'
-                            );
-                            assert.equal(
-                                $screen.find('.term:eq(1)').text().trim(),
-                                '0',
-                                'the first operand is transformed - content'
-                            );
+                            assertToken(assert, $screen, 1, 'NUM0', 'digit', '0', '0');
                         })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen');
-                            return new Promise(function (resolve) {
-                                calculator
-                                    .after('termadd.test', function () {
-                                        calculator.off('termadd.test');
+                        .then(
+                            () =>
+                                new Promise(resolve => {
+                                    calculator
+                                        .after('termadd.test', () => {
+                                            calculator.off('termadd.test');
+                                            const $screen = $container.find('.calculator-screen .expression');
 
-                                        assert.equal(
-                                            calculator.getExpression(),
-                                            data.expression,
-                                            `The expression should be ${data.expression}`
-                                        );
-                                        assert.equal(
-                                            calculator.getPosition(),
-                                            data.expression.length,
-                                            `The position should be ${data.expression.length}`
-                                        );
+                                            assert.equal(
+                                                calculator.getExpression(),
+                                                data.expression,
+                                                `The expression should be ${data.expression}`
+                                            );
+                                            assert.equal(
+                                                calculator.getPosition(),
+                                                data.expression.length,
+                                                `The position should be ${data.expression.length}`
+                                            );
 
-                                        assert.equal(
-                                            $screen.find('.expression .term').length,
-                                            1,
-                                            'The expected number of terms has been transformed in the expression'
-                                        );
+                                            assertTokenNumber(assert, $screen, 1);
+                                            assertToken(
+                                                assert,
+                                                $screen,
+                                                0,
+                                                data.term,
+                                                data.type,
+                                                data.value,
+                                                data.label
+                                            );
 
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').data('value'),
-                                            data.value,
-                                            'the operand is transformed - data-value'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').data('token'),
-                                            data.term,
-                                            'the operand is transformed - data-token'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').data('type'),
-                                            data.type,
-                                            'the operand is transformed - data-type'
-                                        );
-                                        assert.equal(
-                                            $screen.find('.expression .term:eq(0)').text().trim(),
-                                            data.label,
-                                            'the operand is transformed - content'
-                                        );
-
-                                        resolve();
-                                    })
-                                    .useTerm(data.term);
-                            });
-                        })
-                        .catch(function (err) {
+                                            resolve();
+                                        })
+                                        .useTerm(data.term);
+                                })
+                        )
+                        .catch(err => {
                             assert.ok(false, `Unexpected failure : ${err.message}`);
                         })
-                        .then(function () {
+                        .then(() => {
                             plugin.destroy();
                             calculator.destroy();
                         });
                 })
-                .on('error', function (err) {
+                .on('error', err => {
                     //eslint-disable-next-line no-console
                     console.error(err);
                     assert.ok(false, 'The operation should not fail!');
@@ -3794,73 +1777,67 @@ define([
             {
                 title: '-3',
                 expression: '-3',
-                text: `${registeredTerms.NEG.label}3`
+                text: `${labels.NEG}3`
             },
             {
                 title: '-PI',
                 expression: '-PI',
-                text: `${registeredTerms.NEG.label}${registeredTerms.PI.label}`
+                text: `${labels.NEG}${labels.PI}`
             },
             {
                 title: 'PI-3',
                 expression: 'PI-3',
-                text: `${registeredTerms.PI.label}-3`
+                text: `${labels.PI}${labels.SUB}3`
             },
             {
                 title: '4*-3',
                 expression: '4*-3',
-                text: `4${registeredTerms.MUL.label}${registeredTerms.NEG.label}3`
+                text: `4${labels.MUL}${labels.NEG}3`
             },
             {
                 title: '4-3',
                 expression: '4-3',
-                text: '4-3'
+                text: `4${labels.SUB}3`
             },
             {
                 title: '4*(-3+2)',
                 expression: '4*(-3+2)',
-                text: `4${registeredTerms.MUL.label}(${registeredTerms.NEG.label}3+2)`
+                text: `4${labels.MUL}(${labels.NEG}3${labels.ADD}2)`
             },
             {
                 title: '4*(3+2)-5',
                 expression: '4*(3+2)-5',
-                text: `4${registeredTerms.MUL.label}(3+2)-5`
+                text: `4${labels.MUL}(3${labels.ADD}2)${labels.SUB}5`
             },
             {
                 title: 'sin-5',
                 expression: 'sin-5',
-                text: `sin${registeredTerms.NEG.label}5`
+                text: `sin${labels.NEG}5`
             }
         ])
-        .test('treatment of minus operator', function (data, assert) {
-            var ready = assert.async();
-            var $container = $('#fixture-minus-operator');
-            var calculator = calculatorBoardFactory($container)
-                .on('ready', function () {
-                    var areaBroker = calculator.getAreaBroker();
-                    var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+        .test('treatment of minus operator', (data, assert) => {
+            const ready = assert.async();
+            const $container = $('#fixture-minus-operator');
+            const calculator = calculatorBoardFactory($container)
+                .on('ready', () => {
+                    const areaBroker = calculator.getAreaBroker();
+                    const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                     assert.expect(5);
 
                     calculator
-                        .on('plugin-render.simpleScreen', function () {
+                        .on('plugin-render.simpleScreen', () => {
                             assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                         })
-                        .on('destroy', function () {
-                            ready();
-                        });
+                        .on('destroy', ready);
 
                     plugin
                         .install()
-                        .then(function () {
-                            return plugin.init();
-                        })
-                        .then(function () {
-                            return plugin.render();
-                        })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen .expression');
-                            var termsCount = calculator.getTokenizer().tokenize(data.expression).length;
+                        .then(() => plugin.init())
+                        .then(() => plugin.render())
+                        .then(() => {
+                            const $screen = $container.find('.calculator-screen .expression');
+                            const termsCount = calculator.getTokenizer().tokenize(data.expression).length;
                             assert.equal(
                                 areaBroker.getScreenArea().find('.calculator-screen .expression').length,
                                 1,
@@ -3881,15 +1858,15 @@ define([
                             );
                             assert.equal($screen.text(), data.text, 'the expected text is set');
                         })
-                        .catch(function (err) {
+                        .catch(err => {
                             assert.ok(false, `Unexpected failure : ${err.message}`);
                         })
-                        .then(function () {
+                        .then(() => {
                             plugin.destroy();
                             calculator.destroy();
                         });
                 })
-                .on('error', function (err) {
+                .on('error', err => {
                     //eslint-disable-next-line no-console
                     console.error(err);
                     assert.ok(false, 'The operation should not fail!');
@@ -3902,71 +1879,58 @@ define([
             {
                 title: '42',
                 expression: 'ans',
-                variables: {
-                    ans: mathsEvaluator('42')
-                },
+                value: '42',
                 text: '42'
             },
             {
                 title: '1/3',
                 expression: 'ans',
-                variables: {
-                    ans: mathsEvaluator('1/3')
-                },
-                text: `0.33333${registeredTerms.ELLIPSIS.label}`
+                value: '1/3',
+                text: `0.33333${labels.ELLIPSIS}`
             },
             {
                 title: '2/3',
                 expression: 'ans',
-                variables: {
-                    ans: mathsEvaluator('2/3')
-                },
-                text: `0.66667${registeredTerms.ELLIPSIS.label}`
+                value: '2/3',
+                text: `0.66667${labels.ELLIPSIS}`
             },
             {
                 title: 'PI',
                 expression: 'ans',
-                variables: {
-                    ans: mathsEvaluator('PI')
-                },
-                text: `3.14159${registeredTerms.ELLIPSIS.label}`
+                value: 'PI',
+                text: `3.14159${labels.ELLIPSIS}`
             }
         ])
-        .test('treatment of ellipsis', function (data, assert) {
-            var ready = assert.async();
-            var $container = $('#fixture-ellipsis');
-            var calculator = calculatorBoardFactory($container)
-                .on('ready', function () {
-                    var areaBroker = calculator.getAreaBroker();
-                    var plugin = simpleScreenPluginFactory(calculator, areaBroker);
+        .test('treatment of ellipsis', (data, assert) => {
+            const ready = assert.async();
+            const $container = $('#fixture-ellipsis');
+            const calculator = calculatorBoardFactory($container)
+                .on('ready', () => {
+                    const areaBroker = calculator.getAreaBroker();
+                    const plugin = simpleScreenPluginFactory(calculator, areaBroker);
 
                     assert.expect(4);
 
                     calculator
-                        .on('plugin-render.simpleScreen', function () {
+                        .on('plugin-render.simpleScreen', () => {
                             assert.ok(plugin.getState('ready'), 'The plugin has been rendered');
                         })
-                        .on('destroy', function () {
-                            ready();
-                        });
+                        .on('destroy', ready);
 
                     plugin
                         .install()
-                        .then(function () {
-                            return plugin.init();
-                        })
-                        .then(function () {
-                            return plugin.render();
-                        })
-                        .then(function () {
-                            var $screen = $container.find('.calculator-screen .expression');
+                        .then(() => plugin.init())
+                        .then(() => plugin.render())
+                        .then(() => {
+                            const $screen = $container.find('.calculator-screen .expression');
                             assert.equal(
                                 areaBroker.getScreenArea().find('.calculator-screen .expression').length,
                                 1,
                                 'The screen layout has been inserted'
                             );
 
-                            calculator.setVariables(data.variables);
+                            const mathsEvaluator = calculator.getMathsEvaluator();
+                            calculator.setVariable('ans', mathsEvaluator(data.value));
                             calculator.replace(data.expression);
 
                             assert.equal(
@@ -3976,15 +1940,15 @@ define([
                             );
                             assert.equal($screen.text(), data.text, 'the expected text is set');
                         })
-                        .catch(function (err) {
+                        .catch(err => {
                             assert.ok(false, `Unexpected failure : ${err.message}`);
                         })
-                        .then(function () {
+                        .then(() => {
                             plugin.destroy();
                             calculator.destroy();
                         });
                 })
-                .on('error', function (err) {
+                .on('error', err => {
                     //eslint-disable-next-line no-console
                     console.error(err);
                     assert.ok(false, 'The operation should not fail!');
@@ -3994,15 +1958,14 @@ define([
 
     QUnit.module('visual test');
 
-    QUnit.test('screen', function (assert) {
-        var ready = assert.async();
-        var expression = '3*sqrt 3/2+(-2+x)*4-sin PI/2';
-        var $container = $('#visual-test .calculator');
-        var $input = $('#visual-test .input');
-        calculatorBoardFactory($container, [simpleScreenPluginFactory])
-            .on('ready', function () {
-                var self = this;
-                var areaBroker = this.getAreaBroker();
+    QUnit.test('screen', assert => {
+        const ready = assert.async();
+        const expression = '3*sqrt 3/2+(-2+x)*4-sin PI/2';
+        const $container = $('#visual-test .calculator');
+        const $input = $('#visual-test .input');
+        const calculator = calculatorBoardFactory($container, [simpleScreenPluginFactory])
+            .on('ready', () => {
+                const areaBroker = calculator.getAreaBroker();
                 assert.equal(
                     areaBroker.getScreenArea().find('.calculator-screen').length,
                     1,
@@ -4010,19 +1973,19 @@ define([
                 );
 
                 $input.val(expression);
-                self.setVariable('x', '1').setExpression(expression);
+                calculator.setVariable('x', '1').replace(expression);
 
-                $('#visual-test').on('click', 'button', function () {
+                $('#visual-test').on('click', 'button', function onClick() {
                     if (this.classList.contains('set')) {
-                        self.setExpression($input.val());
+                        calculator.replace($input.val());
                     } else if (this.classList.contains('execute')) {
-                        self.evaluate();
+                        calculator.evaluate();
                     }
                 });
 
                 ready();
             })
-            .on('error', function (err) {
+            .on('error', err => {
                 //eslint-disable-next-line no-console
                 console.error(err);
                 assert.ok(false, 'The operation should not fail!');

--- a/test/maths/calculator/scientificCalculator/test.html
+++ b/test/maths/calculator/scientificCalculator/test.html
@@ -15,11 +15,14 @@
             });
         </script>
         <style>
+            div#qunit {
+                position: relative;
+            }
             #visual-test {
                 position: relative;
                 background: #ccc;
-                height: 500px;
-                width: 1000px;
+                height: 800px;
+                width: 100%;
             }
         </style>
     </head>


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5209

### Summary

Update the calculator for using the extracted engine [tao-calculator](https://github.com/oat-sa/tao-calculator-fe).

**Note:** When running the tests `npm test`, some tests related to removed modules will fail. This is expected and this will be addressed in the second pull request that will clean up the place.

### Details

Replace the calculator's engine with the one that has been extracted and placed into [tao-calculator](https://github.com/oat-sa/tao-calculator-fe).

The internal design of the calculator has been simplified:
- as we keep the same high-level hierarchy, with nested components, the API is wired through the main component, aka the `core/board`. Most of the API is a delegation from the component to the engine. It could be simplified by allowing direct calls to the wrapped engine, but it is safer to delegate and it also respects Demeter's law.
- another pull request will come later for removing the obsolete modules and cleaning up the place:
    - most of the plugins are no longer needed since they are included in the engine
    - some modules have been removed and inlined since they don't add value: `core/areaBroker`, `core/pluginLoader`.

Sorry for the still big number of files, but most of them are small or changes in unit tests. Actually, the most noticeable changes are in the modules `core/board.js` and `plugins/screen/simpleScreen/simpleScreen.js`.

The changes in the unit tests are mostly conversion to ES6 and adaptation for the new engine.

### How to test

- install `npm i`
- run the tests in the browser:
    - run `npm run test:keepAlive`
    - open a browser at `http://127.0.0.1:5400/test/maths/calculator/`
    - run each test from this list (other tests will fail as they are related to removed modules, they will be addressed in a separate PR):
        - http://127.0.0.1:5400/test/maths/calculator/core/board/test.html
        - http://127.0.0.1:5400/test/maths/calculator/core/labels/test.html
        - http://127.0.0.1:5400/test/maths/calculator/plugins/keyboard/templateKeyboard/test.html
        - http://127.0.0.1:5400/test/maths/calculator/plugins/screen/simpleScreen/test.html
        - http://127.0.0.1:5400/test/maths/calculator/calculatorComponent/test.html
        - http://127.0.0.1:5400/test/maths/calculator/defaultCalculator/test.html
        - http://127.0.0.1:5400/test/maths/calculator/basicCalculator/test.html
        - http://127.0.0.1:5400/test/maths/calculator/scientificCalculator/test.html
    - play with the samples from the [`basicCalculator`](http://127.0.0.1:5400/test/maths/calculator/basicCalculator) and the [`scientifiCalculator`](http://127.0.0.1:5400/test/maths/calculator/scientificCalculator).