### PR TITLE
Refresh file list after upload

### DIFF
--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -128,7 +128,8 @@ export default function (options) {
             if (root !== 'local' || !_.find(subTree.children, { name: file.name })) {
                 updatePermissions(file);
                 const childrenFilesOnly = _.filter(subTree.children, function (child) {
-                    return !child.hasOwnProperty('path');
+                    // Only file object has link property
+                    return Object.prototype.hasOwnProperty.call(child, 'link');
                 });
 
                 if (childrenFilesOnly.length === subTree.total) {

--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -127,7 +127,11 @@ export default function (options) {
             }
             if (root !== 'local' || !_.find(subTree.children, { name: file.name })) {
                 updatePermissions(file);
-                if (subTree.children.length === subTree.total) {
+                const childrenFilesOnly = _.filter(subTree.children, function (child) {
+                    return !child.hasOwnProperty('path');
+                });
+
+                if (childrenFilesOnly.length === subTree.total) {
                     // all children loaded new file can be pushed to the end of tree
                     // if not all, new file will be loaded with next page
                     subTree.children.push(file);


### PR DESCRIPTION
This will fix correct behavior after file has been uploaded, file list will be refreshed. 

How to test it.
1. In Assets create at least 1 class
2. Create new item
3. Add inline block interaction
4. Add media
5. Upload file
6. Ensure uploaded file is visible. 





https://github.com/user-attachments/assets/b115ca41-c82b-4e0a-b913-cc888fb8ec59


