### PR TITLE
Fix/adf-1833/level 2 class issues

### DIFF
--- a/src/searchModal.js
+++ b/src/searchModal.js
@@ -175,7 +175,7 @@ export default function searchModalFactory(config) {
                 //set up the inner resource selector
                 selectionMode: 'single',
                 selectClass: true,
-                classUri: rootClassUri,
+                classUri: initialClassUri,
                 showContext: false,
                 showSelection: false
             });

--- a/src/searchModal/scss/searchModal.scss
+++ b/src/searchModal/scss/searchModal.scss
@@ -282,6 +282,7 @@ $classTreeVariables: (
         }
         .filter-container {
             position: relative;
+            z-index: 1;
             margin-bottom: 8px;
             &:last-child {
                 padding-bottom: 16px;


### PR DESCRIPTION
related to 
 - https://oat-sa.atlassian.net/browse/ADF-1833
 - https://oat-sa.atlassian.net/browse/ADF-1743
 
 ### Description

PR addresses the UI issues with class selection dropdown

### How to test

 -  `npm run test`
 - ADF-1833: try to open search, select second child level (i.e Subfolder in the structure:  Item->Folder->SubFolder) from the root level and search. Close the searchModal, open it again. The results should be there like before closing
  - ADF-1743: try to add criteria with multiple selection (i.e Translated into languages field), now open Class selection dropdown. Is should go ontop of the criteria combination radiobuttons