### PR TITLE
fix: booklet download from tasks queue

### DIFF
--- a/src/taskQueue/taskQueueModel.js
+++ b/src/taskQueue/taskQueueModel.js
@@ -496,10 +496,12 @@ export default function taskQueueModel(config) {
                 throw new TypeError('config.url.download is not configured while download() is being called');
             }
 
-            return this.getCached(taskId).then(function (taskData) {
-                let redirectUrl = (taskData || {}).redirectUrl;
+            return this.getCached(taskId).then(function (taskData = {}) {
+                const { redirectUrl, category } = taskData;
 
-                if (redirectUrl) {
+                // if the task is an update task, we should not use redirectUrl for download
+                // it only uses for DOCX file download (export category)
+                if (redirectUrl && category !== 'update') {
                     return new Promise(function (resolve) {
                         $.fileDownload(redirectUrl, {
                             httpMethod: 'GET',


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/LSI-5002

## What's Changed

- Fixed the issue when user is not able to download the PDF generated from booklet

## How to test

- In the Tests tab, select a test
- Click “New booklet” button
- Click “Generate”
- In the Background tasks, find the task with generated booklet
- Click “Download” icon
- The booklet should be downloaded successfully