### PR TITLE
Feature/tr 6452/vertical item layout

### DIFF
--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -101,7 +101,8 @@ body {
     blockquote, dd, dl, fieldset, figure, h1, h2, h3, h4, h5, h6,
     hr, ol, p, pre, ul {
         display: block;
-        margin-bottom: 10px;
+        margin-block-end: 10px;
+        margin-inline-end: 0;
         white-space: normal;
     }
 

--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -484,10 +484,6 @@ body {
         font-size: 1.4rem !important;
     }
 
-    .writing-mode-vertical-rl {
-        writing-mode: vertical-rl;
-    }
-
 
 
     // everything on list styles and counters

--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -102,7 +102,6 @@ body {
     hr, ol, p, pre, ul {
         display: block;
         margin-block-end: 10px;
-        margin-inline-end: 0;
         white-space: normal;
     }
 

--- a/scss/inc/_base.scss
+++ b/scss/inc/_base.scss
@@ -484,6 +484,10 @@ body {
         font-size: 1.4rem !important;
     }
 
+    .writing-mode-vertical-rl {
+        writing-mode: vertical-rl;
+    }
+
 
 
     // everything on list styles and counters

--- a/scss/inc/_functions.scss
+++ b/scss/inc/_functions.scss
@@ -51,6 +51,16 @@ Usage:
     width: $spanPercent;
 }
 
+@mixin grid-unit-writing-mode($span, $numCols: 12, $gutter: 0) {
+    $gridPx: 840;
+    $rawSpanPx: calc((($gridPx - ($numCols * $gutter)) / $numCols));
+    $spanPx: $rawSpanPx * $span + (($span - 1) * $gutter);
+    $spanPercent: widthPerc($spanPx, $gridPx);
+    $marginPercent: widthPerc($gutter, $gridPx);
+    margin-inline-start: $marginPercent;
+    inline-size: $spanPercent;
+}
+
 
 @mixin vendor-prefix($property, $value, $whatToPrefix: property, $prefixes: (-webkit-, -moz-, -ms-, -o-, '')) {
     @if $whatToPrefix == 'property' {

--- a/scss/inc/_functions.scss
+++ b/scss/inc/_functions.scss
@@ -48,17 +48,13 @@ Usage:
     $spanPercent: widthPerc($spanPx, $gridPx);
     $marginPercent: widthPerc($gutter, $gridPx);
     margin-left: $marginPercent;
-    width: $spanPercent;
+    inline-size: $spanPercent;
 }
-
-@mixin grid-unit-writing-mode($span, $numCols: 12, $gutter: 0) {
+@mixin grid-unit-writing-mode-margin($span, $numCols: 12, $gutter: 0) {
     $gridPx: 840;
-    $rawSpanPx: calc((($gridPx - ($numCols * $gutter)) / $numCols));
-    $spanPx: $rawSpanPx * $span + (($span - 1) * $gutter);
-    $spanPercent: widthPerc($spanPx, $gridPx);
     $marginPercent: widthPerc($gutter, $gridPx);
     margin-inline-start: $marginPercent;
-    inline-size: $spanPercent;
+    margin-left: 0;
 }
 
 

--- a/scss/inc/_functions.scss
+++ b/scss/inc/_functions.scss
@@ -47,16 +47,9 @@ Usage:
     $spanPx: $rawSpanPx * $span + (($span - 1) * $gutter);
     $spanPercent: widthPerc($spanPx, $gridPx);
     $marginPercent: widthPerc($gutter, $gridPx);
-    margin-left: $marginPercent;
+    margin-inline-start: $marginPercent;
     inline-size: $spanPercent;
 }
-@mixin grid-unit-writing-mode-margin($span, $numCols: 12, $gutter: 0) {
-    $gridPx: 840;
-    $marginPercent: widthPerc($gutter, $gridPx);
-    margin-inline-start: $marginPercent;
-    margin-left: 0;
-}
-
 
 @mixin vendor-prefix($property, $value, $whatToPrefix: property, $prefixes: (-webkit-, -moz-, -ms-, -o-, '')) {
     @if $whatToPrefix == 'property' {

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -26,7 +26,7 @@
 }
 @for $i from 1 through 12 {
     .col-#{$i} {
-        @include grid-unit-writing-mode($i, 12, 12);
+        @include grid-unit($i, 12, 12);
         margin-block-end: 12px;
     }
     .alpha {
@@ -38,6 +38,11 @@
     .grid-row.grid-row, .fixed-grid-row.fixed-grid-row {
         block-size: auto;
         inline-size: 100%;
+    }
+    @for $i from 1 through 12 {
+        :where(.col-#{$i}) {
+            @include grid-unit-writing-mode-margin($i, 12, 12);
+        }
     }
 }
 

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -1,8 +1,8 @@
 [class*=" col-"], [class^="col-"] {
     float: left;
-    min-height: 1rem;
+    min-block-size: 1rem;
     &:first-child {
-        margin-left: 0;
+        margin-inline-start: 0;
     }
     &.grid-container {
         margin-bottom: 0;
@@ -19,15 +19,15 @@
 
 .grid-row, .fixed-grid-row {
     @extend .clearfix;
-    width: widthPerc(852, 840);
+    inline-size: widthPerc(852, 840);
 }
 .colrow {
     @extend .clearfix;
 }
 @for $i from 1 through 12 {
     .col-#{$i} {
-        @include grid-unit($i, 12, 12);
-        margin-bottom: 12px;
+        @include grid-unit-writing-mode($i, 12, 12);
+        margin-block-end: 12px;
     }
     .alpha {
         margin-left: 0 !important
@@ -35,16 +35,9 @@
 }
 
 .writing-mode-vertical-rl {
-    .grid-row, .fixed-grid-row {
+    .grid-row.grid-row, .fixed-grid-row.fixed-grid-row {
         block-size: auto;
         inline-size: 100%;
-
-        [class*=" col-"], [class^="col-"] {
-            &.col-12 {
-                block-size: auto;
-                inline-size: 100%;
-            }
-        }
     }
 }
 
@@ -52,7 +45,7 @@
 
     .grid-row {
         @extend .clearfix;
-        width: 100%
+        width: 100%;
     }
     @for $i from 1 through 12 {
         .col-#{$i} {

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -34,6 +34,20 @@
     }
 }
 
+.writing-mode-vertical-rl {
+    .grid-row, .fixed-grid-row {
+        block-size: auto;
+        inline-size: 100%;
+
+        [class*=" col-"], [class^="col-"] {
+            &.col-12 {
+                block-size: auto;
+                inline-size: 100%;
+            }
+        }
+    }
+}
+
 #icon-editor {
 
     .grid-row {

--- a/scss/inc/_grid.scss
+++ b/scss/inc/_grid.scss
@@ -2,7 +2,7 @@
     float: left;
     min-block-size: 1rem;
     &:first-child {
-        margin-inline-start: 0;
+        margin-left: 0;
     }
     &.grid-container {
         margin-bottom: 0;
@@ -39,9 +39,13 @@
         block-size: auto;
         inline-size: 100%;
     }
-    @for $i from 1 through 12 {
-        :where(.col-#{$i}) {
-            @include grid-unit-writing-mode-margin($i, 12, 12);
+    [class*=" col-"], [class^="col-"] {
+        &:first-child {
+            margin-inline-start: 0;
+            margin-block-end: 12px;
+        }
+        &:last-child {
+            margin-inline-end: 0;
         }
     }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-6452

`writing-mode: vertical-rl` for item, in Terre test-runner.
Base branch for interaction tickets.

### Note
Changing `left -> inset-end`, `margin-right -> margin-inline-end`, ...  affects `dir="rtl"` too, so need to be careful there.

### Related PRs:
- base item layout
  - https://github.com/oat-sa/tao-item-runner-qti-fe/pull/421 
  - https://github.com/oat-sa/extension-tao-itemqti/pull/2669
  - https://github.com/oat-sa/tao-core-ui-fe/pull/629
  - https://github.com/oat-sa/tao-core/pull/4194
  - https://github.com/oat-sa/tao-test-runner-qti-fe/pull/528
  - https://github.com/oat-sa/extension-tao-testqti/pull/2573
  - https://github.com/oat-sa/extension-tao-testqti-previewer/pull/214