### PR TITLE
fix: SOLAR-1933 keep asset browser pagination visible

### DIFF
--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -388,11 +388,12 @@ export default function (options) {
         const total = Number(selectedClass.total);
         const childrenLimit = Number(selectedClass.childrenLimit);
 
+        $paginationContainer.empty();
+
         if (!Number.isFinite(total) || !Number.isFinite(childrenLimit) || childrenLimit <= 0) {
             return;
         }
 
-        $paginationContainer.empty();
         const totalPages = Math.ceil(total / childrenLimit);
 
         if (total > 0 && totalPages > 1) {

--- a/src/resourcemgr/fileBrowser.js
+++ b/src/resourcemgr/fileBrowser.js
@@ -107,7 +107,7 @@ export default function (options) {
                 $selected.parent('li').addClass('active');
 
                 //internal event to set the file-selector content
-                updateSelectedClass(fullPath, subTree.total, $selected.data('children-limit'));
+                updateSelectedClass(fullPath, content.total, content.childrenLimit);
                 $container.trigger(`folderselect.${ns}`, [
                     content.label,
                     getPage(content.children),
@@ -137,9 +137,11 @@ export default function (options) {
                     // if not all, new file will be loaded with next page
                     subTree.children.push(file);
                 }
-                subTree.total++;
-                selectedClass.total++;
-                $container.trigger(`folderselect.${ns}`, [subTree.label, getPage(subTree.children), path]);
+                subTree.total = Number.isFinite(Number(subTree.total)) ? Number(subTree.total) + 1 : 1;
+                if (selectedClass.path === path) {
+                    selectedClass.total = subTree.total;
+                }
+                $container.trigger(`folderselect.${ns}`, [subTree.label, getPage(subTree.children), path, subTree]);
                 renderPagination();
             }
         }
@@ -201,7 +203,11 @@ export default function (options) {
                     const loadedFiles = _.filter(data.children, function (item) {
                         return !!item.uri;
                     });
-                    setToPath(tree, path, { children: loadedFiles });
+                    setToPath(tree, path, {
+                        children: loadedFiles,
+                        total: data.total,
+                        childrenLimit: data.childrenLimit
+                    });
                     content = getByPath(tree, path);
                     cb(content);
                 });
@@ -263,7 +269,12 @@ export default function (options) {
         if (tree) {
             if (tree.path === path) {
                 tree.children = tree.children ? tree.children.concat(data.children) : data.children;
-                tree.total = data.total;
+                if (Object.prototype.hasOwnProperty.call(data, 'total')) {
+                    tree.total = data.total;
+                }
+                if (Object.prototype.hasOwnProperty.call(data, 'childrenLimit')) {
+                    tree.childrenLimit = data.childrenLimit;
+                }
             } else if (tree.children) {
                 _.forEach(tree.children, function (child) {
                     done = setToPath(child, path, data);
@@ -356,10 +367,16 @@ export default function (options) {
      * @param {Number} childrenLimit - page size
      */
     function updateSelectedClass(path, total, childrenLimit) {
+        const normalizedTotal = Number(total);
+        const normalizedChildrenLimit = Number(childrenLimit);
+
         selectedClass = {
             path,
-            total,
-            childrenLimit,
+            total: Number.isFinite(normalizedTotal) && normalizedTotal >= 0 ? normalizedTotal : 0,
+            childrenLimit:
+                Number.isFinite(normalizedChildrenLimit) && normalizedChildrenLimit > 0
+                    ? normalizedChildrenLimit
+                    : selectedClass.childrenLimit || 10,
             page: 1
         };
     }
@@ -368,10 +385,17 @@ export default function (options) {
      */
     function renderPagination() {
         const $paginationContainer = $('.pagination-bottom', $container);
-        $paginationContainer.empty();
-        const totalPages = Math.ceil(selectedClass.total / selectedClass.childrenLimit);
+        const total = Number(selectedClass.total);
+        const childrenLimit = Number(selectedClass.childrenLimit);
 
-        if (selectedClass.total && totalPages > 1) {
+        if (!Number.isFinite(total) || !Number.isFinite(childrenLimit) || childrenLimit <= 0) {
+            return;
+        }
+
+        $paginationContainer.empty();
+        const totalPages = Math.ceil(total / childrenLimit);
+
+        if (total > 0 && totalPages > 1) {
             paginationComponent({
                 mode: 'simple',
                 activePage: selectedClass.page,

--- a/src/resourcemgr/fileSelector.js
+++ b/src/resourcemgr/fileSelector.js
@@ -231,14 +231,10 @@ export default function (options) {
     function setUpUploader(currentPath) {
         let errors = [];
         let $switcher = $('.upload-switcher a', $fileSelector);
+        let isUploadMode = false;
 
         $uploader.on('upload.uploader', function (e, file, result) {
-            let path =
-                $(`[data-display="${currentPath}"]`).data('path') || $(`[data-display="/${currentPath}"]`).data('path');
-            if (!path) {
-                path = currentPath;
-            }
-            $container.trigger(`filenew.${ns}`, [result, path]);
+            $container.trigger(`filenew.${ns}`, [result, currentPath]);
         });
         $uploader.on('fail.uploader', function (e, file, err) {
             errors.push(__('Unable to upload file %s : %s', file.name, err.message));
@@ -246,7 +242,7 @@ export default function (options) {
 
         $uploader.on('end.uploader', function () {
             if (errors.length === 0) {
-                _.delay(switchUpload, 500);
+                setUploadMode(false);
             } else {
                 feedback().error(`<ul><li>${errors.join('</li><li>')}</li></ul>`, { encodeHtml: false });
             }
@@ -333,8 +329,9 @@ export default function (options) {
             });
         });
 
-        function switchUpload() {
-            if ($fileContainer.css('display') === 'none') {
+        function setUploadMode(enableUploadMode) {
+            if (!enableUploadMode) {
+                isUploadMode = false;
                 $uploader.hide();
                 $fileContainer.show();
                 // Note: show() would display as inline, not inline-block!
@@ -342,6 +339,7 @@ export default function (options) {
                 $switcher.filter('.listing').hide();
                 $browserTitle.text(__('Browse folders:'));
             } else {
+                isUploadMode = true;
                 $fileContainer.hide();
                 $placeholder.hide();
                 $uploader.show();
@@ -355,8 +353,14 @@ export default function (options) {
         //switch to upload mode
         $switcher.click(function (e) {
             e.preventDefault();
-            switchUpload();
+            if ($(this).hasClass('upload')) {
+                setUploadMode(true);
+            } else if ($(this).hasClass('listing')) {
+                setUploadMode(false);
+            }
         });
+
+        setUploadMode(isUploadMode);
     }
 
     function updateFiles(path, files) {


### PR DESCRIPTION
## Summary

Fixes SOLAR-1933 in Item Authoring resource manager where pagination controls disappeared after folder navigation and upload/list transitions.

## Root cause

`fileBrowser` could lose pagination metadata (`total`, `childrenLimit`) on subtree updates and then compute pagination with invalid values. In addition, `fileSelector` used toggle-based mode switching and DOM-based path lookup after upload, which could desynchronize list/upload state.

## Changes

### `src/resourcemgr/fileBrowser.js`

- Use canonical loaded folder data when selecting folder:
  - `updateSelectedClass(fullPath, content.total, content.childrenLimit)`
- Keep `selectedClass.total` synchronized with active folder after `filenew`.
- Include subtree content in `folderselect` payload triggered from `filenew`.
- Preserve `total` and `childrenLimit` in `setToPath()` when loading more pages.
- Normalize and guard pagination inputs in `updateSelectedClass()` / `renderPagination()`.

### `src/resourcemgr/fileSelector.js`

- Replace display-based toggle with deterministic `setUploadMode(true|false)`.
- Remove delayed switch race (`_.delay`) after upload end.
- Use canonical `currentPath` for `filenew` instead of DOM lookup.

## Validation

- `npx eslint -c .eslintrc.js src/resourcemgr/fileSelector.js src/resourcemgr/fileBrowser.js`
- Manual runtime verification in TAO authoring after rebuild (`taobundle`, `taosass`).
- Reproduced and validated critical flow:
  - open resource manager
  - navigate Assets
  - use pagination next/prev
  - reselect folder in Browse resources
  - pagination remains consistent.



https://github.com/user-attachments/assets/accc53eb-2f7b-4d2b-8608-34d24562a1cf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination reliability by normalizing and validating pagination totals/limits before updating UI.
  * Updated folder selection and pagination to rely on server-provided page data for more consistent paging results.
  * Refined `filenew` handling to safely update totals and adjust the emitted event payload for folder selection.
  * Improved upload mode stability with clearer UI state toggling, consistent `filenew` path handling, and smoother return to browsing after upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->