### PR TITLE
fix: booklet download from tasks queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "3.8.1",
+    "version": "3.8.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-ui",
-    "version": "3.8.1",
+    "version": "3.8.2",
     "displayName": "TAO Core UI",
     "description": "UI libraries of TAO",
     "scripts": {

--- a/src/taskQueue/taskQueueModel.js
+++ b/src/taskQueue/taskQueueModel.js
@@ -496,10 +496,12 @@ export default function taskQueueModel(config) {
                 throw new TypeError('config.url.download is not configured while download() is being called');
             }
 
-            return this.getCached(taskId).then(function (taskData) {
-                let redirectUrl = (taskData || {}).redirectUrl;
+            return this.getCached(taskId).then(function (taskData = {}) {
+                const { redirectUrl, category } = taskData;
 
-                if (redirectUrl) {
+                // if the task is an update task, we should not use redirectUrl for download
+                // it only uses for DOCX file download (export category)
+                if (redirectUrl && category !== 'update') {
                     return new Promise(function (resolve) {
                         $.fileDownload(redirectUrl, {
                             httpMethod: 'GET',


### PR DESCRIPTION
Back-port of https://oat-sa.atlassian.net/browse/LSI-5002 into 3.8.1 version