### PR TITLE
Fix/aut 3923/textreader image figure support

### DIFF
--- a/src/figure/FigureStateActive.js
+++ b/src/figure/FigureStateActive.js
@@ -169,6 +169,7 @@ export default function ({ stateFactory, ActiveState, formTpl, formElement, inli
         const figurelem = this.widget.element;
         const $texarea = this.widget.$form.find('textarea#figcaption');
         texareaHTMLElem = $texarea[0];
+        texareaHTMLElem.style.minHeight = '2em';
         function outputsize() {
             figurelem.data('heigthCaptionInput', $texarea.height());
         }

--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021-2023  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2024  (original work) Open Assessment Technologies SA;
  */
 import context from 'context';
 import _ from 'lodash';
@@ -21,29 +21,6 @@ import _ from 'lodash';
 export const FLOAT_LEFT_CLASS = 'wrap-left';
 export const FLOAT_RIGHT_CLASS = 'wrap-right';
 export const CENTER_CLASS = 'tao-centered';
-
-const searchRecurse = (parentElement, serial) => {
-    if (!parentElement) {
-        return null;
-    }
-    if (parentElement.serial === serial) {
-        return parentElement;
-    }
-    let found = null;
-    _.some(parentElement['elements'], childElement => {
-        if (childElement.serial === serial) {
-            found = parentElement;
-        } else if (childElement['elements']) {
-            found = searchRecurse(childElement, serial);
-        } else if (childElement['prompt']) {
-            found = searchRecurse(childElement.prompt.bdy, serial);
-        }
-        if (found) {
-            return true;
-        }
-    });
-    return found;
-};
 
 export const positionFloat = function positionFloat(widget, position) {
     if (!position) {
@@ -81,25 +58,8 @@ export const positionFloat = function positionFloat(widget, position) {
 
     if (!context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] && prevClassName !== className) {
         // Re-build Figure widget to toggle between inline/block
-        const parent = searchRecurse(widget.element.bdy.rootElement.bdy, widget.serial);
-        // avoid changes on Figure in a prompt
-        if (parent.contentModel && parent.contentModel === 'inlineStatic') {
-            _.defer(() => {
-                widget.element.data('widget').refresh();
-            });
-            return;
-        }
-        widget.element.data('widget').changeState('sleep');
         _.defer(() => {
-            if (parent && parent.data('widget')) {
-                parent.data('widget').changeState('active');
-                _.defer(() => {
-                    parent.data('widget').changeState('sleep');
-                    _.defer(() => {
-                        widget.element.data('widget').changeState('active');
-                    });
-                });
-            }
+            widget.element.data('widget').refresh();
         });
     }
     widget.$original.trigger('contentChange.qti-widget');

--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021-2024  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2023  (original work) Open Assessment Technologies SA;
  */
 import context from 'context';
 import _ from 'lodash';
@@ -21,6 +21,29 @@ import _ from 'lodash';
 export const FLOAT_LEFT_CLASS = 'wrap-left';
 export const FLOAT_RIGHT_CLASS = 'wrap-right';
 export const CENTER_CLASS = 'tao-centered';
+
+const searchRecurse = (parentElement, serial) => {
+    if (!parentElement) {
+        return null;
+    }
+    if (parentElement.serial === serial) {
+        return parentElement;
+    }
+    let found = null;
+    _.some(parentElement['elements'], childElement => {
+        if (childElement.serial === serial) {
+            found = parentElement;
+        } else if (childElement['elements']) {
+            found = searchRecurse(childElement, serial);
+        } else if (childElement['prompt']) {
+            found = searchRecurse(childElement.prompt.bdy, serial);
+        }
+        if (found) {
+            return true;
+        }
+    });
+    return found;
+};
 
 export const positionFloat = function positionFloat(widget, position) {
     if (!position) {
@@ -58,11 +81,31 @@ export const positionFloat = function positionFloat(widget, position) {
 
     if (!context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] && prevClassName !== className) {
         // Re-build Figure widget to toggle between inline/block
+        const parent = searchRecurse(widget.element.bdy.rootElement.bdy, widget.serial);
+        // avoid changes on Figure in a prompt
+        if (parent.contentModel && parent.contentModel === 'inlineStatic') {
+            _.defer(() => {
+                widget.element.data('widget').refresh();
+            });
+            return;
+        }
+        // in A-block, text is inside '<p>'. When'<figure>' is added inside, this '<p>' tag gets split and a linebreak appears.
+        // here we change state to sleep-active so that the user will see that reflected in UI immediately.
+        // otherwise, he will see this linebreak only if he focuses text in this A-block again, or reopens the item.
+        widget.element.data('widget').changeState('sleep');
         _.defer(() => {
-            widget.element.data('widget').refresh();
+            if (parent && parent.data('widget')) {
+                parent.data('widget').changeState('active');
+                _.defer(() => {
+                    parent.data('widget').changeState('sleep');
+                    _.defer(() => {
+                        widget.element.data('widget').changeState('active');
+                    });
+                });
+            }
         });
+        widget.$original.trigger('contentChange.qti-widget');
     }
-    widget.$original.trigger('contentChange.qti-widget');
 };
 
 export const initAlignment = function initAlignment(widget) {

--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -82,14 +82,14 @@ export const positionFloat = function positionFloat(widget, position) {
     if (!context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] && prevClassName !== className) {
         // Re-build Figure widget to toggle between inline/block
         const parent = searchRecurse(widget.element.bdy.rootElement.bdy, widget.serial);
-        // avoid changes on Figure in a prompt
-        if (parent.contentModel && parent.contentModel === 'inlineStatic') {
+        // If Figure is not in A-block (Prompt, TextReader PCI)
+        if (parent.contentModel === 'inlineStatic' || widget.$container.closest('.qti-customInteraction').length) {
             _.defer(() => {
                 widget.element.data('widget').refresh();
             });
             return;
         }
-        // in A-block, text is inside '<p>'. When'<figure>' is added inside, this '<p>' tag gets split and a linebreak appears.
+        // If Figure is in A-block, text is inside '<p>'. When'<figure>' is added inside, this '<p>' tag gets split and a linebreak appears.
         // here we change state to sleep-active so that the user will see that reflected in UI immediately.
         // otherwise, he will see this linebreak only if he focuses text in this A-block again, or reopens the item.
         widget.element.data('widget').changeState('sleep');
@@ -104,8 +104,8 @@ export const positionFloat = function positionFloat(widget, position) {
                 });
             }
         });
-        widget.$original.trigger('contentChange.qti-widget');
     }
+    widget.$original.trigger('contentChange.qti-widget');
 };
 
 export const initAlignment = function initAlignment(widget) {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/AUT-3923

### Changes
1. `mediaAlignment/helper`
  In _TextReader PCI_, `parent.contentModel && parent.contentModel === 'inlineStatic'` didn't pass because `parent.contentModel` was undefined. Because `widget.refresh` didn't run, something wasn't updated, and image align reverted to _Inline_.
  It seemed fine to always call `widget.refresh` instead of `active/sleep/active` for other cases (_A-block, ChoiceInteraction choice_), not only for _Prompt_. Only for prompts of _MathEntry/Likert PCI_, there was now "_QTI XML compilation error_" when there was `<figure>` in the prompt (figure wasn't allowed before, for same reason as in TextReader PCI), but it was solved by another change in https://github.com/oat-sa/extension-tao-itemqti/pull/2613 
  This code was added in https://github.com/oat-sa/tao-core-ui-fe/pull/528, and `refresh` was added at the last moment.

2. `FigureStateActive`
 _Image Caption textarea_ in Authoring _side panel_: it was completely collapsed for newly added images. Add some min-height to it. _Image Caption textarea_ appears after you wrap inline image.

### Test
On unit05. Related PRs:
- https://github.com/oat-sa/tao-core/pull/4125
- https://github.com/oat-sa/tao-core-ui-fe/pull/606
- https://github.com/oat-sa/extension-pcisample/pull/172
- https://github.com/oat-sa/extension-tao-itemqti/pull/2613
