### PR TITLE
Feature/AUT-3635/Apply the Solar Design to the Item Authoring

### DIFF
--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -43,6 +43,8 @@ export default function (options) {
 
     //load the content of the ROOT
     getFolderContent(fileTree, rootPath, function (content) {
+        indexTree(content);
+
         //create the tree node for the ROOT folder by default once the initial content loaded
         $folderContainer.append(rootFolderTpl(content));
 
@@ -81,6 +83,8 @@ export default function (options) {
 
         //get the folder content
         getFolderContent(subTree, fullPath, function (content) {
+            indexTree(fileTree);
+
             if (content) {
                 //either create the inner list of the content is new or just show it
                 let $innerList = $selected.siblings('ul');
@@ -201,6 +205,21 @@ export default function (options) {
             }
         } else {
             cb(content);
+        }
+    }
+
+    /**
+     * Sets the tree level for each node in the tree.
+     * @param {object} tree - the tree model
+     * @param {number} level - the root level
+     */
+    function indexTree(tree, level = 0) {
+        if (!tree) {
+            return;
+        }
+        tree.level = level;
+        if (tree.children) {
+            _.forEach(tree.children, child => indexTree(child, level + 1));
         }
     }
 
@@ -372,6 +391,8 @@ export default function (options) {
 
         //get the folder content
         getFolderContent(subTree, selectedClass.path, function (content) {
+            indexTree(fileTree);
+
             if (content) {
                 //internal event to set the file-selector content
                 $container.trigger(`folderselect.${ns}`, [content.label, getPage(content.children), content.path]);

--- a/src/resourcemgr/tpl/folder.tpl
+++ b/src/resourcemgr/tpl/folder.tpl
@@ -4,6 +4,8 @@
 			data-path="{{path}}"
 			data-display="{{relPath}}"
 			data-children-limit="{{childrenLimit}}"
+			data-level="{{level}}"
+			style="--tree-level: {{level}};"
 			href="#">
 			{{label}}
 		</a>

--- a/src/resourcemgr/tpl/rootFolder.tpl
+++ b/src/resourcemgr/tpl/rootFolder.tpl
@@ -5,7 +5,9 @@
 			href="#"
 			data-path="{{path}}"
 			data-display="{{relPath}}"
-			data-children-limit="{{childrenLimit}}">
+			data-children-limit="{{childrenLimit}}"
+			data-level="0"
+			style="--tree-level: 0;">
 			{{label}}
 		</a>
 		<ul></ul>


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/AUT-3635

Requires: 
 - [ ] https://github.com/oat-sa/tao-core/pull/4026
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/2505

### Summary

Sets the tree level to the tree nodes in the resource manager.

This is needed to properly style the tree-view for having each node covering a whole line.
![image](https://github.com/oat-sa/tao-core-ui-fe/assets/1500098/c1e296ee-a7a7-4775-9f71-9dbfc575a06e)

### How to test

- see with the companion pull requests
