### PR TITLE
fix: fix for media-player hide on escape press when in inserted in prompt

### DIFF
--- a/src/previewer.js
+++ b/src/previewer.js
@@ -139,7 +139,7 @@ const previewer = {
      * @private
      */
     _clearPlayer: function($elt) {
-        if ($elt.parents('.qti-prompt').length) return; // avoid clear in prompt
+        if ($elt.parents('.qti-item').length) return; // avoid clear in qti mode
         if ($elt && $elt.data('player')) {
             $elt.data('player').destroy();
             $elt.removeData('player');

--- a/src/previewer.js
+++ b/src/previewer.js
@@ -139,6 +139,7 @@ const previewer = {
      * @private
      */
     _clearPlayer: function($elt) {
+        if ($elt.parents('.qti-prompt').length) return; // avoid clear in prompt
         if ($elt && $elt.data('player')) {
             $elt.data('player').destroy();
             $elt.removeData('player');


### PR DESCRIPTION
Fixed prompt behavior when pressing `esc` caused hiding the media player. 

![image](https://i.imgur.com/cZKp3cP.gif)


Steps to Reproduce
1. Create item(s) with video included in:
- Media interaction
- Text block
- Choice interaction prompt (or any other interaction prompt)
2. Preview the item(s)/include the item(s) in a test, publish the test and launch it.
3. Press the ESC key.