### PR TITLE
Feature/ADF-1782/Add styled datatable actions

### DIFF
--- a/src/datatable.js
+++ b/src/datatable.js
@@ -887,7 +887,8 @@ const dataTable = {
                         const disabled = getPropertyValue('disabled', action, nextData);
                         const icon = getPropertyValue('icon', action, nextData);
                         const label = getPropertyValue('label', action, nextData);
-                        const $actionButton = $(buttonTpl({ id, icon, label, title, disabled }));
+                        const cls = getPropertyValue('cls', action, nextData);
+                        const $actionButton = $(buttonTpl({ id, icon, label, title, disabled, cls }));
 
                         if (!hidden) {
                             $actionCell.append('\n').append($actionButton);

--- a/src/datatable/tpl/button.tpl
+++ b/src/datatable/tpl/button.tpl
@@ -1,4 +1,4 @@
-<button class="btn-info small {{id}}"
+<button class="btn-info small {{cls}} {{id}}"
   {{#if title}} title="{{title}}"{{/if}}
   {{#if disabled}} disabled="disabled"{{/if}}>
   {{#if icon}}<span class="icon-{{icon}}"></span>{{/if}}

--- a/src/datatable/tpl/layout.tpl
+++ b/src/datatable/tpl/layout.tpl
@@ -97,7 +97,7 @@
                                     {{#if id}}
                                         {{#with ../../../../this}}
                                             {{#unless ../hidden}}
-                                <button class="btn-info small {{../../id}}"
+                                <button class="btn-info small {{../../cls}} {{../../id}}"
                                     {{#if ../../title}} title="{{../../../title}}"{{/if}}
                                     {{#if ../../disabled}} disabled="disabled"{{/if}}>
                                     {{#if ../../icon}}<span class="icon-{{../../../icon}}"></span>{{/if}}
@@ -128,7 +128,7 @@
                                 {{#if id}}
                                     {{#with ../../../this}}
                                         {{#unless ../hidden}}
-                            <button class="btn-info small {{../../id}}"
+                            <button class="btn-info small {{../../cls}} {{../../id}}"
                                 {{#if ../../title}} title="{{../../../title}}"{{/if}}
                                 {{#if ../../disabled}} disabled="disabled"{{/if}}>
                                 {{#if ../../icon}}<span class="icon-{{../../../icon}}"></span>{{/if}}


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1782

### Summary

Add the possibility to style the action buttons from the datatable component.

### Details

Each action may now be styled by setting a `cls` attribute in their descriptor.

Example:
```js
$tableContainer.datatable({
    model: [ ... ],
    actions: [
        {
            id: 'label',
            label: 'Label',
            cls: 'btn-secondary',
            action() { ... }
        }
    ]
});
```