### PR TITLE
Feature/INF-445/singleton resizeObserver

### DIFF
--- a/src/resizeObserver.js
+++ b/src/resizeObserver.js
@@ -1,0 +1,86 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA ;
+ */
+import $ from 'jquery';
+
+let callbacks;
+let resizeObserver;
+
+/**
+ * Use the single ResizeObserver instance
+ * @returns {Object}
+ */
+export default {
+    /**
+     * @param {jQuery|Element} elem
+     * @param {(entry: ResizeObserverEntry, observer: ResizeObserver) => {}} callback
+     * @param {Object?} observeOptions - see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe#options
+     */
+    observe: function (elem, callback = () => {}, observeOptions) {
+        const node = elem && $(elem).get(0);
+        if (!node) {
+            return;
+        }
+
+        ensureResizeObserverInstance();
+        resizeObserver.observe(node, observeOptions);
+
+        let nodeCallbacks = callbacks.get(node);
+        if (!nodeCallbacks) {
+            callbacks.set(node, new Set());
+            nodeCallbacks = callbacks.get(node);
+        }
+        nodeCallbacks.add(callback);
+    },
+
+    /**
+     * @param {jQuery|Element} elem
+     * @param {Function} callback
+     */
+    unobserve: function (elem, callback) {
+        const node = elem && $(elem).get(0);
+        if (!node) {
+            return;
+        }
+
+        ensureResizeObserverInstance();
+        resizeObserver.unobserve(node);
+
+        const nodeCallbacks = callbacks.get(node);
+        nodeCallbacks.delete(callback);
+        if (nodeCallbacks.size < 1) {
+            callbacks.delete(node);
+        }
+    }
+};
+
+function ensureResizeObserverInstance() {
+    if (!resizeObserver) {
+        callbacks = new WeakMap();
+        resizeObserver = new ResizeObserver((entries, observer) => {
+            for (const entry of entries) {
+                const entryCallbacks = callbacks.get(entry.target);
+                if (!entryCallbacks) {
+                    return;
+                }
+                for (const entryCallback of entryCallbacks) {
+                    entryCallback(entry, observer);
+                }
+            }
+        });
+    }
+}

--- a/src/resizeObserver.js
+++ b/src/resizeObserver.js
@@ -58,11 +58,14 @@ export default {
         }
 
         ensureResizeObserverInstance();
-        resizeObserver.unobserve(node);
 
         const nodeCallbacks = callbacks.get(node);
+        if (!nodeCallbacks) {
+            return;
+        }
         nodeCallbacks.delete(callback);
         if (nodeCallbacks.size < 1) {
+            resizeObserver.unobserve(node);
             callbacks.delete(node);
         }
     }
@@ -75,7 +78,7 @@ function ensureResizeObserverInstance() {
             for (const entry of entries) {
                 const entryCallbacks = callbacks.get(entry.target);
                 if (!entryCallbacks) {
-                    return;
+                    continue;
                 }
                 for (const entryCallback of entryCallbacks) {
                     entryCallback(entry, observer);

--- a/test/resizeObserver/test.html
+++ b/test/resizeObserver/test.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Ui Test - ResizeObserver Utility</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['test/ui/resizeObserver/test'], function() {
+                        QUnit.config.reorder = false;
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="test-element" style="width: 100px; height: 100px;"></div>
+            <div id="test-element-2" style="width: 50px; height: 50px;"></div>
+        </div>
+    </body>
+</html>

--- a/test/resizeObserver/test.js
+++ b/test/resizeObserver/test.js
@@ -1,0 +1,131 @@
+define(['jquery', 'ui/resizeObserver'], function ($, resizeObserver) {
+    'use strict';
+
+    QUnit.module('ResizeObserver Helper');
+
+    QUnit.test('module', function (assert) {
+        assert.ok(typeof resizeObserver === 'object', 'The resizeObserver module is available');
+        assert.ok(typeof resizeObserver.observe === 'function', 'The observe method is available');
+        assert.ok(typeof resizeObserver.unobserve === 'function', 'The unobserve method is available');
+    });
+
+    QUnit.test('observe triggers callback on resize', function (assert) {
+        const ready = assert.async();
+        const $fixture = $('#qunit-fixture');
+        const $element = $fixture.find('#test-element');
+        let callCount = 0;
+
+        assert.expect(4);
+
+        const callback = function (entry) {
+            requestAnimationFrame(() => {
+                callCount++;
+                if (callCount === 1) {
+                    assert.ok(true, 'Initial callback triggered on observe');
+                    assert.ok(entry instanceof ResizeObserverEntry, 'Callback receives a ResizeObserverEntry');
+                    assert.strictEqual(entry.target, $element.get(0), 'Entry target matches the observed element');
+                    $element.css('width', '200px');
+                } else if (callCount === 2) {
+                    assert.ok(true, 'Callback triggered after resize');
+                    resizeObserver.unobserve($element, callback);
+                    ready();
+                }
+            });
+        };
+
+        resizeObserver.observe($element, callback);
+    });
+
+    QUnit.test('unobserve stops observation', function (assert) {
+        const ready = assert.async();
+        const $fixture = $('#qunit-fixture');
+        const $element = $fixture.find('#test-element');
+        let callCount = 0;
+
+        assert.expect(1);
+
+        const callback = function () {
+            callCount++;
+            if (callCount === 1) {
+                resizeObserver.unobserve($element, callback);
+                $element.css('width', '300px');
+                setTimeout(function () {
+                    assert.strictEqual(callCount, 1, 'Callback was not called after unobserve');
+                    ready();
+                }, 100);
+            }
+        };
+
+        resizeObserver.observe($element, callback);
+    });
+
+    QUnit.test('multiple callbacks on same element', function (assert) {
+        const ready = assert.async();
+        const $fixture = $('#qunit-fixture');
+        const $element = $fixture.find('#test-element');
+        let callback1Count = 0;
+        let callback2Count = 0;
+
+        assert.expect(4);
+
+        const callback1 = function () {
+            requestAnimationFrame(() => {
+                callback1Count++;
+            });
+        };
+
+        const callback2 = function () {
+            requestAnimationFrame(() => {
+                callback2Count++;
+                if (callback2Count === 1) {
+                    assert.strictEqual(callback1Count, 1, 'First element callback was called');
+                    assert.strictEqual(callback2Count, 1, 'Second element callback was called');
+                    resizeObserver.unobserve($element, callback1);
+                    $element.css('width', '250px');
+                } else if (callback2Count === 2) {
+                    assert.strictEqual(callback1Count, 1, 'First callback stopped after unobserve');
+                    assert.strictEqual(callback2Count, 2, 'Second callback still receives updates');
+                    resizeObserver.unobserve($element, callback2);
+                    ready();
+                }
+            });
+        };
+
+        resizeObserver.observe($element, callback1);
+        resizeObserver.observe($element, callback2);
+    });
+
+    QUnit.test('observe multiple elements', function (assert) {
+        const ready = assert.async();
+        const $fixture = $('#qunit-fixture');
+        const $element1 = $fixture.find('#test-element');
+        const domElement2 = $fixture.find('#test-element-2').get(0);
+        let element1Called = false;
+        let element2Called = false;
+
+        assert.expect(2);
+
+        const callback1 = function () {
+            element1Called = true;
+            checkDone();
+        };
+
+        const callback2 = function () {
+            element2Called = true;
+            checkDone();
+        };
+
+        function checkDone() {
+            if (element1Called && element2Called) {
+                assert.ok(element1Called, 'First element callback was called');
+                assert.ok(element2Called, 'Second element callback was called');
+                resizeObserver.unobserve($element1, callback1);
+                resizeObserver.unobserve(domElement2, callback2);
+                ready();
+            }
+        }
+
+        resizeObserver.observe($element1, callback1);
+        resizeObserver.observe(domElement2, callback2);
+    });
+});

--- a/test/resizeObserver/test.js
+++ b/test/resizeObserver/test.js
@@ -63,31 +63,37 @@ define(['jquery', 'ui/resizeObserver'], function ($, resizeObserver) {
         const ready = assert.async();
         const $fixture = $('#qunit-fixture');
         const $element = $fixture.find('#test-element');
+        let callback1, callback2;
         let callback1Count = 0;
         let callback2Count = 0;
 
         assert.expect(4);
 
-        const callback1 = function () {
+        const checkDone = function () {
+            if (callback2Count === 1) {
+                assert.strictEqual(callback1Count, 1, 'First element callback was called');
+                assert.strictEqual(callback2Count, 1, 'Second element callback was called');
+                resizeObserver.unobserve($element, callback1);
+                $element.css('width', '250px');
+            } else if (callback2Count === 2) {
+                assert.strictEqual(callback1Count, 1, 'First callback stopped after unobserve');
+                assert.strictEqual(callback2Count, 2, 'Second callback still receives updates');
+                resizeObserver.unobserve($element, callback2);
+                ready();
+            }
+        };
+
+        callback1 = function () {
             requestAnimationFrame(() => {
                 callback1Count++;
+                checkDone();
             });
         };
 
-        const callback2 = function () {
+        callback2 = function () {
             requestAnimationFrame(() => {
                 callback2Count++;
-                if (callback2Count === 1) {
-                    assert.strictEqual(callback1Count, 1, 'First element callback was called');
-                    assert.strictEqual(callback2Count, 1, 'Second element callback was called');
-                    resizeObserver.unobserve($element, callback1);
-                    $element.css('width', '250px');
-                } else if (callback2Count === 2) {
-                    assert.strictEqual(callback1Count, 1, 'First callback stopped after unobserve');
-                    assert.strictEqual(callback2Count, 2, 'Second callback still receives updates');
-                    resizeObserver.unobserve($element, callback2);
-                    ready();
-                }
+                checkDone();
             });
         };
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-445

Since it's a little better performance-wise to have a single ResizeObserver instance, and use it to observe multiple nodes, add a helper for that: adapted from https://github.com/oat-sa/live-design-system/blob/develop/packages/core/actions/resizeObserver.js 

### Related PRs:
- https://github.com/oat-sa/tao-item-runner-qti-fe/pull/484
- https://github.com/oat-sa/extension-tao-itemqti/pull/2945
- https://github.com/oat-sa/tao-core-ui-fe/pull/695
- https://github.com/oat-sa/tao-core/pull/4400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added element resize observation capability with shared observer and per-element callback management.

* **Tests**
  * Added a browser test harness and comprehensive tests validating single/multiple element monitoring, independent callbacks, unobserve cleanup, and cross-element behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->