### PR TITLE
Feature/BSA-391/Allow to disable figure widgets

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
               run: npm run coverage:clover
             - name: Report coverage
               if: always()
-              uses: slavcodev/coverage-monitor-action@1.1.0
+              uses: slavcodev/coverage-monitor-action@v1
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   clover_file: coverage/clover.xml

--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -13,8 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021-2022  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2023  (original work) Open Assessment Technologies SA;
  */
+import context from 'context';
 import _ from 'lodash';
 
 export const FLOAT_LEFT_CLASS = 'wrap-left';
@@ -74,7 +75,7 @@ export const positionFloat = function positionFloat(widget, position) {
         widget.element.removeAttr('class');
     }
 
-    if (prevClassName !== className) {
+    if (!context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] && prevClassName !== className) {
         // Re-build Figure widget to toggle between inline/block
         const parent = searchRecurse(widget.element.bdy.rootElement.bdy, widget.serial);
         // avoid changes on Figure in a prompt


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/BSA-391

### Summary

Manage a feature flag for disabling the figure widget.

### Details

Some customers rely on the block positioning of the figures for aligning images in columns. The figure widget sets them to inline positioning, hence the need to have a feature flag for disabling it. The other possibility is to roll back the feature, but this is less handy.

The feature can be disabled thanks to the feature flag `FEATURE_FLAG_DISABLE_FIGURE_WIDGET`.
The feature is enabled by default

### How to test

- have all dependencies (other PR) installed
- edit an item and place images on the canvas. Check the attached ticket for a sample item.
- turn the feature flag on and off, and see the differences