### PR TITLE
feat: conditional enable sourceditor ckeditor plugin

### DIFF
--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -670,7 +670,7 @@ const ckConfigurator = (function () {
 
             //enable sourcedialog plugin upon featureflag (false by default)
             if(context.featureFlags.FEATURE_FLAG_CKEDITOR_SOURCEDIALOG) {
-                ckConfig.toolbar.push({'name': 'sourcedialog', items: ['Sourcedialog']})
+                ckConfig.toolbar.push({'name': 'sourcedialog', items: ['Sourcedialog']});
               }
         }
 

--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -19,6 +19,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import dtdHandler from 'ui/ckeditor/dtdHandler';
 import 'ckeditor';
+import context from 'context';
 import module from 'module';
 import featuresService from 'services/features';
 
@@ -666,6 +667,11 @@ const ckConfigurator = (function () {
         // add the toolbar
         if (typeof toolbars[toolbarType] !== 'undefined') {
             ckConfig.toolbar = toolbars[toolbarType];
+
+            //enable sourcedialog plugin upon featureflag (false by default)
+            if(context.featureFlags.FEATURE_FLAG_CKEDITOR_SOURCEDIALOG) {
+                ckConfig.toolbar.push({'name': 'sourcedialog', items: ['Sourcedialog']})
+              }
         }
 
         // ensures positionedPlugins has the right format

--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -57,7 +57,8 @@ const ckConfigurator = (function () {
             {
                 name: 'links',
                 items: ['Link']
-            },{
+            },
+            {
                 name: 'language',
                 items: ['Language']
             }
@@ -455,7 +456,7 @@ const ckConfigurator = (function () {
         disableNativeTableHandles: true
     };
 
-    if(moduleConfig && moduleConfig.specialChars) {
+    if (moduleConfig && moduleConfig.specialChars) {
         ckConfigDefault.specialChars = moduleConfig.specialChars;
     }
 
@@ -643,11 +644,11 @@ const ckConfigurator = (function () {
             }
             if (options.furiganaPlugin && featuresService.isVisible(furiganaPluginVisibilityKey, false)) {
                 if (!options.toolbar || options.toolbar.find(el => el.items.includes('Superscript'))) {
-                    positionedPlugins.TaoFurigana = {insertAfter: 'Superscript'};
+                    positionedPlugins.TaoFurigana = { insertAfter: 'Superscript' };
                 } else {
                     const lastGroup = options.toolbar[options.toolbar.length - 1];
                     const firstPlugin = lastGroup.items[0];
-                    positionedPlugins.TaoFurigana = {insertBefore: firstPlugin};
+                    positionedPlugins.TaoFurigana = { insertBefore: firstPlugin };
                 }
             }
         }
@@ -669,9 +670,9 @@ const ckConfigurator = (function () {
             ckConfig.toolbar = toolbars[toolbarType];
 
             //enable sourcedialog plugin upon featureflag (false by default)
-            if(context.featureFlags.FEATURE_FLAG_CKEDITOR_SOURCEDIALOG) {
-                ckConfig.toolbar.push({'name': 'sourcedialog', items: ['Sourcedialog']});
-              }
+            if (context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_SOURCEDIALOG) {
+                ckConfig.toolbar.push({ name: 'sourcedialog', items: ['Sourcedialog'] });
+            }
         }
 
         // ensures positionedPlugins has the right format


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/PISA25-364

### Description

Enables [sourceditor](https://ckeditor.com/cke4/addon/sourcedialog) plugin based on context (featureFlag FEATURE_FLAG_CKEDITOR_SOURCEDIALOG )

### How to test

`npm run test`
check with installed version of tao or on deployed kitchen environment (see environment field of the ticket)