### PR TITLE
Fix/AUT-3960/GapMatchinteraction ckeditor console error on image wrap

### DIFF
--- a/src/mediaEditor/plugins/mediaAlignment/helper.js
+++ b/src/mediaEditor/plugins/mediaAlignment/helper.js
@@ -81,7 +81,11 @@ export const positionFloat = function positionFloat(widget, position) {
 
     if (!context.featureFlags['FEATURE_FLAG_DISABLE_FIGURE_WIDGET'] && prevClassName !== className) {
         // Re-build Figure widget to toggle between inline/block
-        const parent = searchRecurse(widget.element.bdy.rootElement.bdy, widget.serial);
+        const parent = searchRecurse(widget.element.rootElement.bdy, widget.serial);
+        // If it's Image not Figure (Choice, GapMatch/HotText qti-flow-container)
+        if (!parent) {
+            return;
+        }
         // If Figure is not in A-block (Prompt, TextReader PCI)
         if (parent.contentModel === 'inlineStatic' || widget.$container.closest('.qti-customInteraction').length) {
             _.defer(() => {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/AUT-3960

Add image to the body of HotText/GapMatch or to ChoiceInteraction's Choice, wrap it --> there's ckEditor error in console on `widget.element.bdy.rootElement` because `widget.element.bdy` doesn't exist.
This console error is harmless but let's get rid of it.

### To test
On unit01. All PRs: 
- https://github.com/oat-sa/extension-tao-itemqti/pull/2624
- https://github.com/oat-sa/extension-pcisample/pull/175
- https://github.com/oat-sa/tao-core-ui-fe/pull/608
- https://github.com/oat-sa/tao-core/pull/4130