### PR TITLE
Fix/TR-6664/vertical writing ol marker

### DIFF
--- a/scss/inc/base/_list-style.scss
+++ b/scss/inc/base/_list-style.scss
@@ -19,6 +19,14 @@ nav {
         list-style: none;
     }
 }
+.writing-mode-vertical-rl ol {
+    li::marker {
+        text-combine-upright: all;
+    }
+    li {
+        padding-inline-start: 6px;
+    }
+}
 
 /*
 This SCSS generates CSS classes for custom list styling, it:


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-6664

Vertical-writing: marker of numbered list should have upright position.
  
<img width="452" height="155" alt="Screenshot_4" src="https://github.com/user-attachments/assets/c8e0a0fb-05bb-47fe-961d-c422a68f3c33" />
