### PR TITLE
chore: update methods to lodash 4 version

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -1019,7 +1019,7 @@ function toBoolean(value) {
  * @returns {autocompleter} Returns the instance of the autocompleter component
  */
 function autocompleteFactory(element, options) {
-    var autocomplete = _.clone(autocompleter, true);
+    var autocomplete = _.cloneDeep(autocompleter);
     _.defaults(autocomplete, defaults);
     return autocomplete.init(element, options);
 }

--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -601,10 +601,10 @@ const ckConfigurator = (function () {
 
         options.resourcemgr = options.resourcemgr || {};
 
-        toolbars = _.clone(toolbarPresets, true);
+        toolbars = _.cloneDeep(toolbarPresets);
         dtdMode = options.dtdMode || 'html';
 
-        const ckConfig = _.clone(ckConfigDefault, true);
+        const ckConfig = _.cloneDeep(ckConfigDefault);
 
         // modify DTD to either comply with QTI or XHTML
         if (dtdMode === 'qti' || toolbarType.indexOf('qti') === 0) {


### PR DESCRIPTION
Related: https://oat-sa.atlassian.net/browse/ADF-1579

Update lodash methods to version 4. Fix usage methods _.clone.