### PR TITLE
fix/ADF-1860/readonly-field-show-in-filters

### DIFF
--- a/src/resource/filters.js
+++ b/src/resource/filters.js
@@ -35,6 +35,7 @@ import filtersTpl from 'ui/resource/tpl/filters';
  * FIXME add radio as soon as supported
  */
 var supportedWidgets = [
+    'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Readonly',
     'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox',
     'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox',
     'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox',


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1860

### Description

Show in the form list the field with the widget 

`http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Readonly`


### How to test

Try to search an item when doing test authoring

`Equivalent Resource ID` search criteria should appear