### PR TITLE
Feature/aut 4159 add interaction source plugin

### DIFF
--- a/scss/ckeditor/skins/tao/scss/inc/_presets.scss
+++ b/scss/ckeditor/skins/tao/scss/inc/_presets.scss
@@ -8,6 +8,9 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
 .cke_button__sourcedialog_label {
   display: inline;
 }
+.cke_button__interactionsource_label {
+    display: inline;
+}
 
 /* "Font Size" combo width */
 .cke_combo__fontsize .cke_combo_text {

--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -673,10 +673,6 @@ const ckConfigurator = (function () {
             if (context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_SOURCEDIALOG) {
                 ckConfig.toolbar.push({ name: 'sourcedialog', items: ['Sourcedialog'] });
             }
-            //enable interactionsource plugin upon featureflag (false by default)
-            if (context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_INTERACTION_SOURCE) {
-                ckConfig.toolbar.push({ name: 'interactionsource', items: ['InteractionSource'] });
-            }
         }
 
         // ensures positionedPlugins has the right format

--- a/src/ckeditor/ckConfigurator.js
+++ b/src/ckeditor/ckConfigurator.js
@@ -673,6 +673,10 @@ const ckConfigurator = (function () {
             if (context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_SOURCEDIALOG) {
                 ckConfig.toolbar.push({ name: 'sourcedialog', items: ['Sourcedialog'] });
             }
+            //enable interactionsource plugin upon featureflag (false by default)
+            if (context.featureFlags && context.featureFlags.FEATURE_FLAG_CKEDITOR_INTERACTION_SOURCE) {
+                ckConfig.toolbar.push({ name: 'interactionsource', items: ['InteractionSource'] });
+            }
         }
 
         // ensures positionedPlugins has the right format


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4160
https://oat-sa.atlassian.net/browse/AUT-4161

## What's Changed
- Add ability to wrap interactions into custom classed div`s

## TODO 
- [x] Unit tests

## Dependencies PRs
- https://github.com/oat-sa/ckeditor-dev/pull/54
- https://github.com/oat-sa/extension-tao-itemqti/pull/2733

## How to test
- set ff `FEATURE_FLAG_CKEDITOR_INTERACTION_SOURCE` to `true`
- Create new item, go to Authoring and add some interaction, for example choice.
- Select it and click **Edit Interaction Source** button in editor toolbar.
- Wrap interaction's placeholder in` <div class="foobar"> `and click **OK** button.
- Observe dev Tools Network panel that `div` wrapper is saved.
- If custom `CSS` spreadsheet is added to item class inside will be already visible.

## Video


https://github.com/user-attachments/assets/c82434d3-c5bc-4874-b269-befc80278dc7

Wrapper deletion 

https://github.com/user-attachments/assets/0607cdf6-16f3-48d7-895e-72f5ff9eb649



