### PR TITLE
chore: github workflow: publish from tag

### DIFF
--- a/.github/workflows/publish-npm-released.yml
+++ b/.github/workflows/publish-npm-released.yml
@@ -1,0 +1,48 @@
+# This workflow will do a clean install of node dependencies, build the source code and publish packages to npm.
+# It does not do the release or version bump.
+
+name: Publish tag to NPM
+
+on:
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: 'Tag'
+                required: true
+            npmTag:
+                description: 'NPM tag'
+                required: true
+                default: 'latest'
+
+jobs:
+    npm-publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org
+
+            - name: Validate tag
+              run: |
+                  if ! echo "${{ github.event.inputs.ref }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$'; then
+                    echo "Error: '${{ github.event.inputs.ref }}' is not a valid tag format (expected: v1.2.3 or v1.2.3-suffix)"
+                    exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.inputs.ref }}
+
+            - name: Install packages
+              run: npm ci
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_RELEASE_TOKEN }}
+
+            - name: Publish to npm
+              id: publish_npm
+              run: npm publish --tag ${{ github.event.inputs.npmTag || 'latest' }}
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_RELEASE_TOKEN }}

--- a/.github/workflows/publish-npm-released.yml
+++ b/.github/workflows/publish-npm-released.yml
@@ -18,12 +18,6 @@ jobs:
     npm-publish:
         runs-on: ubuntu-latest
         steps:
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22
-                  registry-url: https://registry.npmjs.org
-
             - name: Validate tag
               run: |
                   if ! echo "${{ github.event.inputs.ref }}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$'; then
@@ -36,13 +30,17 @@ jobs:
               with:
                   ref: ${{ github.event.inputs.ref }}
 
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org
+
             - name: Install packages
               run: npm ci
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_RELEASE_TOKEN }}
 
             - name: Publish to npm
               id: publish_npm
-              run: npm publish --tag ${{ github.event.inputs.npmTag || 'latest' }}
+              run: npm publish --tag "${{ github.event.inputs.npmTag || 'latest' }}"
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.CI_NPM_RELEASE_TOKEN }}


### PR DESCRIPTION
**For backports**:
After release tag and version bump are done manually,
Use github workflow to do `npm publish`
- to avoid running `npm run build` on the local machine
- to avoid having token with publishing permissions on the local machine

Based on https://github.com/oat-sa/tao-deliver-fe/blob/main/.github/workflows/publish-npm-released.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual workflow to publish tagged releases to NPM from a specified tag, with semantic version validation, optional release tag selection (defaults to "latest"), and secure token-based authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->