### PR TITLE
feat/ADF-1811/group-conditions-logic

### DIFF
--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -119,7 +119,7 @@ export default function advancedSearchFactory(config) {
          * Access to component state
          * @returns {Object} - criteria state
          */
-        getState() {
+        getState(){
             return criteriaState;
         },
         /**
@@ -158,6 +158,9 @@ export default function advancedSearchFactory(config) {
                             renderedCriterion.value.push('');
                         }
                         query += renderedCriterion.value.map(value=>`${queryParam}:${value}`).join(` ${renderedCriterion.logic} `);
+                        
+                        //we need to remove empty member from renderedCriterion.value because renderedCriterion can be reused after the query is done
+                        renderedCriterion.value = renderedCriterion.value.filter((value)=>value !== '');
                     }
                 }
             });

--- a/src/searchModal/advancedSearch.js
+++ b/src/searchModal/advancedSearch.js
@@ -76,8 +76,8 @@ export default function advancedSearchFactory(config) {
     const criteriaLogic = {
         and: 'LOGIC_AND',
         or: 'LOGIC_OR',
-        not: 'LOGIC_NOT',
-    }
+        not: 'LOGIC_NOT'
+    };
 
     let isAdvancedSearchStatusEnabled;
     let isCriteriaListUpdated = false;
@@ -119,7 +119,7 @@ export default function advancedSearchFactory(config) {
          * Access to component state
          * @returns {Object} - criteria state
          */
-        getState(){
+        getState() {
             return criteriaState;
         },
         /**
@@ -153,14 +153,16 @@ export default function advancedSearchFactory(config) {
                     }
                 } else if (renderedCriterion.type === criteriaTypes.list) {
                     if (renderedCriterion.value && renderedCriterion.value.length > 0) {
-                        if(renderedCriterion.value.length === 1 && renderedCriterion.logic === criteriaLogic.not) {
+                        if (renderedCriterion.value.length === 1 && renderedCriterion.logic === criteriaLogic.not) {
                             //we have to pass NOT logic anyways, so add empty member to have NOT logic modifier in the query
                             renderedCriterion.value.push('');
                         }
-                        query += renderedCriterion.value.map(value=>`${queryParam}:${value}`).join(` ${renderedCriterion.logic} `);
-                        
+                        query += renderedCriterion.value
+                            .map(value => `${queryParam}:${value}`)
+                            .join(` ${renderedCriterion.logic} `);
+
                         //we need to remove empty member from renderedCriterion.value because renderedCriterion can be reused after the query is done
-                        renderedCriterion.value = renderedCriterion.value.filter((value)=>value !== '');
+                        renderedCriterion.value = renderedCriterion.value.filter(value => value !== '');
                     }
                 }
             });
@@ -444,7 +446,10 @@ export default function advancedSearchFactory(config) {
                     $(`input[name=${criterion.id}-select]`, $criterionContainer).select2('data', initialCriterion);
                 }
                 criterion.logic = criterion.logic || criteriaLogic.and;
-                $(`input[name="${criterion.id}-logic"][value="${criterion.logic}"]`, $criterionContainer).prop('checked', true);
+                $(`input[name="${criterion.id}-logic"][value="${criterion.logic}"]`, $criterionContainer).prop(
+                    'checked',
+                    true
+                );
                 // set event to bind input value to critariaState
                 $(`input[name=${criterion.id}-select]`, $criterionContainer).on('change', event => {
                     criterion.value = event.val;

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -111,6 +111,12 @@ $invalidCriteriaBorder: #266d9c;
                     width: 100%;
                 }
             }
+            .logic-radio-group {
+                display: flex;
+                justify-content: flex-start;
+                gap: 10px;
+            }
+    
         }
         .invalid-criteria-warning-container {
             background-color: $invalidCriteriaBackground;

--- a/src/searchModal/scss/advancedSearch.scss
+++ b/src/searchModal/scss/advancedSearch.scss
@@ -78,7 +78,7 @@ $invalidCriteriaBorder: #266d9c;
                     margin-left: 0;
                 }
             }
-            label {
+            div.criterion-container {
                 width: 100%;
                 padding: 0;
                 margin: 0;
@@ -114,9 +114,9 @@ $invalidCriteriaBorder: #266d9c;
             .logic-radio-group {
                 display: flex;
                 justify-content: flex-start;
-                gap: 10px;
+                gap: 16px;
             }
-    
+
         }
         .invalid-criteria-warning-container {
             background-color: $invalidCriteriaBackground;

--- a/src/searchModal/tpl/list-select-criterion.tpl
+++ b/src/searchModal/tpl/list-select-criterion.tpl
@@ -1,6 +1,6 @@
 <div class="filter-container {{criterion.id}}-filter" data-criteria="{{criterion.label}}" data-type="{{criterion.type}}">
     <button class="icon-result-nok" aria-label="{{__ "Remove criteria"}}"></button>
-    <label>
+    <div class="criterion-container">
         <span class="filter-label-text">{{criterion.label}}
             {{#if criterion.isDuplicated}}
                 {{#if criterion.alias}}<span class="criteria-alias">({{criterion.alias}})</span>{{/if}}
@@ -8,16 +8,16 @@
             {{/if}}
         </span>
         <div class="logic-radio-group">
-            <label>
+            <label class="logic-label">
                 <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_AND"><span class="icon-radio"></span> And
             </label>
-            <label>
+            <label class="logic-label">
                 <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_OR"><span class="icon-radio"></span> Or
             </label>
-            <label>
+            <label class="logic-label">
                 <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_NOT"><span class="icon-radio"></span> Not
             </label>
         </div>
         <input type='text' name="{{criterion.id}}-select">
-    </label>
+    </div>
 </div>

--- a/src/searchModal/tpl/list-select-criterion.tpl
+++ b/src/searchModal/tpl/list-select-criterion.tpl
@@ -9,13 +9,13 @@
         </span>
         <div class="logic-radio-group">
             <label class="logic-label">
-                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_AND"><span class="icon-radio"></span> And
+                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_AND"><span class="icon-radio"></span> {{__ "Exact match"}}
             </label>
             <label class="logic-label">
-                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_OR"><span class="icon-radio"></span> Or
+                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_OR"><span class="icon-radio"></span> {{__ "In"}}
             </label>
             <label class="logic-label">
-                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_NOT"><span class="icon-radio"></span> Not
+                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_NOT"><span class="icon-radio"></span> {{__ "Not in"}}
             </label>
         </div>
         <input type='text' name="{{criterion.id}}-select">

--- a/src/searchModal/tpl/list-select-criterion.tpl
+++ b/src/searchModal/tpl/list-select-criterion.tpl
@@ -7,6 +7,17 @@
                 {{#if criterion.class.label}}<span class="class-path">/ {{criterion.class.label}}</span>{{/if}}
             {{/if}}
         </span>
+        <div class="logic-radio-group">
+            <label>
+                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_AND"><span class="icon-radio"></span> And
+            </label>
+            <label>
+                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_OR"><span class="icon-radio"></span> Or
+            </label>
+            <label>
+                <input type="radio" name="{{criterion.id}}-logic" value="LOGIC_NOT"><span class="icon-radio"></span> Not
+            </label>
+        </div>
         <input type='text' name="{{criterion.id}}-select">
     </label>
 </div>

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -301,7 +301,7 @@ define([
             statusUrl: 'undefined/tao/AdvancedSearch/status'
         });
         const ready = assert.async();
-        assert.expect(9);
+        assert.expect(11);
 
         instance.on('ready', function () {
             assert.ok(instance.isEnabled(), 'the advanced search is enabled');
@@ -326,19 +326,12 @@ define([
                 const $criterionTextInput = $criteriaContainer.find('.inBothTextParentUri-filter input');
                 const $criterionSelectInput = $criteriaContainer.find('.inBothSelectParentUri-filter input');
 
-                // Checkboxes are temporary replaced with select2
-                // const $criterionListSelected = $criteriaContainer
-                //     .find('.-filter input[type=checkbox]:checked')
-                //     .get()
-                //     .map(checkbox => {
-                //         return checkbox.value;
-                //     });
-
                 const $criterionListSelected = $criteriaContainer.find('.inBothListParentUri-filter input');
 
                 // check default value on each criterion type
                 await nextTick();
                 assert.equal($criterionTextInput.val(), 'default value0', 'text criterion correctly initialized');
+                await nextTick();
                 assert.deepEqual(
                     $criterionSelectInput.select2('val'),
                     ['value0'],
@@ -354,11 +347,6 @@ define([
                 // update value on each criterion
                 $criterionTextInput.val('foo0').trigger('change');
 
-                // Checkboxes are temporary replaced with select2
-                // $criteriaContainer
-                //     .find('.inBothListParentUri-filter input[type=checkbox][value=value2]')
-                //     .prop('checked', true)
-                //     .trigger('change');
                 $criteriaContainer.find('.inBothListParentUri-filter .select2-choices').click();
                 await nextTick(200);
                 $('.select2-results .select2-selected + * .select2-result-label').mouseup();
@@ -374,14 +362,32 @@ define([
                     ['value1', 'value2'],
                     'list criteria correctly updated'
                 );
-
+                
                 const query = instance.getAdvancedCriteriaQuery();
                 assert.equal(
                     query,
-                    // TODO: change 2nd AND to OR when functionality is developed on BE
                     'inBothTextParentUri:foo0 AND inBothListParentUri:value1 LOGIC_AND inBothListParentUri:value2 AND inBothSelectParentUri:value0',
                     'advanced search query is correctly built'
                 );
+
+                $criteriaContainer.find('input[name="inBothListParentUri-logic"][value="LOGIC_OR"]').prop('checked', true).change();
+                await nextTick(200);
+                const queryOr = instance.getAdvancedCriteriaQuery();
+                assert.equal(
+                    queryOr,
+                    'inBothTextParentUri:foo0 AND inBothListParentUri:value1 LOGIC_OR inBothListParentUri:value2 AND inBothSelectParentUri:value0',
+                    'advanced search query with OR logic is correctly built'
+                );
+
+                $criteriaContainer.find('input[name="inBothListParentUri-logic"][value="LOGIC_NOT"]').prop('checked', true).change();
+                await nextTick(200);
+                const queryNot = instance.getAdvancedCriteriaQuery();
+                assert.equal(
+                    queryNot,
+                    'inBothTextParentUri:foo0 AND inBothListParentUri:value1 LOGIC_NOT inBothListParentUri:value2 AND inBothSelectParentUri:value0',
+                    'advanced search query with NOT logic is correctly built'
+                );
+
                 instance.destroy();
                 ready();
             });

--- a/test/searchModal/advancedSearch/test.js
+++ b/test/searchModal/advancedSearch/test.js
@@ -379,7 +379,7 @@ define([
                 assert.equal(
                     query,
                     // TODO: change 2nd AND to OR when functionality is developed on BE
-                    'inBothTextParentUri:foo0 AND inBothListParentUri:value1 AND value2 AND inBothSelectParentUri:value0',
+                    'inBothTextParentUri:foo0 AND inBothListParentUri:value1 LOGIC_AND inBothListParentUri:value2 AND inBothSelectParentUri:value0',
                     'advanced search query is correctly built'
                 );
                 instance.destroy();


### PR DESCRIPTION
related to:

- https://oat-sa.atlassian.net/browse/ADF-1811
- https://oat-sa.atlassian.net/browse/ADF-1794

## TODO

 - [ ] ⚠️ Release and add to tao-core dependencies

### Description

For list advancedSearch criteria search logic has to be implemented to allow user to 
 - Conjunct selected list items in search (logical and), say we want to select entities which has value1 and value2 and ... valueN in a list property
 - Disjunct selected list items in search (logical or) to select entities having either value1 or value2 or ... valueN in a list property
 - Negation of disjunction to select entities having neither value1 nor value2 nor ... valueN in a list property
 
 ### How to test
 
  - with unit tests `npm run test:keepAlive` navigate `searchModal->advancedSearch` test, run
  - with advanceSearch BE counterpart https://github.com/oat-sa/extension-tao-advanced-search/pull/138