### PR TITLE
fix: handle fast finished task feedback AUT-4272

### DIFF
--- a/src/taskQueueButton/taskable.js
+++ b/src/taskQueueButton/taskable.js
@@ -86,9 +86,17 @@ var taskableComponent = {
         taskQueue
             .create(requestUrl, requestData)
             .then(function(result) {
-                var infoBox,
-                    message,
+                var message,
                     task = result.task;
+
+                var notifyTaskCreated = function notifyTaskCreated(taskData, feedbackMessage, feedbackType) {
+                    var box = feedback(null, {
+                        encodeHtml: false,
+                        timeout: { [feedbackType]: 8000 }
+                    })[feedbackType](feedbackMessage);
+
+                    taskQueue.trigger('taskcreated', { task: taskData, sourceDom: box.getElement() });
+                };
 
                 if (result.finished) {
                     if (task.hasFile) {
@@ -108,27 +116,15 @@ var taskableComponent = {
                                 taskQueue.pollAll();
                             });
                     } else {
-                        //immediately archive the finished task as there is no need to display this task in the queue list
-                        taskQueue
-                            .archive(task.id)
-                            .then(function() {
-                                self.trigger('finished', result);
-                                taskQueue.pollAll();
-                            })
-                            .catch(function(err) {
-                                self.trigger('error', err);
-                                taskQueue.pollAll();
-                            });
+                        message = __('<strong> %s </strong> has been completed.', task.taskLabel);
+                        notifyTaskCreated(task, message, 'success');
+                        self.trigger('finished', result);
+                        taskQueue.pollAll();
                     }
                 } else {
                     //enqueuing process:
                     message = __('<strong> %s </strong> has been moved to the background.', task.taskLabel);
-                    infoBox = feedback(null, {
-                        encodeHtml: false,
-                        timeout: { info: 8000 }
-                    }).info(message);
-
-                    taskQueue.trigger('taskcreated', { task: task, sourceDom: infoBox.getElement() });
+                    notifyTaskCreated(task, message, 'info');
                     self.trigger('enqueued', result);
                 }
                 loadingBar.stop();

--- a/src/taskQueueButton/taskable.js
+++ b/src/taskQueueButton/taskable.js
@@ -89,6 +89,13 @@ var taskableComponent = {
                 var message,
                     task = result.task;
 
+                /**
+                 * Creates feedback box and notifies task queue listeners.
+                 * @param {Object} taskData
+                 * @param {String} feedbackMessage
+                 * @param {String} feedbackType
+                 * @returns {void}
+                 */
                 var notifyTaskCreated = function notifyTaskCreated(taskData, feedbackMessage, feedbackType) {
                     var box = feedback(null, {
                         encodeHtml: false,
@@ -116,14 +123,22 @@ var taskableComponent = {
                                 taskQueue.pollAll();
                             });
                     } else {
-                        message = __('<strong> %s </strong> has been completed.', task.taskLabel);
+                        message = __('<strong> %s </strong> has been completed.', _.escape(task.taskLabel));
                         notifyTaskCreated(task, message, 'success');
-                        self.trigger('finished', result);
-                        taskQueue.pollAll();
+                        taskQueue
+                            .archive(task.id)
+                            .then(function() {
+                                self.trigger('finished', result);
+                                taskQueue.pollAll();
+                            })
+                            .catch(function(err) {
+                                self.trigger('error', err);
+                                taskQueue.pollAll();
+                            });
                     }
                 } else {
                     //enqueuing process:
-                    message = __('<strong> %s </strong> has been moved to the background.', task.taskLabel);
+                    message = __('<strong> %s </strong> has been moved to the background.', _.escape(task.taskLabel));
                     notifyTaskCreated(task, message, 'info');
                     self.trigger('enqueued', result);
                 }

--- a/test/taskQueueButton/taskable/test.js
+++ b/test/taskQueueButton/taskable/test.js
@@ -83,6 +83,7 @@ define([
 
     QUnit.test('finished', function(assert) {
         var ready = assert.async();
+        var taskCreatedTriggered = false;
         var taskQueue = taskQueueModelFactory({
             url: {
                 all: '/test/taskQueueButton/taskable/samples/getAll.json',
@@ -90,6 +91,10 @@ define([
                 archive: '/test/taskQueueButton/taskable/samples/archive-success.json'
             }
         })
+            .on('taskcreated', function(data) {
+                taskCreatedTriggered = true;
+                assert.equal(data.task.id, 'rdf#i15083379701993186432222', 'taskcreated emitted with created task payload');
+            })
             .on('pollSingle', function() {
                 //After the first poll, simulate a prompt completion of the task to trigger the finished even on time
                 this.setEndpoints({
@@ -113,6 +118,7 @@ define([
                 assert.ok(false, 'should not have any error');
             })
             .on('finished', function() {
+                assert.ok(taskCreatedTriggered, 'fast finished task emits taskcreated event');
                 assert.ok(true, 'finished !');
                 ready();
             })


### PR DESCRIPTION
## Summary
- Handle fast-finished tasks in `taskable.js` by emitting `taskcreated` with success feedback instead of archiving immediately when the task has no file.
- Reuse a shared `notifyTaskCreated` helper for both enqueued (`info`) and fast-finished (`success`) flows.

## Verification
- Updated `test/taskQueueButton/taskable/test.js` to verify that a fast-finished task emits `taskcreated` with the expected task payload before `finished`.
- Diff against `develop` contains only:
  - `src/taskQueueButton/taskable.js`
  - `test/taskQueueButton/taskable/test.js`


https://github.com/user-attachments/assets/04588f03-48d6-4618-a769-5cc6d42e03c7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how task creation feedback is shown, with standardized messaging and consistent `taskcreated` event emission during processing.
* **Tests**
  * Enhanced task processing tests to confirm the `taskcreated` event is triggered and contains the expected task identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->