### PR TITLE
fix: center video content in html5 player

### DIFF
--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -115,6 +115,48 @@ export default function html5PlayerFactory($container, config = {}) {
     const debug = (action, ...args) =>
         (config.debug === true || config.debug === action) && window.console.log(getDebugContext(action), ...args);
 
+    const isVerticalLayout = () => {
+        const $layoutContext = $container.closest('.qti-interaction, .custom-text-box');
+
+        return (
+            ($('body').hasClass('item-writing-mode-vertical-rl') || $layoutContext.hasClass('writing-mode-vertical-rl')) &&
+            !$layoutContext.hasClass('writing-mode-horizontal-tb')
+        );
+    };
+
+    const applyVideoSizing = () => {
+        if (type !== 'video' || !$media || !$media.length) {
+            return;
+        }
+
+        $container.css({
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            overflow: 'hidden'
+        });
+
+        $media.css({
+            width: '100%',
+            height: '100%',
+            maxWidth: '100%',
+            maxHeight: '100%',
+            margin: '0 auto',
+            objectFit: 'contain',
+            objectPosition: 'center center',
+            boxSizing: 'border-box'
+        });
+
+        if (isVerticalLayout()) {
+            $media.css({
+                width: 'auto',
+                height: '100%',
+                maxWidth: 'none',
+                maxHeight: '100%'
+            });
+        }
+    };
+
     return eventifier({
         init() {
             const tpl = 'audio' === type ? audioTpl : videoTpl;
@@ -142,37 +184,7 @@ export default function html5PlayerFactory($container, config = {}) {
             $media = $(tpl({ cors, preload, poster, link }));
             $container.append($media);
 
-            if (type === 'video') {
-                $container.css({
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    overflow: 'hidden'
-                });
-
-                $media.css({
-                    width: '100%',
-                    height: '100%',
-                    maxWidth: '100%',
-                    maxHeight: '100%',
-                    margin: '0 auto',
-                    objectFit: 'contain',
-                    objectPosition: 'center center',
-                    boxSizing: 'border-box'
-                });
-
-                const isVerticalLayout =
-                    $container.closest('.writing-mode-vertical-rl, .item-writing-mode-vertical-rl').length > 0;
-
-                if (isVerticalLayout) {
-                    $media.css({
-                        width: 'auto',
-                        height: '100%',
-                        maxWidth: 'none',
-                        maxHeight: '100%'
-                    });
-                }
-            }
+            applyVideoSizing();
 
             media = $media.get(0);
             result = !!(media && support.checkSupport(media));
@@ -410,7 +422,7 @@ export default function html5PlayerFactory($container, config = {}) {
                     $media.height($media.height());
                     $media.on('loadedmetadata.recover', () => {
                         $media.off('loadedmetadata.recover');
-                        $media.css({ width: '', height: '' });
+                        applyVideoSizing();
                     });
                 }
 

--- a/src/mediaplayer/players/html5.js
+++ b/src/mediaplayer/players/html5.js
@@ -142,6 +142,38 @@ export default function html5PlayerFactory($container, config = {}) {
             $media = $(tpl({ cors, preload, poster, link }));
             $container.append($media);
 
+            if (type === 'video') {
+                $container.css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    overflow: 'hidden'
+                });
+
+                $media.css({
+                    width: '100%',
+                    height: '100%',
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    margin: '0 auto',
+                    objectFit: 'contain',
+                    objectPosition: 'center center',
+                    boxSizing: 'border-box'
+                });
+
+                const isVerticalLayout =
+                    $container.closest('.writing-mode-vertical-rl, .item-writing-mode-vertical-rl').length > 0;
+
+                if (isVerticalLayout) {
+                    $media.css({
+                        width: 'auto',
+                        height: '100%',
+                        maxWidth: 'none',
+                        maxHeight: '100%'
+                    });
+                }
+            }
+
             media = $media.get(0);
             result = !!(media && support.checkSupport(media));
 


### PR DESCRIPTION
## What
- center HTML5 video content inside player container
- apply objectFit: contain and objectPosition: center center for consistent centering
- keep vertical writing mode override for width/height behavior

## Why
- ensures video frame stays centered in player area for vertical layout scenarios

## Scope
- src/mediaplayer/players/html5.js

## Screenshot

<img width="1350" height="963" alt="image" src="https://github.com/user-attachments/assets/7b7a16fa-f658-42c7-9829-76053cb55c95" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Video display now reliably sizes and contains media with centered positioning.
  * Layout better handles vertical writing-mode content, preserving correct dimensions.
  * Sizing logic is now applied on initialization and after recovery to prevent temporary sizing resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->