### PR TITLE
fix: update lodash dependeny to ^4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "interactjs": "1.3.4",
                 "jquery": "1.9.1",
                 "jquery-mockjax": "^2.5.0",
-                "lodash": "2.4.1",
+                "lodash": "^4.17.21",
                 "moment": "^2.29.4",
                 "moment-timezone": "^0.5.43",
                 "npm-run-all": "^4.1.5",
@@ -2835,12 +2835,6 @@
                 "jsesc": "bin/jsesc"
             }
         },
-        "node_modules/babel-generator/node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
-        },
         "node_modules/babel-generator/node_modules/source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2927,12 +2921,6 @@
                 "lodash": "^4.17.4"
             }
         },
-        "node_modules/babel-template/node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
-        },
         "node_modules/babel-traverse": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
@@ -2968,12 +2956,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/babel-traverse/node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
-        },
         "node_modules/babel-traverse/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2991,12 +2973,6 @@
                 "lodash": "^4.17.4",
                 "to-fast-properties": "^1.0.3"
             }
-        },
-        "node_modules/babel-types/node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
         },
         "node_modules/babel-types/node_modules/to-fast-properties": {
             "version": "1.0.3",
@@ -5944,14 +5920,10 @@
             }
         },
         "node_modules/lodash": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-            "integrity": "sha512-qa6QqjA9jJB4AYw+NpD2GI4dzHL6Mv0hL+By6iIul4Ce0C1refrjZJmcGvWdnLUwl4LIPtvzje3UQfGH+nCEsQ==",
-            "dev": true,
-            "engines": [
-                "node",
-                "rhino"
-            ]
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "interactjs": "1.3.4",
         "jquery": "1.9.1",
         "jquery-mockjax": "^2.5.0",
-        "lodash": "2.4.1",
+        "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.43",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1595

### Description

Updates version of lodash lib to `^4.17.21` and makes code lodash v4 compatible

### How to test

`npm run test`