### PR TITLE
Feature/BSA-391/2.3.0/Allow to disable figure widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-core-ui",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "GPL-2.0",
             "devDependencies": {
                 "@babel/core": "^7.19.3",
@@ -8699,6 +8699,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/svelte": {
+            "version": "3.59.2",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+            "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/temp-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -8956,6 +8966,20 @@
             "dev": true,
             "dependencies": {
                 "is-typedarray": "^1.0.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "dev": true,
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -13,8 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021-2022  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2023  (original work) Open Assessment Technologies SA;
  */
+import context from 'context';
 import _ from 'lodash';
 
 export const FLOAT_LEFT_CLASS = 'wrap-left';
@@ -74,7 +75,7 @@ export const positionFloat = function positionFloat(widget, position) {
         widget.element.removeAttr('class');
     }
 
-    if (prevClassName !== className) {
+    if (!context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] && prevClassName !== className) {
         // Re-build Figure widget to toggle between inline/block
         const parent = searchRecurse(widget.element.bdy.rootElement.bdy, widget.serial);
         // avoid changes on Figure in a prompt


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/BSA-391

### Summary

Manage a feature flag for disabling the figure widget.

### Details

**Note:** This PR targets version `2.3.0` since version `3.x` contains breaking changes and is not yet used by `tao-core`.

Some customers rely on the block positioning of the figures for aligning images in columns. The figure widget sets them to inline positioning, hence the need to have a feature flag for disabling it. The other possibility is to roll back the feature, but this is less handy.

The feature can be disabled thanks to the feature flag `FEATURE_FLAG_DISABLE_FIGURE_WIDGET`.
The feature is enabled by default.

### How to test

- have all dependencies (other PR) installed
- edit an item and place images on the canvas. Check the attached ticket for a sample item.
- turn the feature flag on and off, and see the differences