### PR TITLE
fix: increase width to fit panel icons

### DIFF
--- a/scss/inc/_variables.scss
+++ b/scss/inc/_variables.scss
@@ -1,7 +1,7 @@
 $sidebarWidth: 180;
 $sidebarGutter: 0;
 $toolbarHeight: 50;
-$treeSidebar: 380;
+$treeSidebar: 414;
 
 // fonts
 $fontPath : 'font/' !default;


### PR DESCRIPTION
**Related to:** [AUT-3655](https://oat-sa.atlassian.net/browse/AUT-3655)

**Description:**
Increment the width on the left tree sidebar to fit panel icons

**Changes:**

- Update the current width 

[RFE-1271]: https://oat-sa.atlassian.net/browse/RFE-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AUT-3655]: https://oat-sa.atlassian.net/browse/AUT-3655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ