### PR TITLE
chore: version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-core-ui",
-            "version": "3.9.0",
+            "version": "3.9.1",
             "license": "GPL-2.0",
             "devDependencies": {
                 "@babel/core": "^7.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {


### PR DESCRIPTION
Re-release https://github.com/oat-sa/tao-core-ui-fe/pull/608 because it can't be published as v3.9.0 belonged to untagged release https://github.com/oat-sa/tao-core-ui-fe/pull/610