### PR TITLE
Fix/adf 1585 vulnaribilities

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -100,7 +100,7 @@ export default inputs.map(input => {
                 watch: false
             }),
             cssResolve(),
-            wildcardExternal(['core/**', 'lib/**', 'util/**', 'layout/**']),
+            wildcardExternal(['core/**', 'lib/**', 'util/**', 'layout/**', 'services/*']),
             alias({
                 resolve: ['.js', '.json', '.tpl'],
                 ...aliases

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@oat-sa/tao-calculator": "^0.6.2",
                 "@oat-sa/tao-core-libs": "^1.0.0",
                 "@oat-sa/tao-core-sdk": "^3.0.0",
-                "@oat-sa/tao-core-shared-libs": "^1.4.1",
+                "@oat-sa/tao-core-shared-libs": "^1.6.1",
                 "@oat-sa/tao-qunit-testrunner": "^2.0.0",
                 "async": "^0.2.10",
                 "autoprefixer": "^10.4.14",
@@ -2140,9 +2140,9 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.5.0.tgz",
-            "integrity": "sha512-luZT0Vli6rgn8rlVxx9cgmak4zYoepl0W/uhuvjK752savUztdXEwrrFyIzYN5Z2KPTxM2vlb19VZgLfm+LOWg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.6.1.tgz",
+            "integrity": "sha512-KnW5RnCOjewkimfDgh/+w9J77bc3gWH5YR1fIHon6j86ywFL+Fevcn5ghdZZrWTzwEMZfEju39VhI7LjXUWKnA==",
             "dev": true
         },
         "node_modules/@oat-sa/tao-qunit-testrunner": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@oat-sa/tao-calculator": "^0.6.2",
         "@oat-sa/tao-core-libs": "^1.0.0",
         "@oat-sa/tao-core-sdk": "^3.0.0",
-        "@oat-sa/tao-core-shared-libs": "^1.4.1",
+        "@oat-sa/tao-core-shared-libs": "^1.6.1",
         "@oat-sa/tao-qunit-testrunner": "^2.0.0",
         "async": "^0.2.10",
         "autoprefixer": "^10.4.14",

--- a/test/themeLoader/test.js
+++ b/test/themeLoader/test.js
@@ -118,7 +118,7 @@ define(['lodash', 'jquery', 'ui/themeLoader'], function (_, $, themeLoader) {
                 );
                 ready();
             }, 250);
-        }, 50);
+        }, 100);
     });
 
     QUnit.test('preload', assert => {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/ADF-1585

- Update tao-core-shared-libs. It should not contain any breaking change (https://github.com/oat-sa/tao-core-shared-libs-fe/releases), I've updated to remove a vulnerability.
- I've fixed a warning message that appears during build. `services/*` plugins were not marked as external.

Test:
- `npm run test`