### PR TITLE
feature: add additional list styles

### DIFF
--- a/src/liststyler.js
+++ b/src/liststyler.js
@@ -57,7 +57,13 @@ var listStyles = {
     'upper-roman': 'I',
     'lower-greek': '\u03b1',
     armenian: '\u0531',
-    georgian: '\u10d0'
+    georgian: '\u10d0',
+    'decimal-period': '1.',
+    'decimal-parenthesis': '1)',
+    'lower-alpha-period': 'a.',
+    'lower-alpha-parenthesis': 'a)',
+    'upper-alpha-period': 'A.',
+    'upper-alpha-parenthesis': 'A)'
 };
 
 /**


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4082

## What's Changed

- Add -period ".", and -parenthesis ")") suffixes to list-style in choice interaction

## How to test
- Add changes to `@oat-sa/tao` by running `npm install --save github:oat-sa/tao-core-ui-fe#feature/AUT-4082-new-classes-to-list-style` in you `/nextgen-stack/tao/tao/views ` folder
- run` npm run sass` in `/nextgen-stack/tao/tao/view/build` folder
- go to Backoffice run item authoring and check new list in choice interaction

##Video

https://github.com/user-attachments/assets/c7b7cf1f-6d8c-4705-b561-408536573371


