### PR TITLE
feature: better handling of new list-style, add ability to add parent…

### DIFF
--- a/scss/inc/base/_list-style.scss
+++ b/scss/inc/base/_list-style.scss
@@ -1,58 +1,47 @@
-ul, ol {
-    padding-left: 40px;
-    &.plain, &.none {
-        padding: 0;
-        margin: 0;
-        list-style: none;
-    }
-    li {
-        vertical-align: text-top !important;
-    }
-}
+/*
+This SCSS generates CSS classes for custom list styling, it:
+- For classes like .list-style-disc, .list-style-decimal-period etc.
+- Uses counter-reset for automatic item numbering
+- Supports base styles (disc, decimal etc.) and suffix variants (-period ".", -parenthesis ")")
+- Easy addition of new styles using $list_styles array and new suffixes and $suffixes map
+*/
 
-nav {
-    ul {
-        padding: 0;
-        margin: 0;
-        list-style: none;
-    }
-}
+//https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type
+$list_styles: disc, circle, square, decimal, decimal-leading-zero, lower-roman, upper-roman,
+lower-greek, lower-latin, upper-latin, armenian, georgian, lower-alpha, upper-alpha;
 
-// according to https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type these styles are the most compatible ones
-// disc|circle|square|decimal|decimal-leading-zero|lower-roman|upper-roman|lower-greek|lower-latin|upper-latin|armenian|georgian|lower-alpha|upper-alpha|none. lower|upper-latin are aliases of lower|upper-roman
-$list_styles: disc,circle,square,decimal,decimal-leading-zero,lower-roman,upper-roman,lower-greek,lower-latin,upper-latin,armenian,georgian,lower-alpha,upper-alpha,none;
-
-
-@for $i from 1 through length($list_styles) {
-    ul.#{nth($list_styles, $i)}, ol.#{nth($list_styles, $i)} {
-        list-style-type: #{nth($list_styles, $i)};
-    }
-}
-
-// this part enables list styles on all elements by using CSS counter, the required class name is e.g. list-style-disc
-// exp.
-// <parent class="list-style-disc">
-//    <child> -> parent > p | parent > div | parent > li has a bullet
+$suffixes: (
+    'parenthesis': ')',
+    'period': '.'
+);
 
 [class^="list-style-"], [class*=" list-style-"] {
-
     counter-reset: custom-counter;
 
-    &>p, &>div, &>li {
+    &>p, &>div, &>li.qti-choice {
+        position: relative;
         &::before {
             counter-increment: custom-counter;
+            position: absolute;
+            left: -25px;
             width: 20px;
             display: inline-block;
             text-align: center;
         }
     }
 
-    @for $i from 1 through length($list_styles) {
-        &.list-style-#{nth($list_styles, $i)} {
-            &>p, &>div, &>li {
-                &::before {
-                    content: counter(custom-counter, #{nth($list_styles, $i)});
-                }
+    @each $style in $list_styles {
+        &.list-style-#{$style} {
+            &>p, &>div, &>li.qti-choice::before {
+                content: counter(custom-counter, #{$style});
+            }
+        }
+    }
+
+    @each $style in $list_styles {
+        @each $suffix, $symbol in $suffixes {
+            &.list-style-#{$style}-#{$suffix} > li.qti-choice::before {
+                content: counter(custom-counter, #{$style}) "#{$symbol}";
             }
         }
     }

--- a/scss/inc/base/_list-style.scss
+++ b/scss/inc/base/_list-style.scss
@@ -1,3 +1,23 @@
+ul, ol {
+    padding-left: 40px;
+    &.plain, &.none {
+        padding: 0;
+        margin: 0;
+        list-style: none;
+    }
+    li {
+        vertical-align: text-top !important;
+    }
+}
+
+nav {
+    ul {
+        padding: 0;
+        margin: 0;
+        list-style: none;
+    }
+}
+
 /*
 This SCSS generates CSS classes for custom list styling, it:
 - For classes like .list-style-disc, .list-style-decimal-period etc.


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4082

## What's Changed

- Add -period ".", and -parenthesis ")") suffixes to list-style in choice interaction

## How to test
- Add changes to `@oat-sa/tao` by running `npm install --save github:oat-sa/tao-core-ui-fe#feature/AUT-4082-new-classes-to-list-style` in you `/nextgen-stack/tao/tao/views ` folder
- run` npm run sass` in `/nextgen-stack/tao/tao/view/build` folder
- go to Backoffice run item authoring and check new list in choice interaction

##Video

https://github.com/user-attachments/assets/c7b7cf1f-6d8c-4705-b561-408536573371


