### PR TITLE
Feature/AUT-3790/resource manager deletion hook

### DIFF
--- a/src/resourcemgr/tpl/fileSelect.tpl
+++ b/src/resourcemgr/tpl/fileSelect.tpl
@@ -1,10 +1,10 @@
 {{#each files}}
-    <li data-type="{{type}}" 
-        data-file="{{uri}}" 
-        data-display="{{display}}" 
-        data-mime="{{mime}}" 
-        data-size="{{size}}" 
-        data-url="{{viewUrl}}" 
+    <li data-type="{{type}}"
+        data-file="{{uri}}"
+        data-display="{{display}}"
+        data-mime="{{mime}}"
+        data-size="{{size}}"
+        data-url="{{viewUrl}}"
         {{#if permissions.download}} data-download="true" {{/if}}
         {{#if permissions.preview}} data-preview="true" {{/if}}
         {{#if permissions.read}} data-select="true" {{/if}}
@@ -25,7 +25,7 @@
                                         <a href="{{downloadUrl}}" download="{{name}}" target="_blank" class="tlb-button-off download" title="{{__ 'Download this file'}}"><span class="icon-download"></span></a>
                                     {{/if}}
                                     {{#if permissions.delete }}
-                                        <a href="#" class="tlb-button-off" title="{{__ 'Remove this file'}}" data-delete=":parent li"><span class="icon-bin"></span></a>
+                                        <a href="#" class="tlb-button-off delete" title="{{__ 'Remove this file'}}"><span class="icon-bin"></span></a>
                                     {{/if}}
                                 </span>
                             {{/if}}


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/AUT-3790

### Summary

Allow to hook the file deletion in the resource manager.

### Details

The file deletion in the resource manager was relying on the `ui/deleter` helper, which is a global helper watching for elements having the `data-delete` attribute and adding behavior to them. However, it was impossible to hook it and insert a validation step in the middle. While this is possible to inject a step between the deletion event and the file deletion, the deletion event is emitted after the line is removed from the DOM. For this is reason, it is better to break the dependency to the `ui/deleter` helper and write a specific handling directly to the fileSelector component, adding an option to hook it.

### How to test

Please refer to the companion [PR](https://github.com/oat-sa/extension-tao-itemqti/pull/2567).