### PR TITLE
feature: display / do not display Continue button in report

### DIFF
--- a/src/taskQueueButton/taskable.js
+++ b/src/taskQueueButton/taskable.js
@@ -146,10 +146,21 @@ var taskableComponent = {
      * @param {Object} report - the standard report object
      * @param {String} title - the report title
      * @param {String} result - raw result data from the task creation action
+     * @param {boolean} displayContinueButton - display Continue button if true
      */
-    displayReport: function displayReport(report, title, result) {
+    displayReport: function displayReport(report, title, result, displayContinueButton = true) {
         var self = this,
             $reportContainer;
+
+        let actions = [];
+        if (displayContinueButton) {
+            actions = [{
+                id: 'continue',
+                icon: 'right',
+                title: 'continue',
+                label: __('Continue')
+            }];
+        }
 
         if (this.config.taskReportContainer instanceof $) {
             $reportContainer = $(
@@ -162,14 +173,7 @@ var taskableComponent = {
 
             return reportFactory(
                 {
-                    actions: [
-                        {
-                            id: 'continue',
-                            icon: 'right',
-                            title: 'continue',
-                            label: __('Continue')
-                        }
-                    ]
+                    actions: actions
                 },
                 report
             )


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/ADF-961

## What's Changed
- Added configure option to display / do not display Continue button in report display.

## TODO 
- [ ] Unit tests
- [x] E2E tests
- [ ] Update composer with packages

## How to test
Continue button is visible:
- Open Assets.
- Import an image.
- At the successful report display there is a Continue button.

Continue button is NOT visible:
- In Authoring create a new Passage Asset.
- Edit the Asset and embed and image.
- Delete the embedded image - so there will be a broken link in the Asset.
- You should be able to notice the errors, there is no Continue button.
